### PR TITLE
(g.4) Bare Ĥ' per-block PF eig ⊓ ker(P) ≤ 1 via Marshall similarity -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -192,6 +192,7 @@ import LatticeSystem.Quantum.SpinS.BlockDiagSubmatrixBridge
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
 import LatticeSystem.Quantum.SpinS.DressedFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.GaugeIntersectionEigenspaceFinrank
+import LatticeSystem.Quantum.SpinS.BareAxisSwapFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.ParityReachWitness
 import LatticeSystem.Quantum.SpinS.MagSumStepDown
 import LatticeSystem.Quantum.SpinS.ParityReachStepDown

--- a/LatticeSystem/Quantum/SpinS/BareAxisSwapFullEigInterParityLeOne.lean
+++ b/LatticeSystem/Quantum/SpinS/BareAxisSwapFullEigInterParityLeOne.lean
@@ -1,0 +1,76 @@
+import LatticeSystem.Quantum.SpinS.DressedFullEigInterParityLeOne
+import LatticeSystem.Quantum.SpinS.GaugeIntersectionEigenspaceFinrank
+
+/-!
+# Bare `Ĥ'` per-parity-block full-eigenspace `finrank ℂ ≤ 1` at the PF ν
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(g.4): transfers the dressed `Ĥ'_dressed` per-block PF bound (#3834) to the bare
+axis-swapped `Ĥ'`, via the Marshall similarity (#3776 family) lifted to intersected
+eigenspaces (#3835).
+
+The key observation: the Marshall sign diagonal `Θ_A` commutes with the magnetization
+parity diagonal `P = magParityDiagS` (two diagonal matrices), so the intersected
+eigenspace finrank `eig Ĥ' μ ⊓ ker(P=c)` is preserved by Marshall similarity from
+dressed to bare.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Marshall diagonal commutes with `magParityDiagS`**: two diagonal matrices commute. -/
+theorem marshallDiagonal_commute_magParityDiagS (A : Λ → Bool) (N : ℕ) :
+    magParityDiagS Λ N * (Matrix.diagonal (marshallSignS A) : ManyBodyOpS Λ N) =
+      (Matrix.diagonal (marshallSignS A) : ManyBodyOpS Λ N) * magParityDiagS Λ N := by
+  rw [magParityDiagS, Matrix.diagonal_mul_diagonal, Matrix.diagonal_mul_diagonal]
+  congr 1
+  funext σ
+  ring
+
+/-- **Bare `Ĥ'` per-block full-eigenspace `finrank ℂ ≤ 1`** at the PF ν, via the Marshall
+similarity transfer from #3834. -/
+theorem bare_axisSwapped_full_eigenspace_inter_parity_finrank_le_one
+    (A : Λ → Bool) {J : Λ → Λ → ℂ}
+    (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
+    (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
+    (hJself : ∀ x, J x x = 0) (hJbip : ∀ x y, J x y ≠ 0 → A x ≠ A y)
+    {lam : ℂ} (hlam : lam.im = 0) (hlb : -1 < lam.re) (hub : lam.re < 1)
+    {D : ℂ} (hDim : D.im = 0) (hDpos : 0 < D.re)
+    {c : ℝ}
+    (hc_strict : ∀ σ : Λ → Fin (N + 1),
+      dressedAxisSwappedAnisotropicHeisenbergSReMatrix A J lam D N σ σ < c)
+    (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false)
+    (h_intermediate : ∀ τ : Λ → Fin (N + 1), ∀ x : Λ,
+      ∃ z, A z ≠ A x ∧ (τ z).val < N)
+    {p : ℕ} (hp : p < 2)
+    [Nonempty (parityConfigS Λ N p)] :
+    ∃ ν : ℝ,
+      Module.finrank ℂ ↥(End.eigenspace
+          (Matrix.toLin' (axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D N)) (ν : ℂ) ⊓
+        End.eigenspace (Matrix.toLin' (magParityDiagS Λ N)) ((-1 : ℂ) ^ p)) ≤ 1 := by
+  obtain ⟨ν, hdressed⟩ :=
+    dressed_full_eigenspace_inter_parity_finrank_le_one
+      A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
+      hA_ne hB_ne h_intermediate hp
+  refine ⟨ν, ?_⟩
+  have htransfer :=
+    matrix_similar_eigenspace_inter_finrank_eq
+      (U := Matrix.diagonal (marshallSignS A))
+      (Uinv := Matrix.diagonal (marshallSignS A))
+      (H := axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D N)
+      (H' := dressedAxisSwappedAnisotropicHeisenbergS A J lam D N)
+      (Q := magParityDiagS Λ N)
+      (marshallDiagonal_mul_self A) (marshallDiagonal_mul_self A)
+      (dressedAxisSwappedAnisotropicHeisenbergS_eq_diag_conj A J lam D N)
+      (marshallDiagonal_commute_magParityDiagS A N) (ν : ℂ) ((-1 : ℂ) ^ p)
+  rw [htransfer] at hdressed
+  exact hdressed
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (g.4) bare `Ĥ'` per-block PF eig ⊓ ker(P) ≤ 1 via Marshall transfer

Transfers the dressed `Ĥ'_dressed` per-block PF bound (#3834) to the bare axis-swapped
`Ĥ'`, via the Marshall similarity transfer lemma for intersected eigenspaces (#3835).

Key observation: `Θ_A` and `P = magParityDiagS` are both diagonal, so they commute, and
the intersection finrank `eig Ĥ' μ ⊓ ker(P=c)` is preserved by Marshall similarity
dressed → bare.

## Theorems

| # | Theorem | Role |
|---|---|---|
| 1 | `marshallDiagonal_commute_magParityDiagS` | `P * Θ_A = Θ_A * P` (entrywise) |
| 2 | `bare_axisSwapped_full_eigenspace_inter_parity_finrank_le_one` | bare per-block PF ≤ 1 |

Theorem 2 statement (`p < 2`):
```
∃ ν : ℝ, finrank ℂ (eig (axisSwappedAnisotropicHeisenbergS J lam D N) (ν:ℂ) ⊓
                     ker(magParityDiagS Λ N) ((-1:ℂ)^p)) ≤ 1
```

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e) | #3824 | merged |
| (f.1A)–(f.4) | #3825–#3832 | merged |
| (g.1) dressed eig ≤ 2 from per-block ≤ 1 | #3833 | merged |
| (g.2) dressed per-block PF ≤ 1 at PF ν | #3834 | merged |
| (g.3) similarity-invariant intersection finrank | #3835 | merged |
| **(g.4) bare per-block PF ≤ 1** | **#3836** | this PR |
| (g.5) bare Ĥ' eig ≤ 2 assembly + axis-swap to bare Ĥ | TBD | next |

The bare per-block bound from this PR is the input consumed by the existing
`axisSwappedAnisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one`
(which gives the per-eigenvalue `≤ 2` from `≤ 1` per block, modulo ν-sector matching).

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
