### PR TITLE
Refactor checkpoint: shake import audit + build-speed evaluation

### DIFF
--- a/LatticeSystem/Math/PerronFrobenius.lean
+++ b/LatticeSystem/Math/PerronFrobenius.lean
@@ -1,7 +1,6 @@
 import LatticeSystem.Math.PerronFrobeniusMain
 import Mathlib.Analysis.Matrix.Spectrum
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
-import Mathlib.LinearAlgebra.Matrix.PosDef
 import Mathlib.LinearAlgebra.UnitaryGroup
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 

--- a/LatticeSystem/Quantum/NeelState/Definition.lean
+++ b/LatticeSystem/Quantum/NeelState/Definition.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.MagnetizationSubspace
 import LatticeSystem.Quantum.SpinDot
-import LatticeSystem.Quantum.HeisenbergChain
 
 /-!
 # Néel state definition (Tasaki §2.5)

--- a/LatticeSystem/Quantum/SpinHalfBasis.lean
+++ b/LatticeSystem/Quantum/SpinHalfBasis.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Quantum.SpinHalf
-import Mathlib.Tactic.LinearCombination
 
 /-!
 # Basis states and raising/lowering operators for S = 1/2

--- a/LatticeSystem/Quantum/SpinOne.lean
+++ b/LatticeSystem/Quantum/SpinOne.lean
@@ -2,7 +2,6 @@ import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Real.Sqrt
 import Mathlib.LinearAlgebra.Matrix.Hermitian
 import Mathlib.LinearAlgebra.Matrix.Notation
-import Mathlib.Tactic.LinearCombination
 
 /-!
 # Spin-1 operators following Tasaki §2.1

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -1,0 +1,1 @@
+{"ignoreAll": [], "ignoreImport": [], "ignore": {}}


### PR DESCRIPTION
20-PR refactor-cadence checkpoint (37 feature PRs merged since the last checkpoint #3626, well over the 20-PR threshold; the big deletion #3645 was not a build-speed checkpoint). Tooling + import-hygiene checkpoint.

## Build-speed evaluation (required)

- Incremental rebuild of the heaviest §2.5 leaf modules is healthy: SublatticeCasimirNeelAllAlignedOrtho 3.65s, SublatticeCasimirNeel 3.31s, SublatticeCasimirNeelHeisenbergExpectation 3.55s, Theorem23Local 3.18s, SublatticeSpin 2.64s; build root relinks in ~3–6s.
- Largest source file is 742 lines; no module is large/slow enough to warrant a split. No split performed, by design.

## Import audit (`lake exe shake`)

- Added `scripts/noshake.json` so `lake exe shake LatticeSystem` runs (it errored on the missing config before), enabling future audits.
- shake reports NO unused imports in any module on the sound PF / sublattice-grading route (#3646–#3665): already import-clean.
- Applied only SAFE pure-removal suggestions (no transitive replacement), each confirmed by a full `lake build`:
  - `Math/PerronFrobenius.lean`: drop `Mathlib.LinearAlgebra.Matrix.PosDef`.
  - `Quantum/SpinHalfBasis.lean`, `Quantum/SpinOne.lean`: drop `Mathlib.Tactic.LinearCombination`.
  - `Quantum/NeelState/Definition.lean`: drop `LatticeSystem.Quantum.HeisenbergChain`.
- Remaining shake suggestions (transitive reshuffles across older SpinHalf / MarshallLiebMattis modules) deferred: high-churn, off the Tasaki critical path, risk-bearing.

## Verification

- Full `lake build` passes (3271 jobs), no `sorry`, no new warnings.
