### PR TITLE
MILESTONE: parity-block matrix unconditionally irreducible -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -180,6 +180,7 @@ import LatticeSystem.Quantum.SpinS.DressedAxisSwapSingleIonStrictPos
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapParityStepStrictPos
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockPowPos
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducible
+import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducibleUnconditional
 import LatticeSystem.Quantum.SpinS.ParityReachWitness
 import LatticeSystem.Quantum.SpinS.MagSumStepDown
 import LatticeSystem.Quantum.SpinS.ParityReachStepDown

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
@@ -1,0 +1,55 @@
+import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducible
+import LatticeSystem.Quantum.SpinS.ParityReachTotal
+
+/-!
+# Parity-block matrix irreducibility — unconditional version
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+Discharges the `hreach_total` reachability-totality hypothesis of
+`shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_parityReachable_total`
+(#3797) using `parityReachableS_total` (#3823): any two same-parity configurations on the
+bipartite complete graph are `ParityReachableS`-connected.
+
+This closes **(e) PR5** of Tasaki §2.5 Theorem 2.4 obligation (1): the parity-block shifted PF
+matrix is `Matrix.IsIrreducible` unconditionally under case (i.2) strict (plus the standard
+intermediate-site hypothesis for within-sector reachability and sublattice non-emptyness).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Parity-block shifted PF matrix is irreducible** (unconditional under case (i.2) strict).
+Discharges the totality hypothesis of #3797 via #3823 `parityReachableS_total`. -/
+theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
+    (A : Λ → Bool) {J : Λ → Λ → ℂ}
+    (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
+    (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
+    (hJself : ∀ x, J x x = 0) (hJbip : ∀ x y, J x y ≠ 0 → A x ≠ A y)
+    {lam : ℂ} (hlam : lam.im = 0) (hlb : -1 < lam.re) (hub : lam.re < 1)
+    {D : ℂ} (hDim : D.im = 0) (hDpos : 0 < D.re)
+    {c : ℝ}
+    (hc_strict : ∀ σ : Λ → Fin (N + 1),
+      dressedAxisSwappedAnisotropicHeisenbergSReMatrix A J lam D N σ σ < c)
+    (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false)
+    (h_intermediate : ∀ τ : Λ → Fin (N + 1), ∀ x : Λ,
+      ∃ z, A z ≠ A x ∧ (τ z).val < N)
+    (p : ℕ)
+    [Nonempty (parityConfigS Λ N p)] :
+    (shiftedDressedAxisSwappedReMatrixOnParityBlock A J lam D N c p).IsIrreducible := by
+  refine shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_parityReachable_total
+    A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict p ?_
+  intro σ' σ _hne
+  refine parityReachableS_total A hA_ne hB_ne h_intermediate ?_
+  -- magSumS σ.1 % 2 = p = magSumS σ'.1 % 2 from parityConfigS membership.
+  have hp_σ : magSumS σ.1 % 2 = p := σ.2
+  have hp_σ' : magSumS σ'.1 % 2 = p := σ'.2
+  omega
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

**MILESTONE: closes (e) PR5 of Tasaki §2.5 Theorem 2.4 obligation (1).**

Adds `LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean`: `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible` discharges the `hreach_total` reachability-totality hypothesis of #3797 by feeding in `parityReachableS_total` (#3823): any two same-parity configurations on the bipartite complete graph are `ParityReachableS`-connected.

Result
------
Under case (i.2) strict (`-1 < λ.re < 1`, `D > 0`, `c` strictly above all diagonal entries) **plus** the standard structural hypotheses for the §2.5 setting (`hA_ne`, `hB_ne`: sublattice non-emptyness; `h_intermediate`: §2.3 within-sector reachability hypothesis), the parity-block shifted PF matrix `shiftedDressedAxisSwappedReMatrixOnParityBlock` is `Matrix.IsIrreducible` — *unconditionally* (no remaining abstract reachability obligation).

Proof
-----
Simple thin wrapper around #3797 + #3823:
1. `refine shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_parityReachable_total ...` and leave the `hreach_total` as a `?_` hole.
2. In the hole: `intro σ' σ _hne`, then `parityReachableS_total A hA_ne hB_ne h_intermediate ?_`.
3. The remaining parity-match hypothesis `magSumS σ.1 % 2 = magSumS σ'.1 % 2` follows from `σ.2 : magSumS σ.1 % 2 = p` and `σ'.2 : magSumS σ'.1 % 2 = p` (the `parityConfigS Λ N p` membership), closed by `omega`.

Path to obligation (1) completion
---------------------------------
With (e) PR5 closed, the remaining work for §2.5 Theorem 2.4 obligation (1) is:
- **(f)** complex/real eigenspace bridge.
- **(g)** final ≤ 2 wrap via #3776 (abstract PF `finrank ≤ 1` keystone applied per block).

Both follow from the unconditional irreducibility (this PR) + the abstract PF infrastructure already in place.

No tex / docs update: an aggregator theorem; consolidated docs update planned at obligation (1) completion.
