### PR TITLE
Refactor: (h) chain import cleanup + build-speed eval -- #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/BlockSumFinrankEq.lean
+++ b/LatticeSystem/Quantum/SpinS/BlockSumFinrankEq.lean
@@ -1,7 +1,6 @@
 import LatticeSystem.Quantum.SpinS.BlockDiagSubmatrixEmbed
 import LatticeSystem.Quantum.SpinS.InvolutionEigenspaceDecompEq
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
-import LatticeSystem.Quantum.SpinS.BareAxisSwapFullEigInterParityLeOne
 
 /-!
 # Block-sum finrank equality: `finrank ℂ (eig M μ) = ∑_p finrank ℂ (eig M.submatrix_p μ)`


### PR DESCRIPTION
Tracked in #3739.

## Refactor checkpoint: (h) chain import cleanup + build-speed eval

20-PR cadence refactor (34 PRs since previous refactor #3810).

## Change

| File | Action |
|---|---|
| `BlockSumFinrankEq.lean` | Drop unused `BareAxisSwapFullEigInterParityLeOne` import |

Referenced conceptually in docs but not actually used by the file's source (which
works on the generic block-diagonal `M`, not the bare `Ĥ'` specifically).

## Build-speed evaluation

All 4 files in the (h) chain (PRs #3840–#3844):

| File | Lines | Isolated rebuild |
|---|---|---|
| `BlockDiagSubmatrixEmbed` (h.1) | 214 | 2.7 s |
| `InvolutionEigenspaceDecompEq` (h.2) | 95 | 2.3 s |
| `BlockSumFinrankEq` (h.3) | 121 | 4.5 s (cold) |
| `SubmatrixSimpleEigLeTwo` (h.4) | 121 | 4.8 s (cold) |

**No file exceeds the typical 800-line split threshold; no consolidations or splits
warranted.** All files are well-sized and isolated rebuilds are fast.

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
