### PR TITLE
Add sound PF adjacent-sector ladder link -- #3542

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -74,6 +74,7 @@ import LatticeSystem.Fermion.JWAbstract
 -- The sound per-sector Perron–Frobenius ground state is kept; the unsound conditional
 -- wrapper tree (40 modules) is removed.  Issue #3542.
 import LatticeSystem.Quantum.SpinS.Theorem23SectorExistence
+import LatticeSystem.Quantum.SpinS.Theorem23PFLadderLink
 
 /-!
 # `lattice-system` library root

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFLadderLink.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFLadderLink.lean
@@ -1,0 +1,77 @@
+import LatticeSystem.Quantum.SpinS.Theorem23Casimir
+import LatticeSystem.Quantum.SpinS.SaturatedLadderJointEigenspace
+import LatticeSystem.Quantum.SpinS.AllAlignedStateMagShift
+
+/-!
+# Tasaki §2.5 Theorem 2.3 — Perron–Frobenius adjacent-sector ladder link
+
+Sound replacement for the deleted saturated-ladder-iterate route (Issue
+#3542; see `.self-local/docs/tasaki-2-5-pf-route-design.md`).  The
+per-sector Marshall-positive Perron–Frobenius ground state
+(`tasaki_2_5_theorem_2_3_sector_existence`) is chained across adjacent
+magnetization sectors by the SU(2) total-lowering operator, using only
+`[Ĥ, Ŝ⁻_tot] = 0` and the total-Casimir non-vanishing criterion.
+
+This is the mechanism behind the constancy of the sector ground energies
+in Tasaki §2.5 Theorem 2.3 (and the first half of Theorem 2.2): applying
+`Ŝ⁻_tot` to a Heisenberg eigenvector preserves its energy (commutation)
+and moves it to the next magnetization sector, where it is non-zero as
+long as the total-Casimir eigenvalue is away from the lowering-kernel
+value.  It does **not** require Marshall positivity of the lowered vector
+— exactly the (false) hypothesis on which the deleted ferromagnetic-ladder
+route foundered.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body
+Systems*, Springer 2020, §2.5 Theorem 2.3, p. 42.
+-/
+
+namespace LatticeSystem.Quantum
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- **Tasaki §2.5 Theorem 2.3 Perron–Frobenius adjacent-sector ladder
+link (lowering direction)**: if a magnetization-`M` sector vector
+`Ψ = magSectorEmbedding Φ` is a Heisenberg eigenvector at energy `μ` and
+a total-Casimir eigenvector at a value `γ` away from the sector's
+lowering-kernel value, then its total-lowering image `Ŝ⁻_tot · Ψ` is
+
+* a Heisenberg eigenvector at the **same** energy `μ`
+  (by `[Ĥ, Ŝ⁻_tot] = 0`);
+* non-zero (by the total-Casimir non-vanishing criterion); and
+* supported in the next magnetization sector
+  (`Ŝ⁻_tot` lowers the `Ŝ_tot^(3)` eigenvalue by one).
+
+This packages the sound energy-preserving step that chains the per-sector
+Perron–Frobenius ground states of `tasaki_2_5_theorem_2_3_sector_existence`
+across the admissible range.  No Marshall positivity of the lowered vector
+is used. -/
+theorem tasaki23_pf_ladder_link_succ
+    {N M : ℕ} {J : V → V → ℂ} {μ : ℝ} {γ : ℂ}
+    {Φ : magConfigS V N M → ℂ}
+    (hH :
+      (heisenbergHamiltonianS J N).mulVec (magSectorEmbedding Φ) =
+        (μ : ℂ) • magSectorEmbedding Φ)
+    (hCas :
+      (totalSpinSSquared V N).mulVec (magSectorEmbedding Φ) =
+        γ • magSectorEmbedding Φ)
+    (hγ :
+      γ ≠
+        ((((Fintype.card V : ℂ) * (N : ℂ) / 2) - (M : ℂ)) *
+          ((((Fintype.card V : ℂ) * (N : ℂ) / 2) - (M : ℂ)) - 1)))
+    (hΦ : magSectorEmbedding Φ ≠ 0) :
+    (heisenbergHamiltonianS J N).mulVec
+        ((totalSpinSOpMinus V N).mulVec (magSectorEmbedding Φ)) =
+        (μ : ℂ) • (totalSpinSOpMinus V N).mulVec (magSectorEmbedding Φ) ∧
+      (totalSpinSOpMinus V N).mulVec (magSectorEmbedding Φ) ≠ 0 ∧
+      (totalSpinSOpMinus V N).mulVec (magSectorEmbedding Φ) ∈
+        magSubspaceS V N
+          ((((Fintype.card V : ℂ) * (N : ℂ) / 2) - (M : ℂ)) - 1) := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact mulVec_preserves_eigenvalue_of_commuteS
+      (heisenbergHamiltonianS_commute_totalSpinSOpMinus J) hH
+  · exact tasaki23_totalSpinSOpMinus_mulVec_magSectorEmbedding_ne_zero_of_casimir_ne_kernel_value
+      hCas hγ hΦ
+  · exact totalSpinSOpMinus_mulVec_mem_magSubspaceS_of_mem
+      (magSectorEmbedding_mem_magSubspaceS (V := V) (N := N) (M := M) Φ)
+
+end LatticeSystem.Quantum

--- a/docs/index.md
+++ b/docs/index.md
@@ -1737,6 +1737,7 @@ refactor #30 (PR #2829). Tracked in Issue #412.
 
 | Lean name | Statement |
 |---|---|
+| `tasaki23_pf_ladder_link_succ` | **Sound PF adjacent-sector ladder link (lowering)**: if a magnetization-`M` sector vector `magSectorEmbedding Φ` is a Heisenberg eigenvector at energy `μ` and a total-Casimir eigenvector at `γ` away from the sector's lowering-kernel value `(card·N/2−M)(card·N/2−M−1)`, then `Ŝ⁻_tot · magSectorEmbedding Φ` is a Heisenberg eigenvector at the **same** `μ` (via `[Ĥ, Ŝ⁻_tot]=0`), is non-zero (total-Casimir non-vanishing criterion), and lies in the next magnetization sector. This is the energy-preserving step that chains the per-sector Perron–Frobenius ground states (`tasaki_2_5_theorem_2_3_sector_existence`) across the admissible range; it uses **no** Marshall positivity of the lowered vector (the false hypothesis of the removed ferromagnetic-ladder route). Tasaki, Springer 2020, §2.5 Theorem 2.3, p. 42 (file `Quantum/SpinS/Theorem23PFLadderLink.lean`) |
 | `magConfigS V N M` | sector subtype of magnetization-`M` configurations (`Quantum/SpinS/MagConfig.lean`) |
 | `RaiseLowerStepSMagSector G σ τ` / `RaiseLowerReachableSMagSector G` | bipartite raise/lower step lifted to `magConfigS` and its reflexive transitive closure (`Quantum/SpinS/MagConfig.lean`) |
 | `raiseLowerReachableSMagSector_bipartiteCompleteGraph` | any two configurations in the same sector are reachable via raise/lower steps under the bipartite-intermediate hypothesis (Tasaki §2.5 Property (iii) generic-S form) |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5221,6 +5221,23 @@ See \texttt{.self-local/docs/tasaki-2-5-pf-route-design.md} and Issue \#3542.
 Some passages below describe the toy/Casimir prediction machinery that is
 retained; references to the removed conditional wrappers are obsolete.
 
+\paragraph{Sound adjacent-sector ladder link
+(\texttt{tasaki23\_pf\_ladder\_link\_succ}).} The first reconstructed
+step. If $\Psi=\mathtt{magSectorEmbedding}\,\Phi$ is a Heisenberg
+eigenvector at energy $\mu$ in magnetization sector $M$ and a
+total-Casimir eigenvector at a value $\gamma$ away from the
+lowering-kernel value
+$\bigl(\tfrac{|V|N}{2}-M\bigr)\bigl(\tfrac{|V|N}{2}-M-1\bigr)$, then
+$\hat S^-_{\rm tot}\Psi$ is again a Heisenberg eigenvector at the
+\emph{same} $\mu$ (because $[\hat H,\hat S^-_{\rm tot}]=0$, via
+\texttt{mulVec\_preserves\_eigenvalue\_of\_commuteS}), is non-zero (by
+the total-Casimir non-vanishing criterion
+\texttt{tasaki23\_totalSpinSOpMinus\_mulVec\_magSectorEmbedding\_ne\_zero\_of\_casimir\_ne\_kernel\_value}),
+and lies in sector $M+1$. Crucially this uses no Marshall positivity of
+$\hat S^-_{\rm tot}\Psi$, so it sidesteps the false leaf of the removed
+route. Iterating it across the admissible range gives the constancy of
+the sector ground energies (the common-energy chain).
+
 \textbf{Goal} (Tasaki §2.5 Theorem 2.3, p.~42). For a connected
 bipartite lattice $(\Lambda, B)$ with $|A| \ge 1$ and $|B| \ge 1$,
 the AFM Heisenberg ground states have total spin $S_{\rm tot} =


### PR DESCRIPTION
Tracked in #3542.

First step of the **sound Perron–Frobenius route** that replaces the deleted
unsound saturated-ladder route (PR #3645).

## Theorem

`tasaki23_pf_ladder_link_succ` (`Quantum/SpinS/Theorem23PFLadderLink.lean`):
if a magnetization-`M` sector vector `magSectorEmbedding Φ` is

- a Heisenberg eigenvector at energy `μ`, and
- a total-Casimir eigenvector at `γ` away from the sector lowering-kernel
  value `(card·N/2−M)(card·N/2−M−1)`, with `magSectorEmbedding Φ ≠ 0`,

then `Ŝ⁻_tot · magSectorEmbedding Φ` is (1) a Heisenberg eigenvector at the
**same** `μ` (via `[Ĥ, Ŝ⁻_tot]=0`), (2) non-zero (total-Casimir non-vanishing),
and (3) supported in the next magnetization sector.

No Marshall positivity of the lowered vector is used — exactly the false
hypothesis the deleted route depended on. This is the energy-preserving
mechanism that will chain the per-sector PF ground states
(`tasaki_2_5_theorem_2_3_sector_existence`) into the common-energy chain.

## Notes

- The Casimir hypotheses (eigenvalue ≠ kernel value) are inputs here, to be
  discharged in a later PR from the predicted total spin (acknowledged
  remaining route step).
- Built from existing sound parts: `mulVec_preserves_eigenvalue_of_commuteS`,
  `heisenbergHamiltonianS_commute_totalSpinSOpMinus`,
  `tasaki23_totalSpinSOpMinus_mulVec_magSectorEmbedding_ne_zero_of_casimir_ne_kernel_value`,
  `totalSpinSOpMinus_mulVec_mem_magSubspaceS_of_mem`.

## Verification

- `lake build` passes (3263 jobs), no `sorry`.
- docs/index.md + tex/proof-guide.tex updated.
- codex cross-check: statement confirmed correct (Q1 CONFIRM); the two caveats
  are the acknowledged remaining route steps (chain completion; Casimir discharge).
