### PR TITLE
ParityReachableS symmetry lemmas -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -211,6 +211,7 @@ import LatticeSystem.Quantum.SpinS.ParityConfig
 import LatticeSystem.Quantum.SpinS.DressedParityBlockMatrix
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapPFMatrix
 import LatticeSystem.Quantum.SpinS.ParityReachable
+import LatticeSystem.Quantum.SpinS.ParityReachableSymm
 import LatticeSystem.Quantum.SpinS.ParityReachableMagSum
 import LatticeSystem.Quantum.SpinS.ParityReachableMatrixPow
 import LatticeSystem.Quantum.SpinS.ShiftedDressedAxisSwapBlockDiag

--- a/LatticeSystem/Quantum/SpinS/ParityReachableSymm.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableSymm.lean
@@ -1,0 +1,82 @@
+import LatticeSystem.Quantum.SpinS.ParityReachable
+
+/-!
+# Symmetry of `ParityReachableS` and its underlying elementary steps
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+Every elementary parity-block step (`RaiseLowerStepS`, `ParityBondStepS`, `SingleIonStepS`) is
+defined by a disjunction of raise / lower branches, so each is symmetric: swapping the two
+branches yields the same proposition with `σ` and `σ'` swapped.  Hence the disjoint sum
+`ParityStepS` is symmetric, and so is its reflexive-transitive closure `ParityReachableS` via
+`Relation.ReflTransGen.symmetric` (Mathlib).
+
+The symmetry of `ParityReachableS` is the missing piece for the (d.3) full reachability layer
+of the (d) reachability totality assembly: given the canonical-form embedding `σ → canonical_σ`
+(#3806) we need `canonical_σ' → σ'` for the closing leg, which is exactly the reverse direction
+that symmetry provides.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43.
+-/
+
+namespace LatticeSystem.Quantum
+
+variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
+
+omit [Fintype V] [DecidableEq V] in
+/-- **Symmetry of a `RaiseLowerStepS`**: the disjunction `(σ x + 1 = σ' x ∧ σ' y + 1 = σ y) ∨
+(σ' x + 1 = σ x ∧ σ y + 1 = σ' y)` is symmetric in `σ` and `σ'`. -/
+theorem raiseLowerStepS_symm {G : SimpleGraph V} {σ σ' : V → Fin (N + 1)}
+    (h : RaiseLowerStepS G σ σ') : RaiseLowerStepS G σ' σ := by
+  obtain ⟨x, y, hadj, hor, hoff⟩ := h
+  refine ⟨x, y, hadj, ?_, ?_⟩
+  · rcases hor with ⟨hxy_raise_a, hxy_lower_b⟩ | ⟨hxy_lower_a, hxy_raise_b⟩
+    · exact Or.inr ⟨hxy_raise_a, hxy_lower_b⟩
+    · exact Or.inl ⟨hxy_lower_a, hxy_raise_b⟩
+  · intro k hkx hky
+    exact (hoff k hkx hky).symm
+
+omit [Fintype V] [DecidableEq V] in
+/-- **Symmetry of a `ParityBondStepS`**. -/
+theorem parityBondStepS_symm {G : SimpleGraph V} {σ σ' : V → Fin (N + 1)}
+    (h : ParityBondStepS G σ σ') : ParityBondStepS G σ' σ := by
+  obtain ⟨x, y, hadj, hor, hoff⟩ := h
+  refine ⟨x, y, hadj, ?_, ?_⟩
+  · rcases hor with ⟨hx_raise, hy_raise⟩ | ⟨hx_lower, hy_lower⟩
+    · exact Or.inr ⟨hx_raise, hy_raise⟩
+    · exact Or.inl ⟨hx_lower, hy_lower⟩
+  · intro k hkx hky
+    exact (hoff k hkx hky).symm
+
+omit [Fintype V] [DecidableEq V] in
+/-- **Symmetry of a `SingleIonStepS`**. -/
+theorem singleIonStepS_symm {σ σ' : V → Fin (N + 1)}
+    (h : SingleIonStepS σ σ') : SingleIonStepS σ' σ := by
+  obtain ⟨x, hor, hoff⟩ := h
+  refine ⟨x, ?_, ?_⟩
+  · rcases hor with hxraise | hxlower
+    · exact Or.inr hxraise
+    · exact Or.inl hxlower
+  · intro k hkx
+    exact (hoff k hkx).symm
+
+omit [Fintype V] [DecidableEq V] in
+/-- **Symmetry of `ParityStepS`**: dispatching on the three elementary-step disjuncts and using
+their individual symmetries. -/
+theorem parityStepS_symm {G : SimpleGraph V} {σ σ' : V → Fin (N + 1)}
+    (h : ParityStepS G σ σ') : ParityStepS G σ' σ := by
+  rcases h with hRL | hPB | hSI
+  · exact Or.inl (raiseLowerStepS_symm hRL)
+  · exact Or.inr (Or.inl (parityBondStepS_symm hPB))
+  · exact Or.inr (Or.inr (singleIonStepS_symm hSI))
+
+omit [Fintype V] [DecidableEq V] in
+/-- **Symmetry of `ParityReachableS`**: lifting the single-step symmetry through the
+reflexive-transitive closure (via `Relation.ReflTransGen.symmetric`).  Together with reflexivity
+and transitivity, `ParityReachableS G` is an equivalence relation on configurations. -/
+theorem parityReachableS_symm {G : SimpleGraph V} {σ σ' : V → Fin (N + 1)}
+    (h : ParityReachableS G σ σ') : ParityReachableS G σ' σ :=
+  Relation.ReflTransGen.symmetric (fun _ _ => parityStepS_symm) h
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

Adds `LatticeSystem/Quantum/SpinS/ParityReachableSymm.lean`: symmetry of the elementary parity-block steps and of `ParityReachableS`, the missing reverse direction for the (d.3) full reachability layer of (d) reachability totality.

Public theorems (5):
- `raiseLowerStepS_symm` — `RaiseLowerStepS G σ σ' → RaiseLowerStepS G σ' σ`.
- `parityBondStepS_symm` — analogously for `ParityBondStepS`.
- `singleIonStepS_symm` — analogously for `SingleIonStepS`.
- `parityStepS_symm` — case-split dispatcher across the three elementary-step disjuncts.
- `parityReachableS_symm` — `ParityReachableS G σ σ' → ParityReachableS G σ' σ`, via `Relation.ReflTransGen.symmetric` (Mathlib).

Why this is trivial
-------------------
Every elementary step is *defined* by a raise/lower disjunction (see `ParityReachable.lean`):
- `RaiseLowerStepS = (σ x + 1 = σ' x ∧ σ' y + 1 = σ y) ∨ (σ' x + 1 = σ x ∧ σ y + 1 = σ' y)`.
- `ParityBondStepS = (both raised) ∨ (both lowered)`.
- `SingleIonStepS = (σ x + 2 = σ' x) ∨ (σ' x + 2 = σ x)`.

Each is symmetric by swapping the two disjuncts (and `.symm` on the off-site agreement).  The disjoint sum `ParityStepS` inherits symmetry by case-split; `ParityReachableS = ReflTransGen ParityStepS` then becomes symmetric by `Relation.ReflTransGen.symmetric`.  Together with reflexivity and transitivity (already in `ParityReachable.lean`), `ParityReachableS G` is an equivalence relation on configurations.

Use in (d.3)
------------
The full reachability theorem (next PR) needs the closing leg `canonical_σ' → σ'` of the chain `σ → canonical_σ → canonical_σ' → σ'`.  This is exactly the reverse of the `σ' → canonical_σ'` direction provided by #3806 (concentrateAB), now available via `parityReachableS_symm`.

No tex / docs update: still an intermediate layer in the (d) reachability totality assembly.
