### PR TITLE
Refactor: import cleanup of §2.5 (e)-(g) chain + build-speed eval -- #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/BareAnisotropicEigLeTwoConditional.lean
+++ b/LatticeSystem/Quantum/SpinS/BareAnisotropicEigLeTwoConditional.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.SpinS.AxisSwapUnitarySpinHalf
 import LatticeSystem.Quantum.SpinS.AxisSwapDegeneracy
-import LatticeSystem.Quantum.SpinS.BareAxisSwapFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.ParityDegeneracyBound
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/BlockDiagSubmatrixBridge.lean
+++ b/LatticeSystem/Quantum/SpinS/BlockDiagSubmatrixBridge.lean
@@ -2,7 +2,6 @@ import LatticeSystem.Quantum.SpinS.MagParityOperator
 import LatticeSystem.Quantum.SpinS.ParityConfig
 import Mathlib.LinearAlgebra.Eigenspace.Basic
 import Mathlib.LinearAlgebra.Matrix.ToLin
-import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 
 /-!
 # Block-diagonal submatrix bridge: full eigenspace ⊓ ker(P) → submatrix eigenspace


### PR DESCRIPTION
Tracked in #3739.

## Refactor checkpoint: import cleanup + build-speed eval of §2.5 (e)-(g) chain

20-PR cadence refactor (27 PRs since previous refactor #3810).

## Changes

| File | Action |
|---|---|
| `BlockDiagSubmatrixBridge.lean` | Drop unused `Mathlib.LinearAlgebra.Dimension.StrongRankCondition` |
| `BareAnisotropicEigLeTwoConditional.lean` | Drop unused `BareAxisSwapFullEigInterParityLeOne` |

Both imports were referenced conceptually in docstrings but not actually used by
the file's source. Removed for cleanliness and slightly faster compile.

## Build-speed evaluation

All 11 files in the (e)-(g) chain (PRs #3824–#3837):

| File | Lines | Isolated rebuild |
|---|---|---|
| `ParityBlockDressedFinrank` | 81 | — |
| `RealComplexEigenspaceBridge` | 117 | 2.3 s |
| `AxisSwapAnisotropicImZero` | 94 | 2.4 s |
| `DressedAxisSwapImZero` | 36 | — |
| `ComplexDressedParityBlockFinrank` | 83 | — |
| `BlockDiagSubmatrixBridge` | 138 | 2.7 s |
| `DressedAxisSwapDegeneracyBound` | 108 | 2.7 s |
| `DressedFullEigInterParityLeOne` | 75 | — |
| `GaugeIntersectionEigenspaceFinrank` | 89 | 2.3 s |
| `BareAxisSwapFullEigInterParityLeOne` | 76 | — |
| `BareAnisotropicEigLeTwoConditional` | 72 | 4.8 s (cold) |

**No file exceeds the typical 800-line split threshold; no consolidations or splits
warranted.** All files are below the size where build-time penalty becomes notable
(~500 lines). API surface and proof complexity are appropriate for the conditional
ground-state degeneracy ≤ 2 obligation.

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
