### PR TITLE
WF-iterate parityReachableS_step_down to a sector-min canonical -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -185,6 +185,7 @@ import LatticeSystem.Quantum.SpinS.MagSumStepDown
 import LatticeSystem.Quantum.SpinS.ParityReachStepDown
 import LatticeSystem.Quantum.SpinS.ParityReachStepDownHard
 import LatticeSystem.Quantum.SpinS.ParityReachStepDownFull
+import LatticeSystem.Quantum.SpinS.ParityReachToMinMagSum
 import LatticeSystem.Quantum.SpinS.ParityReachShuffle
 import LatticeSystem.Quantum.SpinS.ParityReachShuffleIter
 import LatticeSystem.Quantum.SpinS.ParityReachTransferIter

--- a/LatticeSystem/Quantum/SpinS/ParityReachToMinMagSum.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachToMinMagSum.lean
@@ -1,0 +1,62 @@
+import LatticeSystem.Quantum.SpinS.ParityReachStepDownFull
+
+/-!
+# WF-iteration of `parityReachableS_step_down` to reach a sector-min canonical
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+Iterating the full step-down dispatcher (#3821) by strong induction on `magSumS σ` shows that
+every configuration reaches some `σ_min` with `magSumS σ_min < 2` — i.e. either the all-zero
+config (for even parity) or a single-1-site config (for odd parity).
+
+Combined with the within-sector reachability lift (#3817) and `ParityReachableS` symmetry
+(#3816), this is the penultimate step before the full `parityReachableS_total` discharging the
+parity-block matrix irreducibility theorem (#3797).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43.
+-/
+
+namespace LatticeSystem.Quantum
+
+variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
+
+set_option linter.unusedDecidableInType false in
+/-- **Auxiliary: strong induction on `n = magSumS σ`** to iterate the step-down dispatcher. -/
+theorem parityReachableS_to_min_magSum_aux
+    (A : V → Bool)
+    (hA_ne : ∃ a, A a = true)
+    (hB_ne : ∃ b, A b = false) :
+    ∀ (n : ℕ) (σ : V → Fin (N + 1)), magSumS σ = n →
+      ∃ σ_min : V → Fin (N + 1),
+        magSumS σ_min < 2 ∧
+        ParityReachableS (bipartiteCompleteGraphOf A) σ σ_min := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro σ hmag
+    by_cases hsmall : n < 2
+    · refine ⟨σ, ?_, ParityReachableS.refl _ _⟩
+      omega
+    · have h_pos : 2 ≤ magSumS σ := by omega
+      obtain ⟨σ', h_mag', h_reach⟩ := parityReachableS_step_down A hA_ne hB_ne h_pos
+      obtain ⟨σ_min, h_min_small, h_min_reach⟩ :=
+        ih (magSumS σ') (by omega) σ' rfl
+      exact ⟨σ_min, h_min_small, ParityReachableS.trans h_reach h_min_reach⟩
+
+set_option linter.unusedDecidableInType false in
+/-- **Step-down to a sector-min canonical**: any configuration reaches some `σ_min` with
+`magSumS σ_min < 2` via `ParityReachableS`.  By the parity invariance of `ParityReachableS`
+(#3786), `magSumS σ_min ≡ magSumS σ (mod 2)`, so the minimum value is `0` (even parity) or
+`1` (odd parity). -/
+theorem parityReachableS_to_min_magSum
+    (A : V → Bool)
+    (hA_ne : ∃ a, A a = true)
+    (hB_ne : ∃ b, A b = false)
+    (σ : V → Fin (N + 1)) :
+    ∃ σ_min : V → Fin (N + 1),
+      magSumS σ_min < 2 ∧
+      ParityReachableS (bipartiteCompleteGraphOf A) σ σ_min :=
+  parityReachableS_to_min_magSum_aux A hA_ne hB_ne (magSumS σ) σ rfl
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

Adds `LatticeSystem/Quantum/SpinS/ParityReachToMinMagSum.lean`: WF-iterate the full step-down dispatcher (#3821) by strong induction on `magSumS σ` to reach a sector-min canonical (`magSumS < 2`).

Two exports
-----------
- `parityReachableS_to_min_magSum_aux`: strong induction on `n = magSumS σ`. In the base case `n < 2`, reflexivity suffices.  In the inductive case `n ≥ 2`, invoke `parityReachableS_step_down` (#3821), then recurse with strictly smaller `magSumS`.
- `parityReachableS_to_min_magSum`: the wrapped main theorem (instantiates `_aux` at `n = magSumS σ` with `rfl`).

Result
------
For any `σ : V → Fin (N + 1)` with `hA_ne`, `hB_ne` (sublattice non-emptyness), there exists `σ_min` with `magSumS σ_min < 2` AND `ParityReachableS σ σ_min`.  By the parity invariance of `ParityReachableS` (`parityReachableS_magSumS_parity_eq`, #3786), `magSumS σ_min ≡ magSumS σ (mod 2)`, so the achievable minimum is `0` (for even-parity σ) or `1` (for odd-parity σ).

Next steps toward (d.3) full totality
-------------------------------------
With this iteration in hand, the remaining work for `parityReachableS_total` (∀ same-parity σ σ', `ParityReachableS σ σ'`) is:
1. From σ and σ' (same parity), use `parityReachableS_to_min_magSum` to reach sector-min configs σ_min, σ'_min (each with `magSumS < 2`).
2. By parity invariance, `magSumS σ_min = magSumS σ'_min` (both equal to `magSumS σ mod 2`).
3. Within-sector reachability (#3817) connects σ_min ↔ σ'_min.
4. Symmetry (#3816) reverses `σ' → σ'_min` into `σ'_min → σ'`.
5. Chain: σ → σ_min → σ'_min → σ'.

That assembly is the next PR.  After that: discharge #3797 parity-block matrix irreducibility, closing (e) PR5 of Tasaki §2.5 Theorem 2.4 obligation (1).

No tex / docs update: still an intermediate layer in the (d) reachability totality assembly.
