### PR TITLE
(i.4) Hermitian eigenspace = ⊥ below the minimum eigenvalue -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -196,6 +196,7 @@ import LatticeSystem.Quantum.SpinS.SubmatrixSimpleEigLeTwo
 import LatticeSystem.Quantum.SpinS.ParityBlockSubmatrixHermitian
 import LatticeSystem.Quantum.SpinS.SubmatrixEigenvalueReal
 import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
+import LatticeSystem.Quantum.SpinS.HermitianEigenspaceBotBelowMin
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
 import LatticeSystem.Quantum.SpinS.DressedFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.GaugeIntersectionEigenspaceFinrank

--- a/LatticeSystem/Quantum/SpinS/HermitianEigenspaceBotBelowMin.lean
+++ b/LatticeSystem/Quantum/SpinS/HermitianEigenspaceBotBelowMin.lean
@@ -1,0 +1,49 @@
+import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
+import Mathlib.LinearAlgebra.Eigenspace.Matrix
+
+/-!
+# Hermitian eigenspace is `⊥` for any value strictly below the minimum eigenvalue
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(i.4): For a Hermitian matrix `M` on a finite-dim complex space, if `μ < hermitianMinEigenvalue M`,
+then the eigenspace at `(μ : ℂ)` is `⊥`.
+
+Combines (i.2) #3847 (realness of Hermitian eigenvalues) and (i.3) #3848 (min eigenvalue
+exists) with Mathlib's spectrum-eigenvalues bridge (`spectrum_real_eq_range_eigenvalues`,
+`hasEigenvalue_iff_mem_spectrum`).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+/-- **Hermitian eigenspace = `⊥` below the minimum eigenvalue** (generic, on `(μ : ℂ)`). -/
+theorem hermitian_eigenspace_eq_bot_of_real_lt_min
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian)
+    {μ : ℝ} (hμ : μ < hermitianMinEigenvalue hM) :
+    End.eigenspace (Matrix.toLin' M) (μ : ℂ) = ⊥ := by
+  by_contra h_ne
+  -- From eig ≠ ⊥: μ is an eigenvalue.
+  have h_eigen : End.HasEigenvalue (Matrix.toLin' M) (μ : ℂ) := h_ne
+  -- HasEigenvalue ↔ μ ∈ spectrum ℂ (toLin' M).
+  have h_spec : (μ : ℂ) ∈ spectrum ℂ (Matrix.toLin' M) :=
+    h_eigen.mem_spectrum
+  -- spectrum ℂ (toLin' M) = spectrum ℂ M.
+  rw [Matrix.spectrum_toLin'] at h_spec
+  -- (μ : ℂ) = RCLike.ofReal μ, hence in spectrum ℝ M (by algebraMap_mem_iff).
+  have h_real_spec : μ ∈ spectrum ℝ M := by
+    rw [← spectrum.algebraMap_mem_iff ℂ (R := ℝ)]
+    exact h_spec
+  -- spectrum ℝ M = range of hM.eigenvalues.
+  rw [hM.spectrum_real_eq_range_eigenvalues] at h_real_spec
+  obtain ⟨i, hi⟩ := h_real_spec
+  -- hM.eigenvalues i = μ, but min ≤ eigenvalues i, contradicting μ < min.
+  have hle : hermitianMinEigenvalue hM ≤ hM.eigenvalues i := hermitian_min_eigenvalue_le hM i
+  linarith
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (i.4) Hermitian eigenspace `= ⊥` below the minimum eigenvalue

For a Hermitian matrix `M` on a finite-dim complex space, if `μ < hermitianMinEigenvalue M`,
then the eigenspace at `(μ : ℂ)` is `⊥`.

Combines (i.2) #3847 + (i.3) #3848 with Mathlib's spectrum-eigenvalues bridge.

## Proof chain

1. Contrapositive: assume `eig ≠ ⊥`.
2. `HasEigenvalue.mem_spectrum` gives `(μ : ℂ) ∈ spectrum ℂ (toLin' M)`.
3. `Matrix.spectrum_toLin'` converts to `spectrum ℂ M`.
4. `spectrum.algebraMap_mem_iff` (with `ofReal` as `algebraMap ℝ → ℂ`) gives `μ ∈ spectrum ℝ M`.
5. `IsHermitian.spectrum_real_eq_range_eigenvalues` gives `μ ∈ range hM.eigenvalues`.
6. Extract index `i` with `hM.eigenvalues i = μ`.
7. `hermitian_min_eigenvalue_le` gives `hermitianMinEigenvalue ≤ μ`, contradicting `hμ` via `linarith`.

## Why this matters

Fourth step in the Hermitian spectral chain (i.X):
- (i.1) #3846: submatrix Hermiticity.
- (i.2) #3847: submatrix eigenvalue realness.
- (i.3) #3848: spectrum minimum exists.
- **(i.4) this PR**: no eigenvalues below the minimum.

Combined with (h.3) block-sum equality, gives the path to unconditional `≤ 2` at GS:
- For GS = `min(ν_0, ν_1)`, if e.g. `ν_0 < ν_1`, then `submatrix_1` has no eigenspace
  at GS by (i.4), so total `eigenspace finrank = submatrix_0 finrank ≤ 1`.
- If `ν_0 = ν_1 = GS`, both blocks contribute `≤ 1`, total `≤ 2`.

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e)–(g.5) + docs | #3824–#3839 | merged |
| (h.1)-(h.4) + docs + refactor | #3840–#3845 | merged |
| (i.1) submatrix Hermiticity | #3846 | merged |
| (i.2) submatrix eigenvalue realness | #3847 | merged |
| (i.3) submatrix min eigenvalue | #3848 | merged |
| **(i.4) no eigenvalues below min** | **#3849** | this PR |
| (i.5) GS identification + final assembly | TBD | next |

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
