### PR TITLE
(i.2) Submatrix eigenvalue realness (Hermitian) -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -194,6 +194,7 @@ import LatticeSystem.Quantum.SpinS.InvolutionEigenspaceDecompEq
 import LatticeSystem.Quantum.SpinS.BlockSumFinrankEq
 import LatticeSystem.Quantum.SpinS.SubmatrixSimpleEigLeTwo
 import LatticeSystem.Quantum.SpinS.ParityBlockSubmatrixHermitian
+import LatticeSystem.Quantum.SpinS.SubmatrixEigenvalueReal
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
 import LatticeSystem.Quantum.SpinS.DressedFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.GaugeIntersectionEigenspaceFinrank

--- a/LatticeSystem/Quantum/SpinS/SubmatrixEigenvalueReal.lean
+++ b/LatticeSystem/Quantum/SpinS/SubmatrixEigenvalueReal.lean
@@ -1,0 +1,71 @@
+import LatticeSystem.Quantum.SpinS.ParityBlockSubmatrixHermitian
+import LatticeSystem.Quantum.SpinS.Theorem23PFCasimirPredicted
+import Mathlib.LinearAlgebra.Eigenspace.Basic
+
+/-!
+# Submatrix eigenvalue realness (Hermitian)
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(i.2): the parity-`p` submatrix of the dressed/bare axis-swapped Hamiltonian (Hermitian
+under real couplings via #3846) has all eigenvalues real (`μ.im = 0`). Combines #3846
+with the existing `isHermitian_eigenvalue_star_eq` (which gives `star μ = μ`, equivalent
+to `μ.im = 0` via `Complex.conj_eq_iff_im`).
+
+This is the second step toward the unconditional ground-state degeneracy ≤ 2: the per-sector
+PF eigenvalue from (g.2) #3834 is one such Hermitian eigenvalue, and is automatically real.
+Combined with Hermitian spectral minimization, it gives min(ν_0, ν_1) as the GS energy.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Hermitian-submatrix eigenvalues are real** (generic): if `M` is Hermitian and has a
+non-trivial eigenspace at `μ`, then `μ.im = 0`. -/
+theorem hermitian_eigenvalue_im_zero
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian)
+    {μ : ℂ} (hμ : End.eigenspace (Matrix.toLin' M) μ ≠ ⊥) :
+    μ.im = 0 := by
+  -- Extract a non-zero eigenvector.
+  obtain ⟨v, hv_mem, hv_ne⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hμ
+  rw [End.mem_eigenspace_iff, Matrix.toLin'_apply] at hv_mem
+  -- Apply the existing isHermitian_eigenvalue_star_eq.
+  have hstar := isHermitian_eigenvalue_star_eq hM hv_mem hv_ne
+  -- star μ = μ ⟹ μ.im = 0.
+  rw [Complex.star_def, Complex.conj_eq_iff_im] at hstar
+  exact hstar
+
+/-- **Bare `Ĥ'` submatrix eigenvalue is real** for real couplings. -/
+theorem axisSwappedAnisotropicHeisenbergS_submatrix_eigenvalue_im_zero
+    {J : Λ → Λ → ℂ} {lam D : ℂ}
+    (hJ : ∀ x y, (J x y).im = 0) (hlam : lam.im = 0) (hD : D.im = 0) (p : ℕ)
+    {μ : ℂ}
+    (hμ : End.eigenspace (Matrix.toLin'
+      ((axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D N).submatrix
+        (fun σ : parityConfigS Λ N p => σ.1)
+        (fun σ : parityConfigS Λ N p => σ.1))) μ ≠ ⊥) :
+    μ.im = 0 :=
+  hermitian_eigenvalue_im_zero
+    (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real hJ hlam hD p) hμ
+
+/-- **Dressed `Ĥ'` submatrix eigenvalue is real** for real couplings. -/
+theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_eigenvalue_im_zero
+    (A : Λ → Bool) {J : Λ → Λ → ℂ} {lam D : ℂ}
+    (hJ : ∀ x y, (J x y).im = 0) (hlam : lam.im = 0) (hD : D.im = 0) (p : ℕ)
+    {μ : ℂ}
+    (hμ : End.eigenspace (Matrix.toLin'
+      ((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N).submatrix
+        (fun σ : parityConfigS Λ N p => σ.1)
+        (fun σ : parityConfigS Λ N p => σ.1))) μ ≠ ⊥) :
+    μ.im = 0 :=
+  hermitian_eigenvalue_im_zero
+    (dressedAxisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real A hJ hlam hD p) hμ
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (i.2) submatrix eigenvalue realness (Hermitian)

Parity-`p` submatrix of the bare/dressed axis-swapped Hamiltonian has all eigenvalues
real (`μ.im = 0`). Combines (i.1) #3846 (submatrix Hermiticity) with the existing
`isHermitian_eigenvalue_star_eq` lemma.

## Theorems

| # | Theorem | Role |
|---|---|---|
| 1 | `hermitian_eigenvalue_im_zero` | Generic: Hermitian eigenvalue ⟹ `μ.im = 0` |
| 2 | `axisSwappedAnisotropicHeisenbergS_submatrix_eigenvalue_im_zero` | Bare submatrix |
| 3 | `dressedAxisSwappedAnisotropicHeisenbergS_submatrix_eigenvalue_im_zero` | Dressed submatrix |

## Proof

For theorem 1: extract a non-zero eigenvector via `Submodule.exists_mem_ne_zero_of_ne_bot`,
apply `isHermitian_eigenvalue_star_eq` to get `star μ = μ`, then convert via
`Complex.conj_eq_iff_im` to `μ.im = 0`. Theorems 2/3 are direct specialisations of
theorem 1 using (i.1) #3846 for the submatrix Hermiticity.

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e)–(g.5) + docs | #3824–#3839 | merged |
| (h.1)-(h.4) + docs + refactor | #3840–#3845 | merged |
| (i.1) submatrix Hermiticity | #3846 | merged |
| **(i.2) submatrix eigenvalue realness** | **#3847** | this PR |
| (i.3) PF eigenvalue = spectrum min | TBD | next |

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
