### PR TITLE
Refactor: (i) chain checkpoint + (i.4) docstring expansion -- #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/HermitianEigenspaceBotBelowMin.lean
+++ b/LatticeSystem/Quantum/SpinS/HermitianEigenspaceBotBelowMin.lean
@@ -21,7 +21,13 @@ namespace LatticeSystem.Quantum
 
 open Matrix Module
 
-/-- **Hermitian eigenspace = `⊥` below the minimum eigenvalue** (generic, on `(μ : ℂ)`). -/
+/-- **Hermitian eigenspace = `⊥` below the minimum eigenvalue** (generic, on `(μ : ℂ)`).
+
+For a Hermitian matrix `M` on a finite-dim complex space, if `μ < hermitianMinEigenvalue M`,
+then the eigenspace at `(μ : ℂ)` is `⊥` (no eigenvectors below the spectrum minimum).
+
+Used by (i.5) (#3850) to bound the full block-diagonal eigenspace below the joint per-block
+minimum. -/
 theorem hermitian_eigenspace_eq_bot_of_real_lt_min
     {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
     {M : Matrix n n ℂ} (hM : M.IsHermitian)


### PR DESCRIPTION
Tracked in #3739.

## Refactor checkpoint: (i) chain + (i.4) docstring expansion

20-PR cadence refactor (41 PRs since previous refactor #3810).

## Change

| File | Action |
|---|---|
| `HermitianEigenspaceBotBelowMin.lean` | Expand docstring on `hermitian_eigenspace_eq_bot_of_real_lt_min` |

The docstring now explicitly explains:
- The lemma's mathematical content ("no eigenvectors below the spectrum minimum").
- Reference to (i.5) #3850 as the consumer.

## Build-speed evaluation

All 6 files in the (i) chain (PRs #3846–#3851):

| File | Lines | Isolated rebuild |
|---|---|---|
| `ParityBlockSubmatrixHermitian` (i.1) | 51 | 9.9 s (cold) |
| `SubmatrixEigenvalueReal` (i.2) | 71 | 3.2 s |
| `SubmatrixMinEigenvalue` (i.3) | 67 | 4.5 s |
| `HermitianEigenspaceBotBelowMin` (i.4) | 49 | 3.5 s |
| `BlockEigBotBelowJointMin` (i.5) | 92 | 3.8 s |
| `BlockMinLeTwo` (i.6) | 93 | 4.2 s |

**No file exceeds the typical 800-line split threshold; no consolidations or splits
warranted.** Files are well-sized and isolated rebuilds are fast.

## Import audit

Checked all (i) chain imports; no redundancies found that warrant action in this PR.

Observation (deferred): `SubmatrixEigenvalueReal` imports `Theorem23PFCasimirPredicted`
for the generic Hermitian eigenvalue realness lemma `isHermitian_eigenvalue_star_eq`.
The lemma is generic (not Casimir-specific), so it would benefit from being extracted
to a more foundational module in a separate refactor PR.

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
