### PR TITLE
Add geometric simplicity of the Perron eigenvalue -- #3542

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -1,6 +1,7 @@
 import LatticeSystem.Math.PerronFrobeniusPrimitive
 import LatticeSystem.Math.CollatzWielandt
 import LatticeSystem.Math.PerronFrobeniusMain
+import LatticeSystem.Math.PerronFrobeniusSimple
 import LatticeSystem.Math.PerronFrobenius
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale

--- a/LatticeSystem/Math/PerronFrobeniusSimple.lean
+++ b/LatticeSystem/Math/PerronFrobeniusSimple.lean
@@ -1,0 +1,88 @@
+import LatticeSystem.Math.PerronFrobenius
+
+/-!
+# Perron–Frobenius: geometric simplicity of the Perron eigenvalue
+
+For an irreducible non-negative matrix with a strictly positive eigenvector
+`v` at eigenvalue `μ`, every (real) eigenvector at the same eigenvalue is a
+scalar multiple of `v`; i.e. the `μ`-eigenspace is one-dimensional.
+
+This strengthens `pos_eigenvec_unique` (uniqueness among *strictly positive*
+eigenvectors) to *all* eigenvectors, via the standard perturbation trick: for
+a small `t > 0` the vector `v + t • u` is still strictly positive and is an
+eigenvector at `μ`, hence proportional to `v` by `pos_eigenvec_unique`, which
+forces `u` to be proportional to `v`.
+
+This is the simplicity needed to conclude that a Perron ground state is a
+joint eigenvector of any commuting operator (e.g. the total Casimir), used in
+the Tasaki §2.5 Theorem 2.3 total-spin determination.
+-/
+
+namespace LatticeSystem.Math.PerronFrobenius
+
+open Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+omit [DecidableEq n] in
+/-- **Geometric simplicity of the Perron eigenvalue**: if `A` is irreducible,
+`v` is a strictly positive eigenvector at `μ`, and `u` is any real eigenvector
+at the same `μ`, then `u = s • v` for some real scalar `s`. -/
+theorem eigenvec_proportional_of_pos_eigenvec [Nonempty n]
+    {A : Matrix n n ℝ} (hIrred : A.IsIrreducible)
+    {μ : ℝ} {v u : n → ℝ}
+    (hv : A *ᵥ v = μ • v) (hv_pos : ∀ i, 0 < v i)
+    (hu : A *ᵥ u = μ • u) :
+    ∃ s : ℝ, u = s • v := by
+  classical
+  -- A small positive `t` so that `v + t • u` is still strictly positive.
+  set t : ℝ :=
+    Finset.univ.inf' Finset.univ_nonempty (fun i => v i / (|u i| + 1)) with ht_def
+  have ht_pos : 0 < t := by
+    rw [ht_def, Finset.lt_inf'_iff]
+    intro i _
+    have h1 : (0 : ℝ) < |u i| + 1 := by positivity
+    exact div_pos (hv_pos i) h1
+  have ht_le : ∀ i, t ≤ v i / (|u i| + 1) := by
+    intro i
+    rw [ht_def]
+    exact Finset.inf'_le (fun i => v i / (|u i| + 1)) (Finset.mem_univ i)
+  -- Hence `t * |u i| < v i` for every `i`.
+  have ht_bound : ∀ i, t * |u i| < v i := by
+    intro i
+    have h1 : (0 : ℝ) < |u i| + 1 := by positivity
+    have h2 : t * (|u i| + 1) ≤ v i := (le_div_iff₀ h1).mp (ht_le i)
+    have h3 : t * |u i| < t * (|u i| + 1) :=
+      mul_lt_mul_of_pos_left (by linarith) ht_pos
+    linarith
+  -- `w := v + t • u` is strictly positive and an eigenvector at `μ`.
+  set w : n → ℝ := v + t • u with hw_def
+  have hw_pos : ∀ i, 0 < w i := by
+    intro i
+    have hb := ht_bound i
+    have : -(t * |u i|) ≤ t * u i := by
+      have := neg_abs_le (u i)
+      nlinarith [mul_le_mul_of_nonneg_left (neg_abs_le (u i)) (le_of_lt ht_pos)]
+    simp only [hw_def, Pi.add_apply, Pi.smul_apply, smul_eq_mul]
+    nlinarith [ht_bound i, neg_abs_le (u i),
+      mul_le_mul_of_nonneg_left (neg_abs_le (u i)) (le_of_lt ht_pos)]
+  have hw_eig : A *ᵥ w = μ • w := by
+    rw [hw_def, Matrix.mulVec_add, hv, Matrix.mulVec_smul, hu, smul_add, smul_smul,
+      smul_smul, mul_comm]
+  -- Uniqueness among positive eigenvectors: `w = r • v` for some `r > 0`.
+  obtain ⟨r, _hr_pos, hwr⟩ := pos_eigenvec_unique hIrred hv hv_pos hw_eig hw_pos
+  -- `v + t • u = r • v` ⟹ `t • u = (r - 1) • v` ⟹ `u = ((r-1)/t) • v`.
+  refine ⟨(r - 1) / t, ?_⟩
+  have heq : t • u = (r - 1) • v := by
+    have : v + t • u = r • v := by rw [← hw_def]; exact hwr
+    funext i
+    have := congrFun this i
+    simp only [Pi.add_apply, Pi.smul_apply, smul_eq_mul] at this ⊢
+    linarith
+  funext i
+  have hi := congrFun heq i
+  simp only [Pi.smul_apply, smul_eq_mul] at hi ⊢
+  field_simp
+  linarith [hi]
+
+end LatticeSystem.Math.PerronFrobenius

--- a/docs/index.md
+++ b/docs/index.md
@@ -1704,6 +1704,7 @@ The sorry in `exists_pos_eigenvec_max` is eliminated via the Collatz-Wielandt po
 | `exists_nonneg_eigenvec_max` | (**sorry**, retained for docs) symmetric nonneg max eigenvalue has nonneg eigenvector | `Math/PerronFrobenius.lean` |
 | `exists_pos_eigenvec_max` | (**sorry-free**) irreducible nonneg Hermitian ⟹ max eigenvalue has strictly positive eigenvector | `Math/PerronFrobenius.lean` |
 | `pos_eigenvec_unique` | strictly positive eigenvector unique up to positive scalar | `Math/PerronFrobenius.lean` |
+| `PerronFrobenius.eigenvec_proportional_of_pos_eigenvec` | **geometric simplicity of the Perron eigenvalue**: irreducible nonneg with a strictly positive eigenvector `v` at `μ` ⟹ every real eigenvector at `μ` is `s • v` for some scalar `s` (the `μ`-eigenspace is 1-dimensional). Perturbation trick: `v + t • u > 0` for small `t > 0` is an eigenvector at `μ`, hence `∝ v` by `pos_eigenvec_unique`, forcing `u ∝ v`. Used to show a Perron ground state is a joint eigenvector of any commuting operator (e.g. the total Casimir) | `Math/PerronFrobeniusSimple.lean` |
 
 References: E. Seneta, *Non-negative Matrices and Markov Chains* (3rd ed.), Springer 2006, §1.2 (pp. 27–28);
 or4nge19/MCMC: `MCMC/PF/LinearAlgebra/Matrix/PerronFrobenius/`.


### PR DESCRIPTION
Tracked in #3542.

Foundational Perron–Frobenius tool for the **total-spin determination** (sound route).

## Theorem

`PerronFrobenius.eigenvec_proportional_of_pos_eigenvec`
(`Math/PerronFrobeniusSimple.lean`): for an irreducible non-negative matrix with a
strictly positive eigenvector `v` at `μ`, every real eigenvector at `μ` equals `s • v`
for some scalar `s` (the `μ`-eigenspace is one-dimensional).

Strengthens `pos_eigenvec_unique` (uniqueness among strictly positive eigenvectors) to
all eigenvectors via the perturbation trick: for small `t > 0`, `v + t • u > 0` is an
eigenvector at `μ`, hence proportional to `v`, forcing `u ∝ v`.

This is the geometric simplicity needed to conclude that a Perron ground state is a
**joint eigenvector of any commuting operator** (e.g. the total Casimir `(Ŝtot)²`),
the next step of the total-spin determination.

## Verification

- `lake build` passes (3267 jobs), no `sorry`.
- docs/index.md Perron–Frobenius section updated.
- codex cross-check: Q1/Q3 CONFIRM (perturbation argument valid; `u=0`, `t>0`,
  division edge cases all fine), Q2 CAVEAT (standard statement; non-circular reliance
  on `pos_eigenvec_unique`).

## Next (under #3542)

Specialise to the dressed sector matrix ⟹ any sector-`M` Heisenberg eigenvector at the
PF ground energy is proportional to the PF ground state ⟹ the PF ground state is a
`(Ŝtot)²` eigenvector ⟹ (with the overlap transfer #3651 + toy-GS predicted membership)
PF GS ∈ predicted subspace (total-spin determination).
