### PR TITLE
(h.3) Block-sum finrank equality + dressed/bare specialisations -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -189,6 +189,7 @@ import LatticeSystem.Quantum.SpinS.AxisSwapAnisotropicImZero
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapImZero
 import LatticeSystem.Quantum.SpinS.ComplexDressedParityBlockFinrank
 import LatticeSystem.Quantum.SpinS.BlockDiagSubmatrixBridge
+import LatticeSystem.Quantum.SpinS.InvolutionEigenspaceDecompEq
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
 import LatticeSystem.Quantum.SpinS.DressedFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.GaugeIntersectionEigenspaceFinrank

--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -191,6 +191,7 @@ import LatticeSystem.Quantum.SpinS.ComplexDressedParityBlockFinrank
 import LatticeSystem.Quantum.SpinS.BlockDiagSubmatrixBridge
 import LatticeSystem.Quantum.SpinS.BlockDiagSubmatrixEmbed
 import LatticeSystem.Quantum.SpinS.InvolutionEigenspaceDecompEq
+import LatticeSystem.Quantum.SpinS.BlockSumFinrankEq
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
 import LatticeSystem.Quantum.SpinS.DressedFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.GaugeIntersectionEigenspaceFinrank

--- a/LatticeSystem/Quantum/SpinS/BlockSumFinrankEq.lean
+++ b/LatticeSystem/Quantum/SpinS/BlockSumFinrankEq.lean
@@ -1,0 +1,122 @@
+import LatticeSystem.Quantum.SpinS.BlockDiagSubmatrixEmbed
+import LatticeSystem.Quantum.SpinS.InvolutionEigenspaceDecompEq
+import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
+import LatticeSystem.Quantum.SpinS.BareAxisSwapFullEigInterParityLeOne
+
+/-!
+# Block-sum finrank equality: `finrank ℂ (eig M μ) = ∑_p finrank ℂ (eig M.submatrix_p μ)`
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(h.3): combines (h.1) #3840 (per-block submatrix-full intersection finrank equality)
+with (h.2) #3841 (involution decomposition finrank equality) to give the **block-sum
+equality** for any parity-block-diagonal Hamiltonian commuting with `magParityDiagS`:
+```
+finrank ℂ (eig M μ) = finrank ℂ (eig M.submatrix_0 μ) + finrank ℂ (eig M.submatrix_1 μ)
+```
+
+Specialised to the dressed `Ĥ'_dressed` and the bare `Ĥ'` (both block-diagonal and
+commuting with `P`), this gives the sharp `≤ 2` bound at any eigenvalue where the
+two per-sector contributions are simultaneously ≤ 1 — the input for the
+unconditional ground-state degeneracy bound via spectral minimisation
+(deferred to subsequent work).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Block-sum finrank equality** for any complex matrix `M` that (i) is parity-block-diagonal
+and (ii) commutes with `magParityDiagS`: at any `μ : ℂ`,
+```
+finrank ℂ (eig M μ) = finrank ℂ (eig M.submatrix_0 μ) + finrank ℂ (eig M.submatrix_1 μ)
+```
+Combines (h.1) #3840 (per-block submatrix-full intersection finrank equality) with
+(h.2) #3841 (involution decomposition finrank equality). -/
+theorem matrix_eigenspace_finrank_eq_sum_parity_blocks
+    {M : Matrix (Λ → Fin (N + 1)) (Λ → Fin (N + 1)) ℂ}
+    (hM_block : ∀ σ τ : Λ → Fin (N + 1), magSumS σ % 2 ≠ magSumS τ % 2 → M σ τ = 0)
+    (hM_comm : M * magParityDiagS Λ N = magParityDiagS Λ N * M)
+    (μ : ℂ) :
+    finrank ℂ (End.eigenspace (Matrix.toLin' M) μ) =
+      finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+          (M.submatrix
+            (fun σ : parityConfigS Λ N 0 => σ.1)
+            (fun σ : parityConfigS Λ N 0 => σ.1))) μ) +
+        finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+          (M.submatrix
+            (fun σ : parityConfigS Λ N 1 => σ.1)
+            (fun σ : parityConfigS Λ N 1 => σ.1))) μ) := by
+  -- Step 1: involution decomposition gives full eig = sum of inter ⊓ ker P_{±1}.
+  have hsplit := eigenspace_finrank_eq_of_commuting_involution
+    (Matrix.toLin' M) (Matrix.toLin' (magParityDiagS Λ N))
+    (by rw [← Matrix.toLin'_mul, ← Matrix.toLin'_mul, hM_comm])
+    (by rw [← Matrix.toLin'_mul, magParityDiagS_mul_self, Matrix.toLin'_one]) μ
+  -- Step 2: per-block (h.1) equality replaces each inter ⊓ ker P_p with eig submatrix_p.
+  have hp0 : (0 : ℕ) < 2 := by norm_num
+  have hp1 : (1 : ℕ) < 2 := by norm_num
+  have heq0 := parity_block_submatrix_full_inter_finrank_eq hM_block hp0 μ
+  have heq1 := parity_block_submatrix_full_inter_finrank_eq hM_block hp1 μ
+  -- ker(P=1) = eigenspace P 1 and (-1)^0 = 1; ker(P=-1) and (-1)^1 = -1.
+  have hpow0 : ((-1 : ℂ) ^ 0) = 1 := by norm_num
+  have hpow1 : ((-1 : ℂ) ^ 1) = -1 := by norm_num
+  rw [hpow0] at heq0
+  rw [hpow1] at heq1
+  rw [hsplit, ← heq0, ← heq1]
+
+/-- **Dressed `Ĥ'` block-sum finrank equality**: specialisation to the dressed
+axis-swapped anisotropic Heisenberg. -/
+theorem dressedAxisSwappedAnisotropicHeisenbergS_eigenspace_finrank_eq_sum_parity_blocks
+    (A : Λ → Bool) {J : Λ → Λ → ℂ} (hJself : ∀ x, J x x = 0) (lam D μ : ℂ) :
+    finrank ℂ (End.eigenspace
+        (Matrix.toLin' (dressedAxisSwappedAnisotropicHeisenbergS A J lam D N)) μ) =
+      finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+          ((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N).submatrix
+            (fun σ : parityConfigS Λ N 0 => σ.1)
+            (fun σ : parityConfigS Λ N 0 => σ.1))) μ) +
+        finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+          ((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N).submatrix
+            (fun σ : parityConfigS Λ N 1 => σ.1)
+            (fun σ : parityConfigS Λ N 1 => σ.1))) μ) := by
+  refine matrix_eigenspace_finrank_eq_sum_parity_blocks ?_ ?_ μ
+  · intro σ τ hne_par
+    have hne : σ ≠ τ := fun h => hne_par (by rw [h])
+    have hodd : Odd (magSumS σ + magSumS τ) := by
+      rw [Nat.odd_iff]
+      have h1 : magSumS σ % 2 < 2 := Nat.mod_lt _ (by norm_num)
+      have h2 : magSumS τ % 2 < 2 := Nat.mod_lt _ (by norm_num)
+      omega
+    exact dressedAxisSwappedAnisotropicHeisenbergS_apply_eq_zero_of_magSum_parity_ne
+      A hJself lam D hne hodd
+  · exact dressedAxisSwappedAnisotropicHeisenbergS_commute_magParityDiagS A hJself lam D
+
+/-- **Bare axis-swapped `Ĥ'` block-sum finrank equality**. -/
+theorem axisSwappedAnisotropicHeisenbergS_eigenspace_finrank_eq_sum_parity_blocks
+    {J : Λ → Λ → ℂ} (hJself : ∀ x, J x x = 0) (lam D μ : ℂ) :
+    finrank ℂ (End.eigenspace
+        (Matrix.toLin' (axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D N)) μ) =
+      finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+          ((axisSwappedAnisotropicHeisenbergS J lam D N).submatrix
+            (fun σ : parityConfigS Λ N 0 => σ.1)
+            (fun σ : parityConfigS Λ N 0 => σ.1))) μ) +
+        finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+          ((axisSwappedAnisotropicHeisenbergS J lam D N).submatrix
+            (fun σ : parityConfigS Λ N 1 => σ.1)
+            (fun σ : parityConfigS Λ N 1 => σ.1))) μ) := by
+  refine matrix_eigenspace_finrank_eq_sum_parity_blocks ?_ ?_ μ
+  · intro σ τ hne_par
+    have hne : σ ≠ τ := fun h => hne_par (by rw [h])
+    have hodd : Odd (magSumS σ + magSumS τ) := by
+      rw [Nat.odd_iff]
+      have h1 : magSumS σ % 2 < 2 := Nat.mod_lt _ (by norm_num)
+      have h2 : magSumS τ % 2 < 2 := Nat.mod_lt _ (by norm_num)
+      omega
+    exact axisSwappedAnisotropicHeisenbergS_apply_eq_zero_of_magSum_parity_ne hJself lam D hne hodd
+  · exact axisSwappedAnisotropicHeisenbergS_commute_magParityDiagS hJself lam D
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/InvolutionEigenspaceDecompEq.lean
+++ b/LatticeSystem/Quantum/SpinS/InvolutionEigenspaceDecompEq.lean
@@ -1,0 +1,95 @@
+import LatticeSystem.Quantum.SpinS.MagParityEigenspaceDecomp
+
+/-!
+# Eigenspace finrank decomposition under a commuting involution: equality version
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(h.2): strengthens `eigenspace_finrank_le_of_commuting_involution` (#3776) from `≤` to `=`.
+The `≤` is tight because the two intersected `±1` eigenspaces of the involution `P` are
+disjoint (a single eigenvector cannot have two distinct `P`-eigenvalues), so
+`Submodule.finrank_sup_add_finrank_inf_eq` collapses to a sum (the inf contributes 0).
+
+This is one of two ingredients for the unconditional ground-state degeneracy ≤ 2 (the other
+being the per-parity-block submatrix finrank equality from (h.1) #3840 ⟶ for the full
+block-diagonal Hamiltonian, `finrank ℂ (eig M μ) = ∑_p finrank ℂ (eig M.submatrix_p μ)`).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Module Matrix
+
+/-- **The ±1 eigenspaces of an involution are disjoint.** -/
+private theorem eigenspace_one_inf_neg_one_eq_bot
+    {V : Type*} [AddCommGroup V] [Module ℂ V]
+    (P : V →ₗ[ℂ] V) :
+    End.eigenspace P 1 ⊓ End.eigenspace P (-1) = ⊥ := by
+  refine le_bot_iff.mp ?_
+  intro v hv
+  simp only [Submodule.mem_inf, End.mem_eigenspace_iff, one_smul, neg_smul] at hv
+  obtain ⟨h1, hm1⟩ := hv
+  -- P v = v AND P v = -v ⟹ v = -v ⟹ 2 v = 0 ⟹ v = 0.
+  have hvv : v = -v := h1.symm.trans hm1
+  have h2v : (2 : ℂ) • v = 0 := by
+    rw [two_smul]
+    nth_rw 1 [hvv]
+    exact neg_add_cancel v
+  have hv0 : v = 0 := by
+    have h_two_ne : (2 : ℂ) ≠ 0 := by norm_num
+    exact (smul_eq_zero.mp h2v).resolve_left h_two_ne
+  rw [hv0]
+  exact Submodule.zero_mem _
+
+/-- **Eigenspace finrank EQUALITY under a commuting involution** (strengthens #3776 from `≤` to `=`):
+for finite-dimensional `T, P` with `T ∘ P = P ∘ T` and `P ∘ P = id`, every `T`-eigenspace
+**splits as a direct sum** across the two `P`-eigenspaces `±1`, giving
+`finrank (eigenspace T μ) = finrank (eigenspace T μ ⊓ eigenspace P 1) + finrank (eigenspace T μ ⊓ eigenspace P (−1))`. -/
+theorem eigenspace_finrank_eq_of_commuting_involution
+    {V : Type*} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
+    (T P : V →ₗ[ℂ] V) (hcomm : T ∘ₗ P = P ∘ₗ T) (hP : P ∘ₗ P = LinearMap.id) (μ : ℂ) :
+    finrank ℂ (End.eigenspace T μ) =
+      finrank ℂ ↥(End.eigenspace T μ ⊓ End.eigenspace P 1) +
+        finrank ℂ ↥(End.eigenspace T μ ⊓ End.eigenspace P (-1)) := by
+  set W := End.eigenspace T μ
+  -- Proof same as the ≤ version: W = (W ⊓ E₁) ⊔ (W ⊓ E_-1) and the inf is bot.
+  have hPP : ∀ w : V, P (P w) = w := fun w => by
+    have := congrArg (fun f => f w) hP; simpa using this
+  have hsplit : ∀ w ∈ W, w ∈ (W ⊓ End.eigenspace P 1) ⊔ (W ⊓ End.eigenspace P (-1)) := by
+    intro w hw
+    have hWinv : P w ∈ W := by
+      rw [End.mem_eigenspace_iff] at hw ⊢
+      have hTP : T (P w) = P (T w) := by
+        rw [← LinearMap.comp_apply, hcomm, LinearMap.comp_apply]
+      rw [hTP, hw, map_smul]
+    have hdecomp : w = ((2 : ℂ)⁻¹ • (w + P w)) + ((2 : ℂ)⁻¹ • (w - P w)) := by
+      rw [smul_add, smul_sub]; module
+    rw [hdecomp]
+    apply Submodule.add_mem_sup
+    · refine Submodule.mem_inf.mpr ⟨W.smul_mem _ (W.add_mem hw hWinv), ?_⟩
+      rw [End.mem_eigenspace_iff, map_smul, map_add, hPP, one_smul]; module
+    · refine Submodule.mem_inf.mpr ⟨W.smul_mem _ (W.sub_mem hw hWinv), ?_⟩
+      rw [End.mem_eigenspace_iff, map_smul, map_sub, hPP]; module
+  have hle : W ≤ (W ⊓ End.eigenspace P 1) ⊔ (W ⊓ End.eigenspace P (-1)) := hsplit
+  have hge : (W ⊓ End.eigenspace P 1) ⊔ (W ⊓ End.eigenspace P (-1)) ≤ W := by
+    exact sup_le inf_le_left inf_le_left
+  have heq : W = (W ⊓ End.eigenspace P 1) ⊔ (W ⊓ End.eigenspace P (-1)) := le_antisymm hle hge
+  conv_lhs => rw [heq]
+  -- Now apply Submodule.finrank_sup_add_finrank_inf_eq, with the inner inf = 0.
+  have hinf_bot : (W ⊓ End.eigenspace P 1) ⊓ (W ⊓ End.eigenspace P (-1)) = ⊥ :=
+    le_antisymm
+      (fun v hv => by
+        simp only [Submodule.mem_inf] at hv
+        have : v ∈ End.eigenspace P 1 ⊓ End.eigenspace P (-1) :=
+          Submodule.mem_inf.mpr ⟨hv.1.2, hv.2.2⟩
+        rw [eigenspace_one_inf_neg_one_eq_bot P] at this
+        exact this)
+      bot_le
+  have hsum_eq := Submodule.finrank_sup_add_finrank_inf_eq
+    (W ⊓ End.eigenspace P 1) (W ⊓ End.eigenspace P (-1))
+  rw [hinf_bot, finrank_bot] at hsum_eq
+  omega
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (h.3) block-sum finrank equality

Combines (h.1) #3840 (per-block submatrix-full intersection finrank equality) with
(h.2) #3841 (involution decomposition finrank equality) to give the **block-sum
equality** for any parity-block-diagonal matrix `M` that commutes with `magParityDiagS`:

```
finrank ℂ (eig M μ) = finrank ℂ (eig M.submatrix_0 μ) + finrank ℂ (eig M.submatrix_1 μ)
```

## Theorems

| # | Theorem | Role |
|---|---|---|
| 1 | `matrix_eigenspace_finrank_eq_sum_parity_blocks` | Generic block-sum equality |
| 2 | `dressedAxisSwappedAnisotropicHeisenbergS_eigenspace_finrank_eq_sum_parity_blocks` | Dressed `Ĥ'` specialisation |
| 3 | `axisSwappedAnisotropicHeisenbergS_eigenspace_finrank_eq_sum_parity_blocks` | Bare `Ĥ'` specialisation |

## Proof

`hsplit` from (h.2) #3841 gives `eig M μ = (eig ⊓ ker P_1) + (eig ⊓ ker P_-1)`. Then
`heq0`/`heq1` from (h.1) #3840 replace each intersection with the corresponding
submatrix eigenspace. `(-1)^0 = 1` and `(-1)^1 = -1` normalised via `norm_num`.

## Why this matters

This is the central tool for unconditional `≤ 2` at any μ where both per-block bounds
hold simultaneously. Combined with PF (per-sector simplicity at the per-sector
spectrum minimum) and a Hermitian spectral identification of the GS energy as
`min(ν_0, ν_1)`, this gives the unconditional bare `Ĥ'` GS degeneracy `≤ 2`.

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e)–(g.5) | #3824–#3837 | merged |
| Docs sync | #3839 | merged |
| (h.1) reverse block-diag bridge | #3840 | merged |
| (h.2) involution decomposition equality | #3841 | merged |
| **(h.3) block-sum finrank equality** | **#3842** | this PR |
| (h.4) Hermitian spectral min identification | TBD | next |

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
