### PR TITLE
(f.3-finish) Dressed Ĥ' entries are real under real coefficients -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -186,6 +186,7 @@ import LatticeSystem.Quantum.SpinS.ParityBlockUnshiftedFinrank
 import LatticeSystem.Quantum.SpinS.ParityBlockDressedFinrank
 import LatticeSystem.Quantum.SpinS.RealComplexEigenspaceBridge
 import LatticeSystem.Quantum.SpinS.AxisSwapAnisotropicImZero
+import LatticeSystem.Quantum.SpinS.DressedAxisSwapImZero
 import LatticeSystem.Quantum.SpinS.ParityReachWitness
 import LatticeSystem.Quantum.SpinS.MagSumStepDown
 import LatticeSystem.Quantum.SpinS.ParityReachStepDown

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapImZero.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapImZero.lean
@@ -1,0 +1,36 @@
+import LatticeSystem.Quantum.SpinS.AxisSwapAnisotropicImZero
+import LatticeSystem.Quantum.SpinS.DressedAxisSwappedAnisotropic
+import LatticeSystem.Quantum.SpinS.MarshallSign
+
+/-!
+# Real entries of the Marshall-dressed axis-swapped `Ĥ'` under real coefficients
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(f.3-finish) step 2: the Marshall-dressed axis-swapped Hamiltonian has all-real entries under
+real coefficients, by lifting the bare `axisSwappedAnisotropicHeisenbergS_apply_im_zero` (#3829)
+through multiplication by the real (`±1`) Marshall sign factors.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Marshall-dressed `Ĥ'` entries are real under real coefficients**: `dressed σ τ =
+marshallSignS A σ * marshallSignS A τ * (axisSwapped J lam D N) σ τ` has imaginary part zero
+since each Marshall sign is `±1` (real) and the bare `axisSwapped` entry is real (#3829). -/
+theorem dressedAxisSwappedAnisotropicHeisenbergS_apply_im_zero
+    (A : Λ → Bool) {J : Λ → Λ → ℂ} (hJim : ∀ x y, (J x y).im = 0) (hJself : ∀ x, J x x = 0)
+    {lam : ℂ} (hlam : lam.im = 0) {D : ℂ} (hDim : D.im = 0)
+    (σ τ : Λ → Fin (N + 1)) :
+    (dressedAxisSwappedAnisotropicHeisenbergS A J lam D N σ τ).im = 0 := by
+  rw [dressedAxisSwappedAnisotropicHeisenbergS_apply]
+  simp [Complex.mul_im, marshallSignS_im,
+    axisSwappedAnisotropicHeisenbergS_apply_im_zero hJim hJself hlam hDim]
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

**(f.3-finish) step 2** — Marshall-dressed `Ĥ'` entries are real under real coefficients.

Adds `LatticeSystem/Quantum/SpinS/DressedAxisSwapImZero.lean` with one public theorem `dressedAxisSwappedAnisotropicHeisenbergS_apply_im_zero` that lifts #3829's `axisSwappedAnisotropicHeisenbergS_apply_im_zero` through the Marshall sign factors.

The Marshall signs `marshallSignS A σ` and `marshallSignS A τ` are `±1` (real, `marshallSignS_im` from `MarshallSign.lean`), so the product `marshallSignS A σ * marshallSignS A τ * (axisSwapped J lam D N) σ τ` has imaginary part zero whenever the bare `axisSwapped` entry does.

Proof: `rw [dressedAxisSwappedAnisotropicHeisenbergS_apply]` exposes the product form; `simp [Complex.mul_im, marshallSignS_im, axisSwappedAnisotropicHeisenbergS_apply_im_zero hJim hJself hlam hDim]` closes.

Path to obligation (1) completion
---------------------------------
This is the second link of the (f.3-finish) chain.  Remaining:
- Matrix identity `(dressed_re.submatrix valS valS).map ((↑) : ℝ → ℂ) = dressed_complex.submatrix valS valS` under im=0 hyps (follows from the entrywise im=0).
- Apply #3828 with `M := dressed_re.submatrix valS valS` → `finrank ℂ (complex dressed parity-block submatrix eigenspace) ≤ 1`.
- (f.4) block-diag bridge → `finrank ℂ (Ĥ' eigenspace ⊓ ker(P=±1)) ≤ 1`.
- (g) `Ĥ` ↔ dressed `Ĥ'` similarity transfer → `finrank ℂ (Ĥ eigenspace) ≤ 2`.

No tex / docs update: intermediate lemma; consolidated docs update planned at obligation (1) completion.
