### PR TITLE
(f.bridge step 1) Generic eigenspace shift correspondence -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -182,6 +182,7 @@ import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockPowPos
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducible
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducibleUnconditional
 import LatticeSystem.Quantum.SpinS.ParityBlockPerronFinrank
+import LatticeSystem.Quantum.SpinS.ParityBlockUnshiftedFinrank
 import LatticeSystem.Quantum.SpinS.ParityReachWitness
 import LatticeSystem.Quantum.SpinS.MagSumStepDown
 import LatticeSystem.Quantum.SpinS.ParityReachStepDown

--- a/LatticeSystem/Quantum/SpinS/ParityBlockUnshiftedFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityBlockUnshiftedFinrank.lean
@@ -1,0 +1,51 @@
+import LatticeSystem.Math.PerronFrobeniusFinrank
+
+/-!
+# Eigenspace shift correspondence (`c • 1 − M` ↔ `M`)
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+Generic linear-algebra helpers for the (f) eigenspace bridge: the `μ`-eigenspace of the shifted
+matrix `c • 1 − M` equals the `c − μ`-eigenspace of `M`, hence their finite-dimensional
+dimensions match.
+
+These are reusable Mathlib-style lemmas — applied first to the parity-block PF setting of
+Tasaki §2.5 Theorem 2.4 (where #3825's Perron `finrank ≤ 1` bound for the shifted parity-block
+matrix transfers to the un-shifted real-form parity-block matrix), and later to the analogous
+sector / Hamiltonian eigenspace bridges in the obligation (1) finishing arc.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Module Matrix
+
+/-- **Generic shift correspondence**: the `μ`-eigenspace of `c • 1 − M` equals the
+`c − μ`-eigenspace of `M`.  Pure linear algebra over ℝ. -/
+theorem eigenspace_smul_one_sub_eq {n : Type*} [Fintype n] [DecidableEq n]
+    (M : Matrix n n ℝ) (c μ : ℝ) :
+    End.eigenspace (Matrix.toLin' (c • (1 : Matrix n n ℝ) - M)) μ =
+      End.eigenspace (Matrix.toLin' M) (c - μ) := by
+  ext v
+  rw [End.mem_eigenspace_iff, End.mem_eigenspace_iff,
+      Matrix.toLin'_apply, Matrix.toLin'_apply, Matrix.sub_mulVec,
+      Matrix.smul_mulVec, Matrix.one_mulVec]
+  constructor
+  · intro h
+    rw [sub_smul, ← h]
+    abel
+  · intro h
+    rw [h, sub_smul]
+    abel
+
+/-- **Generic shift `finrank` correspondence**: the `μ`-eigenspace of `c • 1 − M` and the
+`c − μ`-eigenspace of `M` have equal `ℝ`-dimensions. -/
+theorem eigenspace_smul_one_sub_finrank_eq {n : Type*} [Fintype n] [DecidableEq n]
+    (M : Matrix n n ℝ) (c μ : ℝ) :
+    finrank ℝ (End.eigenspace (Matrix.toLin' (c • (1 : Matrix n n ℝ) - M)) μ) =
+      finrank ℝ (End.eigenspace (Matrix.toLin' M) (c - μ)) := by
+  rw [eigenspace_smul_one_sub_eq]
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

**(f) bridge step 1** — generic eigenspace shift correspondence for the obligation (1) finishing arc.

Two reusable Mathlib-style helpers in `LatticeSystem/Quantum/SpinS/ParityBlockUnshiftedFinrank.lean`:
- `eigenspace_smul_one_sub_eq`: the `μ`-eigenspace of `c • 1 − M` equals the `c − μ`-eigenspace of `M`.
- `eigenspace_smul_one_sub_finrank_eq`: corresponding `finrank ℝ` equality.

Pure linear algebra over ℝ; proven by `End.mem_eigenspace_iff` + `Matrix.{sub,smul,one}_mulVec` + algebraic rearrangement (`sub_smul` + `abel`).

Bridge plan
-----------
These will feed into subsequent sub-PRs of the (f) eigenspace bridge for Tasaki §2.5 Theorem 2.4 obligation (1):
1. (this PR) generic shift correspondence.
2. Application: shifted parity-block matrix eigenspace at Perron `μ_S` (#3825) ↔ un-shifted dressed `Ĥ'` real-form parity-block matrix eigenspace at `c − μ_S`.
3. Real ↔ complex bridge: un-shifted real-form parity-block ↔ complex parity-block at the same eigenvalue.
4. Block-diagonal correspondence: complex parity-block eigenspace ↔ full `Ĥ'` eigenspace ⊓ ker(`magParityDiagS = ±1`).
5. Similarity bridge `Ĥ` ↔ dressed `Ĥ'` via Θ_A (#3753/#3754).

Combined: `finrank ℝ (shifted parity-block) ≤ 1` (#3825) propagates to `finrank ℂ (Ĥ' eigenspace ⊓ ker(P=±1)) ≤ 1` for each ±1; then `axisSwappedAnisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one` (already proven) gives `finrank ℂ (Ĥ' eigenspace) ≤ 2`; finally similarity transfer gives `Ĥ` eigenspace ≤ 2.

No tex / docs update: a reusable Mathlib-style helper; consolidated docs update planned at obligation (1) completion.
