### PR TITLE
Route admissible reach discharge through discharged outside boundary -- #3542

### DIFF
--- a/LatticeSystem/Quantum/SpinS/Theorem23OutsideGroundPredecessorDifference.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23OutsideGroundPredecessorDifference.lean
@@ -389,13 +389,11 @@ theorem
     (hreach :
       tasaki23OutsideGroundAdmissibleReachCallback (V := V) A J N c) :
     tasaki_2_5_theorem_2_3 (V := V) A N J c :=
-  tasaki_2_5_theorem_2_3_of_left_endpoint_threaded_predictedGS_of_unpacked_reembedded_real_source_weight_predecessor_difference_pos_of_admissible_reach
+  tasaki_2_5_theorem_2_3_of_left_endpoint_threaded_predictedGS_of_unpacked_reembedded_real_source_weight_predecessor_difference_pos_of_outside_sector_ground_energy_lower_bound_discharge_nonempty
     (V := V) A (J := J) N c hBA
-    (fun _M hM =>
-      magConfigS_nonempty_of_le_card_mul (V := V) (N := N)
-        (tasaki23GroundStateSectors_le_card_mul (V := V) A N hM))
     hleft_predictedGS
     hsource_unpacked_reembedded_real_source_weight_predecessor_difference_pos
-    hJ_real hJ_real' hJ_nn hJ_sym hJ_bipartite hc_strict hreach
+    (tasaki23OutsideGroundEnergyLowerFamilyCallback_of_admissible_reach
+      (V := V) A N c hJ_real hJ_real' hJ_nn hJ_sym hJ_bipartite hc_strict hreach)
 
 end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

- Route the discharged admissible-reach predecessor-difference wrapper through the already discharged outside-ground boundary.
- Keep the public theorem statement unchanged; the body now builds the outside-ground lower-family callback from admissible reach and lets the discharged outside-ground boundary supply admissible-sector nonemptiness internally.
- No new public `def` / `theorem` / `lemma` / `abbrev`, so no docs/proof-guide update is required.

## Verification

- `lake env lean LatticeSystem/Quantum/SpinS/Theorem23OutsideGroundPredecessorDifference.lean`
- `lake build LatticeSystem.Quantum.SpinS.Theorem23OutsideGroundPredecessorDifference`
- `git diff --check`

Closes no issue. Part of #3542.
