### PR TITLE
Refactor checkpoint: build-speed + import audit (§2.5 Thm 2.3 chains)

### DIFF
--- a/docs/refactoring-conventions.md
+++ b/docs/refactoring-conventions.md
@@ -915,3 +915,20 @@ mechanically** and catch most regressions / drift.
   JordanWigner facades; TotalSpin, HeisenbergChain,
   SpinHalfRotation, GibbsState, TimeReversalMulti content +
   extensions). PRs #335–#372.
+- **2026-05-26 (PR #3686, 20-PR cadence checkpoint, evaluate-only)**:
+  Build-speed + import-hygiene checkpoint for the §2.5 Theorem 2.3
+  Casimir-spectral-bound and minimal-total-spin-state chains
+  (Issue #3658 / #3674, PRs #3667–#3685). New modules rebuild in
+  2.7–3.0s each (`SublatticeMagWeightComponent` 2.73s,
+  `SublatticeMagProjection` 3.00s, `Theorem23ToyWitness` 2.86s,
+  `JointCasimirEigenspaceLadderInvariant` 2.82s,
+  `CasimirSpectralLowerBound` 2.84s) — well under the historical
+  split trigger (~16s); each file is small (40–130 lines) and split
+  at the one-theorem / few-theorem grain, so **no split warranted**.
+  A `lake exe shake` import audit flagged several "remove"
+  suggestions on the chain, but each was build-verified to be
+  **wrong** (the flagged imports — e.g. `SublatticeSpinLadder` in
+  `SublatticeMagShift`, `ToyHamiltonian` in
+  `Theorem23ToyGroundEnergyBound` — are genuinely required), so the
+  chain's imports are already minimal. Both build-speed and import
+  hygiene healthy; no code change.


### PR DESCRIPTION
20-PR refactor-cadence checkpoint (19 feature PRs since the last checkpoint #3666: Issue #3658 Casimir-spectral-bound chain + Issue #3674 minimal-total-spin chain, #3667–#3685). Evaluate-only.

## Build-speed evaluation (required)

New-module incremental rebuilds are healthy, 2.7–3.0s each (SublatticeMagWeightComponent 2.73s, SublatticeMagProjection 3.00s, Theorem23ToyWitness 2.86s, JointCasimirEigenspaceLadderInvariant 2.82s, CasimirSpectralLowerBound 2.84s) — well under the historical split trigger (~16s). Each file is small (40–130 lines), split at the one-/few-theorem grain; no split warranted.

## Import audit (`lake exe shake`)

shake flagged several "remove" suggestions on the chain, but each was build-verified to be WRONG (the flagged imports are genuinely required). The chain's imports are already minimal; no safe removal.

## Verification

- Full `lake build` passes (3308 jobs), no `sorry`; docs-only change.
