### PR TITLE
(g.5) Bare anisotropic Ĥ eigenspace finrank ≤ 2 (conditional, via axis-swap) -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -193,6 +193,7 @@ import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
 import LatticeSystem.Quantum.SpinS.DressedFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.GaugeIntersectionEigenspaceFinrank
 import LatticeSystem.Quantum.SpinS.BareAxisSwapFullEigInterParityLeOne
+import LatticeSystem.Quantum.SpinS.BareAnisotropicEigLeTwoConditional
 import LatticeSystem.Quantum.SpinS.ParityReachWitness
 import LatticeSystem.Quantum.SpinS.MagSumStepDown
 import LatticeSystem.Quantum.SpinS.ParityReachStepDown

--- a/LatticeSystem/Quantum/SpinS/BareAnisotropicEigLeTwoConditional.lean
+++ b/LatticeSystem/Quantum/SpinS/BareAnisotropicEigLeTwoConditional.lean
@@ -1,0 +1,73 @@
+import LatticeSystem.Quantum.SpinS.AxisSwapUnitarySpinHalf
+import LatticeSystem.Quantum.SpinS.AxisSwapDegeneracy
+import LatticeSystem.Quantum.SpinS.BareAxisSwapFullEigInterParityLeOne
+import LatticeSystem.Quantum.SpinS.ParityDegeneracyBound
+
+/-!
+# Bare anisotropic Hamiltonian `Ĥ` eigenspace `finrank ℂ ≤ 2` (conditional)
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(g.5): wraps the conditional `bare Ĥ' eig ≤ 2 from per-block ≤ 1` (via
+`axisSwappedAnisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one`, #3776 family)
+with the axis-swap unitary equivalence (`anisotropic_axisSwapped_eigenspace_finrank_eq`,
+#3756) to give the same conditional bound for the bare anisotropic Hamiltonian `Ĥ`.
+
+The conditional hypotheses (per-parity-block intersection finrank ≤ 1 at the same μ)
+are not yet discharged unconditionally for general spin-S; they ARE discharged for
+each parity sector's PF eigenvalue ν_p separately by (g.4) #3836, but the per-sector
+ν_p may differ, so the unconditional ≤ 2 still awaits a ν-sector matching argument
+(equality of the two PF ground-state energies, deferrable to subsequent work).
+
+The spin-1/2 instance is established via `axisSwapUnitarySpinHalf`; for general S, the
+caller must provide an `AxisSwapUnitaryS N` instance.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Bare anisotropic `Ĥ` eigenspace `finrank ℂ ≤ 2` (conditional, general N with an
+`AxisSwapUnitaryS` instance)**: given per-parity-block bounds on the axis-swapped `Ĥ'` at
+`μ`, the bare anisotropic `Ĥ` at `μ` also has eigenspace `finrank ℂ ≤ 2`.
+
+Combines:
+- `axisSwappedAnisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one`
+  (#3776 family): bare `Ĥ'` eig ≤ 2 from per-block ≤ 1.
+- `AxisSwapUnitaryS.anisotropic_axisSwapped_eigenspace_finrank_eq` (#3756): bare `Ĥ`
+  and `Ĥ'` eigenspaces have equal finrank under the axis-swap unitary `G`. -/
+theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one
+    (G : AxisSwapUnitaryS N)
+    {J : Λ → Λ → ℂ} (hJself : ∀ x, J x x = 0) (lam D μ : ℂ)
+    (heven : finrank ℂ ↥(End.eigenspace
+        (Matrix.toLin' (axisSwappedAnisotropicHeisenbergS J lam D N)) μ ⊓
+      End.eigenspace (Matrix.toLin' (magParityDiagS Λ N)) 1) ≤ 1)
+    (hodd : finrank ℂ ↥(End.eigenspace
+        (Matrix.toLin' (axisSwappedAnisotropicHeisenbergS J lam D N)) μ ⊓
+      End.eigenspace (Matrix.toLin' (magParityDiagS Λ N)) (-1)) ≤ 1) :
+    finrank ℂ (End.eigenspace
+        (Matrix.toLin' (anisotropicHeisenbergS (Λ := Λ) J lam D N)) μ) ≤ 2 := by
+  rw [← G.anisotropic_axisSwapped_eigenspace_finrank_eq J lam D μ]
+  exact axisSwappedAnisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one
+    hJself lam D μ heven hodd
+
+/-- **Spin-1/2 instance**: the conditional bare anisotropic `Ĥ` eigenspace `≤ 2` for `N = 1`. -/
+theorem spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one
+    {J : Λ → Λ → ℂ} (hJself : ∀ x, J x x = 0) (lam D μ : ℂ)
+    (heven : finrank ℂ ↥(End.eigenspace
+        (Matrix.toLin' (axisSwappedAnisotropicHeisenbergS J lam D 1)) μ ⊓
+      End.eigenspace (Matrix.toLin' (magParityDiagS Λ 1)) 1) ≤ 1)
+    (hodd : finrank ℂ ↥(End.eigenspace
+        (Matrix.toLin' (axisSwappedAnisotropicHeisenbergS J lam D 1)) μ ⊓
+      End.eigenspace (Matrix.toLin' (magParityDiagS Λ 1)) (-1)) ≤ 1) :
+    finrank ℂ (End.eigenspace
+        (Matrix.toLin' (anisotropicHeisenbergS (Λ := Λ) J lam D 1)) μ) ≤ 2 :=
+  anisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one
+    axisSwapUnitarySpinHalf hJself lam D μ heven hodd
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (g.5) bare `Ĥ` eigenspace `finrank ℂ ≤ 2` (conditional, via axis-swap)

Wraps the conditional bare `Ĥ' eig ≤ 2 from per-block ≤ 1` (#3776 family) with the
axis-swap unitary equivalence (#3756 family) to give the same conditional bound for
the bare anisotropic Hamiltonian `Ĥ`.

## Theorems

| # | Theorem | Role |
|---|---|---|
| 1 | `anisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one` | General `N` with explicit `AxisSwapUnitaryS N` |
| 2 | `spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_of_blocks_le_one` | `N = 1` instance via `axisSwapUnitarySpinHalf` (#3753 family) |

Both signatures:
```
Given heven, hodd : finrank ℂ (eig (axisSwapped J lam D N) μ ⊓ ker(P=±1)) ≤ 1,
  finrank ℂ (eig (anisotropic J lam D N) μ) ≤ 2.
```

## What's complete

The (g.X) chain is now in place for **conditional** ground-state degeneracy ≤ 2:

| Stage | PR | Status |
|---|---|---|
| (e) | #3824 | merged |
| (f.1A)–(f.4) | #3825–#3832 | merged |
| (g.1) dressed eig ≤ 2 from per-block ≤ 1 | #3833 | merged |
| (g.2) dressed per-block PF ≤ 1 at PF ν | #3834 | merged |
| (g.3) similarity-invariant intersection finrank | #3835 | merged |
| (g.4) bare Ĥ' per-block PF ≤ 1 | #3836 | merged |
| **(g.5) bare Ĥ ≤ 2 (conditional)** | **#3837** | this PR |

## What remains for full obligation (1)

The unconditional obligation (1) (= "bare Ĥ ground-state eigenspace finrank ≤ 2")
requires **ν-sector matching**: showing that the two per-sector PF eigenvalues
(ν_0 from (g.4) at p=0 and ν_1 at p=1) coincide at the ground-state energy `E_GS`,
or alternatively showing that at `E_GS = min(ν_0, ν_1)` only the achieving sector
contributes (giving multiplicity ≤ 1 < 2).

That is a separate, mathematically distinct argument (Hermitian spectral
theory + per-sector minimization) and is deferred to subsequent work.

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
