### PR TITLE
Route predecessor-difference public boundary through lowered chain -- #3542

### DIFF
--- a/LatticeSystem/Quantum/SpinS/Theorem23OutsideGroundPredecessorDifference.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23OutsideGroundPredecessorDifference.lean
@@ -281,19 +281,19 @@ theorem
 set_option linter.style.longLine false in
 /-- **Tasaki §2.5 Theorem 2.3 final predecessor-difference boundary from
 outside-sector ground energies**: this names the final API obtained from
-the explicit-lowerable coefficient route.  The remaining inputs are exactly the
+the lowered-site-sum predecessor-difference route.  The remaining inputs are exactly the
 left-endpoint predicted-GS callback, the local predecessor-difference
 callback, and outside-sector lower bounds for the Marshall-positive
 Theorem 2.2 ground-state representatives.
 
 The proof content is supplied by
-`tasaki_2_5_theorem_2_3_of_left_endpoint_threaded_predictedGS_of_unpacked_reembedded_real_source_weight_predecessor_difference_pos_via_explicit_lowerable_of_outside_sector_ground_energy_lower_bound`;
-this alias keeps the public boundary independent of the technical
-coefficient route used internally. -/
+`tasaki_2_5_theorem_2_3_of_left_endpoint_threaded_predictedGS_of_unpacked_reembedded_real_source_weight_predecessor_difference_pos_via_lowered_site_sum_of_outside_sector_ground_energy_lower_bound`;
+this alias keeps the public boundary on the direct predecessor-difference
+energy-chain route. -/
 abbrev
     tasaki_2_5_theorem_2_3_of_left_endpoint_threaded_predictedGS_of_unpacked_reembedded_real_source_weight_predecessor_difference_pos_of_outside_sector_ground_energy_lower_bound
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) :=
-  tasaki_2_5_theorem_2_3_of_left_endpoint_threaded_predictedGS_of_unpacked_reembedded_real_source_weight_predecessor_difference_pos_via_explicit_lowerable_of_outside_sector_ground_energy_lower_bound
+  tasaki_2_5_theorem_2_3_of_left_endpoint_threaded_predictedGS_of_unpacked_reembedded_real_source_weight_predecessor_difference_pos_via_lowered_site_sum_of_outside_sector_ground_energy_lower_bound
     (V := V) A (J := J) N c
 
 set_option linter.style.longLine false in


### PR DESCRIPTION
Part of #3542.

## Summary

- route the public predecessor-difference outside-ground boundary through the direct lowered-site-sum predecessor-difference chain
- keep the older explicit-lowerable route available as a named technical wrapper
- update the alias doc comment to describe the public route accurately

## Verification

- `lake env lean LatticeSystem/Quantum/SpinS/Theorem23OutsideGroundPredecessorDifference.lean`
- `lake build LatticeSystem.Quantum.SpinS.Theorem23OutsideGroundPredecessorDifference`
- `git diff --check`
