### PR TITLE
Run theorem23 build-speed refactor checkpoint

### DIFF
--- a/LatticeSystem/Quantum/SpinS/Magnetization.lean
+++ b/LatticeSystem/Quantum/SpinS/Magnetization.lean
@@ -494,7 +494,7 @@ theorem magSumS_pos_iff (σ : Λ → Fin (N + 1)) :
     0 < magSumS σ ↔ ∃ x : Λ, σ x ≠ 0 := by
   rw [Nat.pos_iff_ne_zero]
   rw [Ne, magSumS_eq_zero_iff]
-  push_neg
+  push Not
   rfl
 
 omit [DecidableEq Λ] in

--- a/LatticeSystem/Quantum/SpinS/MultiSiteDot.lean
+++ b/LatticeSystem/Quantum/SpinS/MultiSiteDot.lean
@@ -371,7 +371,6 @@ theorem spinSDot_apply_diag_re_of_ne
       ((N : ℝ) / 2 - (σ x).val) * ((N : ℝ) / 2 - (σ y).val) := by
   rw [spinSDot_apply_diag_of_ne hxy]
   rw [Complex.mul_re]
-  push_cast
   simp
 
 /-- For the same-site case, the diagonal real part is `N(N+2)/4`. -/

--- a/LatticeSystem/Quantum/SpinS/SpinSDotAllAlignedZero.lean
+++ b/LatticeSystem/Quantum/SpinS/SpinSDotAllAlignedZero.lean
@@ -123,7 +123,7 @@ theorem spinSDot_mulVec_allAlignedStateS_zero_of_ne
     rw [onSiteS_spinSOp3_mulVec_allAlignedStateS]
     rw [smul_smul]
     rw [show ((0 : Fin (N + 1)).val : ℂ) = 0 from by simp]
-    push_cast; ring_nf
+    ring_nf
   rw [h_plus_minus, h_minus_plus, h_z_z]
   rw [add_zero, smul_zero, zero_add]
   congr 1
@@ -154,7 +154,6 @@ theorem spinSDot_mulVec_basisVecS_zero_of_ne
     change (onSiteS y (spinSOpPlus N) : ManyBodyOpS V N) τ σ = 0
     by_cases h_off : ∀ k, k ≠ y → τ k = σ k
     · rw [onSiteS_apply_of_off_site_agree y _ h_off]
-      change spinSOpPlus N (τ y) (σ y) = 0
       rw [hy]
       apply spinSOpPlus_apply_other
       show (τ y).val + 1 ≠ ((0 : Fin (N + 1)).val)


### PR DESCRIPTION
## Summary

- run the required 20-PR refactor checkpoint after PR #3625
- record the Theorem23 build-speed evaluation and keep module splitting deferred because cache-replay target builds remain fast
- clean up narrow linter hygiene in `Magnetization`, `MultiSiteDot`, and `SpinSDotAllAlignedZero`

## Build-speed evaluation

- `wc -l LatticeSystem/Quantum/SpinS/Theorem23Final.lean LatticeSystem/Quantum/SpinS/Theorem23OutsideGround.lean LatticeSystem/Quantum/SpinS/Theorem23Local.lean`: 4326 / 3398 / 542 lines
- `/usr/bin/time -p lake env lean LatticeSystem/Quantum/SpinS/Theorem23Final.lean`: `real 22.49`, `user 5.34`, `sys 5.05`
- pre-edit cache-replay `/usr/bin/time -p lake build LatticeSystem.Quantum.SpinS.Theorem23Final`: `real 6.26`, `user 1.77`, `sys 2.94`
- post-edit dependent rebuild `/usr/bin/time -p lake build LatticeSystem.Quantum.SpinS.Theorem23Final`: `real 232.37`, `user 287.90`, `sys 287.01`
- post-edit cache-replay `/usr/bin/time -p lake build LatticeSystem.Quantum.SpinS.Theorem23Final`: `real 4.27`, `user 1.78`, `sys 2.71`
- Codex cross-check cache-replay `/usr/bin/time -p lake build LatticeSystem.Quantum.SpinS.Theorem23Final`: `real 3.81`

The conclusion is evaluate-and-cleanup only: `Theorem23Final.lean` is large, but the target remains fast after cache replay and the Tasaki 2.3 boundary route is still actively changing. A module split would carry more import-DAG risk than benefit at this checkpoint.

## Verification

- `lake env lean LatticeSystem/Quantum/SpinS/Magnetization.lean`
- `lake env lean LatticeSystem/Quantum/SpinS/MultiSiteDot.lean`
- `lake env lean LatticeSystem/Quantum/SpinS/SpinSDotAllAlignedZero.lean`
- `/usr/bin/time -p lake build LatticeSystem.Quantum.SpinS.Theorem23Final`
- `git diff --check`
