### PR TITLE
(i.1) Parity-block submatrix Hermiticity -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -193,6 +193,7 @@ import LatticeSystem.Quantum.SpinS.BlockDiagSubmatrixEmbed
 import LatticeSystem.Quantum.SpinS.InvolutionEigenspaceDecompEq
 import LatticeSystem.Quantum.SpinS.BlockSumFinrankEq
 import LatticeSystem.Quantum.SpinS.SubmatrixSimpleEigLeTwo
+import LatticeSystem.Quantum.SpinS.ParityBlockSubmatrixHermitian
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
 import LatticeSystem.Quantum.SpinS.DressedFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.GaugeIntersectionEigenspaceFinrank

--- a/LatticeSystem/Quantum/SpinS/ParityBlockSubmatrixHermitian.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityBlockSubmatrixHermitian.lean
@@ -1,0 +1,51 @@
+import LatticeSystem.Quantum.SpinS.DressedAxisSwapHermitian
+import LatticeSystem.Quantum.SpinS.AxisSwappedAnisotropicHeisenberg
+import LatticeSystem.Quantum.SpinS.ParityConfig
+import Mathlib.LinearAlgebra.Matrix.Hermitian
+
+/-!
+# Parity-block submatrix Hermiticity
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(i.1): the parity-`p` submatrix of the bare and dressed axis-swapped Hamiltonians inherits
+Hermiticity from the full Hamiltonian via `Matrix.IsHermitian.submatrix`. This is the
+starting point for Hermitian spectral analysis of the per-sector matrix — needed to
+identify the per-sector PF eigenvalue as the spectrum minimum and ultimately to bridge
+the conditional `≤ 2` (g/h chains) to the unconditional ground-state degeneracy bound.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Hermiticity of the bare `Ĥ'` parity-`p` submatrix** for real couplings. -/
+theorem axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+    {J : Λ → Λ → ℂ} {lam D : ℂ}
+    (hJ : ∀ x y, (J x y).im = 0) (hlam : lam.im = 0) (hD : D.im = 0) (p : ℕ) :
+    ((axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D N).submatrix
+      (fun σ : parityConfigS Λ N p => σ.1)
+      (fun σ : parityConfigS Λ N p => σ.1)).IsHermitian := by
+  have hHerm := axisSwappedAnisotropicHeisenbergS_isHermitian_of_real (Λ := Λ) (N := N)
+    (J := J) (lam := lam) (D := D)
+    (fun x y => by rw [Complex.star_def, Complex.conj_eq_iff_im]; exact hJ x y)
+    (by rw [Complex.star_def, Complex.conj_eq_iff_im]; exact hlam)
+    (by rw [Complex.star_def, Complex.conj_eq_iff_im]; exact hD)
+  exact hHerm.submatrix (fun σ : parityConfigS Λ N p => σ.1)
+
+/-- **Hermiticity of the dressed `Ĥ'` parity-`p` submatrix** for real couplings. -/
+theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+    (A : Λ → Bool) {J : Λ → Λ → ℂ} {lam D : ℂ}
+    (hJ : ∀ x y, (J x y).im = 0) (hlam : lam.im = 0) (hD : D.im = 0) (p : ℕ) :
+    ((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N).submatrix
+      (fun σ : parityConfigS Λ N p => σ.1)
+      (fun σ : parityConfigS Λ N p => σ.1)).IsHermitian :=
+  (dressedAxisSwappedAnisotropicHeisenbergS_isHermitian_of_real (Λ := Λ) (N := N) A
+    hJ hlam hD).submatrix (fun σ : parityConfigS Λ N p => σ.1)
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (i.1) parity-block submatrix Hermiticity

The parity-`p` submatrix of the bare and dressed axis-swapped Hamiltonians inherits
Hermiticity from the full Hamiltonian via `Matrix.IsHermitian.submatrix`.

## Theorems

| # | Theorem | Role |
|---|---|---|
| 1 | `axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real` | Bare Ĥ' submatrix Hermitian |
| 2 | `dressedAxisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real` | Dressed Ĥ' submatrix Hermitian |

## Why this matters

Starting point for **Hermitian spectral analysis** of the per-sector matrix —
needed to identify the per-sector PF eigenvalue as the spectrum minimum and
ultimately bridge the conditional `≤ 2` (g/h chains) to the unconditional
ground-state degeneracy bound.

Combined with future Mathlib spectral facts (`Matrix.IsHermitian.eigenvalues`,
spectrum min characterization, etc.), this will give:
- ν_p (PF eigenvalue) = min spectrum of submatrix_p.
- For μ < ν_p, eig submatrix_p μ = 0.
- Combined with (h.3) sum equality: unconditional `≤ 2` at the GS.

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e)–(g.5) + docs | #3824–#3839 | merged |
| (h.1)-(h.4) + docs + refactor | #3840–#3845 | merged |
| **(i.1) submatrix Hermiticity** | **#3846** | this PR |
| (i.2) PF eigenvalue = spectrum min | TBD | next |

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
