### PR TITLE
Refactor checkpoint: shake import audit + build-speed eval (option (a) chain) -- #3542

### DIFF
--- a/LatticeSystem/Quantum/SpinS/Theorem23JointPredictedLowering.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23JointPredictedLowering.lean
@@ -1,4 +1,4 @@
-import LatticeSystem.Quantum.SpinS.Theorem23PFLadderLink
+import LatticeSystem.Quantum.SpinS.Theorem23PredictedEndpoint
 import LatticeSystem.Quantum.SpinS.BipartiteToyGSLadderInvariant
 import LatticeSystem.Quantum.SpinS.SaturatedLadderJointEigenspace
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFConstancyCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFConstancyCasimir.lean
@@ -1,4 +1,4 @@
-import LatticeSystem.Quantum.SpinS.Theorem23PFConstancy
+import LatticeSystem.Quantum.SpinS.Theorem23PFLadderLink
 
 /-!
 # Adjacent-sector ground-energy constancy from the predicted total Casimir alone

--- a/LatticeSystem/Quantum/SpinS/Theorem23TotalLowestWeightExistence.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23TotalLowestWeightExistence.lean
@@ -1,4 +1,4 @@
-import LatticeSystem.Quantum.SpinS.CasimirSpectralLowerBound
+import LatticeSystem.Quantum.SpinS.SaturatedLadderJointEigenspace
 import LatticeSystem.Quantum.SpinS.BipartiteToyGSLadderInvariant
 
 /-!


### PR DESCRIPTION
Tracked in #3542.

**20-PR refactoring checkpoint** (per CLAUDE.local.md; 19 feature PRs #3709–#3725 since the last refactor #3708), covering the option-(a) coupled-total-spin-lower-bound chain.

## Build-speed evaluation (mandatory)

The entire option-(a) chain (17 new files) is uniformly small (70–152 lines/file) and builds fast — heaviest `Theorem23ToyMinEnergyBound` 5.0 s incremental, `LatticeSystem` root 4.2 s. No file exceeds the split threshold; **no split needed** this cycle.

## Import audit (shake)

Applied three shake-verified import tightenings (replace transitively-pulled module with the directly-needed one):
- `Theorem23PFConstancyCasimir`: `Theorem23PFConstancy` → `Theorem23PFLadderLink`.
- `Theorem23JointPredictedLowering`: `Theorem23PFLadderLink` → `Theorem23PredictedEndpoint`.
- `Theorem23TotalLowestWeightExistence`: `CasimirSpectralLowerBound` → `SaturatedLadderJointEigenspace`.

## Verification

- `lake build` passes (3346 jobs), no `sorry`, linter-zero.
