### PR TITLE
Route left-endpoint named boundary through discharged predecessor -- #3542

### DIFF
--- a/LatticeSystem/Quantum/SpinS/Theorem23Final.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23Final.lean
@@ -3769,16 +3769,13 @@ set_option linter.style.longLine false in
 /-- **Tasaki §2.5 Theorem 2.3 left-endpoint named-callback final
 boundary**: this public boundary avoids the uniform source-sector
 predicted-GS callback when only the current outside-ground route is
-needed.  It supplies the admissible-sector `magConfigS` non-emptiness
-from the physical-range construction, derives the uniform source predicted-GS
-callback from the left endpoint plus the predecessor-difference interval
-chain, and then reuses the uniform named final boundary.
+needed.  It also avoids exposing the admissible-sector `magConfigS`
+non-emptiness callback by routing through the discharged left-endpoint
+predecessor-difference outside-ground boundary.
 
 The remaining visible inputs are therefore the weaker left-endpoint
 predicted-GS callback, the predecessor-difference local comparison, and
-outside-sector ground-energy lower bounds.  Internally this boundary now uses
-the source-callback closure so the left-endpoint route and the uniform route
-share the same final named-callback suffix. -/
+outside-sector ground-energy lower bounds. -/
 abbrev tasaki_2_5_theorem_2_3_of_left_endpoint_named_callbacks
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ)
     (hBA :
@@ -3791,21 +3788,10 @@ abbrev tasaki_2_5_theorem_2_3_of_left_endpoint_named_callbacks
     (houtside_ground_energy_lower :
       tasaki23OutsideGroundEnergyLowerFamilyCallback (V := V) A J N c) :
     tasaki_2_5_theorem_2_3 (V := V) A N J c := by
-  intro hJ_real hJ_real' hJ_sym hJ_nn hJ_bipartite hJ_pos
-    hc_strict h_intermediate hA_nonempty hnotA_nonempty
   exact
-    tasaki_2_5_theorem_2_3_of_named_callbacks
-      (V := V) A (J := J) N c hBA
-      (tasaki23_source_predictedGSCallback_of_left_endpoint_predictedGS_of_unpacked_reembedded_real_source_weight_predecessor_difference_pos
-        (V := V) A (J := J) N c hJ_real hJ_real' hJ_pos hJ_nn hJ_sym
-        hJ_bipartite hc_strict h_intermediate hBA
-        (fun _M hM =>
-          magConfigS_nonempty_of_le_card_mul (V := V) (N := N)
-            (tasaki23GroundStateSectors_le_card_mul (V := V) A N hM))
-        hleft_predictedGS hpredecessor_difference)
-      hpredecessor_difference houtside_ground_energy_lower hJ_real hJ_real'
-      hJ_sym hJ_nn hJ_bipartite hJ_pos hc_strict h_intermediate hA_nonempty
-      hnotA_nonempty
+    tasaki_2_5_theorem_2_3_of_left_endpoint_threaded_predictedGS_of_unpacked_reembedded_real_source_weight_predecessor_difference_pos_of_outside_sector_ground_energy_lower_bound_discharge_nonempty
+      (V := V) A (J := J) N c hBA hleft_predictedGS hpredecessor_difference
+      houtside_ground_energy_lower
 
 set_option linter.style.longLine false in
 /-- **Tasaki §2.5 Theorem 2.3 left-endpoint named-callback boundary from


### PR DESCRIPTION
Tracked in #3542.

## Summary

- Route `tasaki_2_5_theorem_2_3_of_left_endpoint_named_callbacks` directly through the discharged left-endpoint predecessor-difference outside-ground boundary added in PR #3634.
- Keep the public signature unchanged: the visible inputs remain the left-endpoint predicted-GS callback, predecessor-difference callback, and outside-sector ground-energy lower family.
- Avoid rebuilding the uniform source predicted-GS callback inside this left-endpoint boundary.
- No new public `def`, `theorem`, or `lemma` is added, so no docs/proof-guide update is required.

## Verification

- `lake env lean LatticeSystem/Quantum/SpinS/Theorem23Final.lean`
- `lake build LatticeSystem.Quantum.SpinS.Theorem23Final`
- `git diff --check`
