### PR TITLE
(i.8) Bare anisotropic Ĥ eig ≤ 2 at min(per-block mins) via axis-swap -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -200,6 +200,7 @@ import LatticeSystem.Quantum.SpinS.HermitianEigenspaceBotBelowMin
 import LatticeSystem.Quantum.SpinS.BlockEigBotBelowJointMin
 import LatticeSystem.Quantum.SpinS.BlockMinLeTwo
 import LatticeSystem.Quantum.SpinS.BareAxisSwapMinLeTwo
+import LatticeSystem.Quantum.SpinS.BareAnisotropicMinLeTwo
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapDegeneracyBound
 import LatticeSystem.Quantum.SpinS.DressedFullEigInterParityLeOne
 import LatticeSystem.Quantum.SpinS.GaugeIntersectionEigenspaceFinrank

--- a/LatticeSystem/Quantum/SpinS/BareAnisotropicMinLeTwo.lean
+++ b/LatticeSystem/Quantum/SpinS/BareAnisotropicMinLeTwo.lean
@@ -1,0 +1,97 @@
+import LatticeSystem.Quantum.SpinS.BareAxisSwapMinLeTwo
+import LatticeSystem.Quantum.SpinS.AxisSwapDegeneracy
+import LatticeSystem.Quantum.SpinS.AxisSwapUnitarySpinHalf
+
+/-!
+# Bare anisotropic `Ĥ` eigenspace `finrank ℂ ≤ 2` at `min(per-block mins)`
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(i.8): wraps the bare `Ĥ'` `min(per-block mins) ≤ 2` (#3854) with the axis-swap unitary
+equivalence (`anisotropic_axisSwapped_eigenspace_finrank_eq`, #3753 family) to lift
+the bound to the bare anisotropic Hamiltonian `Ĥ`.
+
+- General `N` version requires an `AxisSwapUnitaryS N` instance.
+- Spin-1/2 (`N = 1`) instance via `axisSwapUnitarySpinHalf`.
+
+This is the analogue of (g.5) #3837 with the per-block-min hypotheses (which feed
+directly through the Hermitian spectral chain to give the unconditional bound at the
+GS, once the PF eigenvalue is identified with `hermitianMinEigenvalue`).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Bare anisotropic `Ĥ` eigenspace `≤ 2` at `min(per-block mins)`** via `AxisSwapUnitaryS N`. -/
+theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_at_min_block_mins
+    (G : AxisSwapUnitaryS N)
+    {J : Λ → Λ → ℂ} {lam D : ℂ}
+    (hJ : ∀ x y, (J x y).im = 0) (hlam : lam.im = 0) (hD : D.im = 0)
+    (hJself : ∀ x, J x x = 0)
+    [Nonempty (parityConfigS Λ N 0)] [Nonempty (parityConfigS Λ N 1)]
+    (h0 : finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+        ((axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D N).submatrix
+          (fun σ : parityConfigS Λ N 0 => σ.1)
+          (fun σ : parityConfigS Λ N 0 => σ.1)))
+          ((hermitianMinEigenvalue
+            (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+              (Λ := Λ) (N := N) hJ hlam hD 0) : ℂ))) ≤ 1)
+    (h1 : finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+        ((axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D N).submatrix
+          (fun σ : parityConfigS Λ N 1 => σ.1)
+          (fun σ : parityConfigS Λ N 1 => σ.1)))
+          ((hermitianMinEigenvalue
+            (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+              (Λ := Λ) (N := N) hJ hlam hD 1) : ℂ))) ≤ 1) :
+    finrank ℂ (End.eigenspace (Matrix.toLin'
+      (anisotropicHeisenbergS (Λ := Λ) J lam D N))
+      ((min
+          (hermitianMinEigenvalue
+            (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+              (Λ := Λ) (N := N) hJ hlam hD 0))
+          (hermitianMinEigenvalue
+            (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+              (Λ := Λ) (N := N) hJ hlam hD 1)) : ℝ) : ℂ)) ≤ 2 := by
+  rw [← G.anisotropic_axisSwapped_eigenspace_finrank_eq J lam D _]
+  exact axisSwappedAnisotropicHeisenbergS_eigenspace_finrank_le_two_at_min_block_mins
+    hJ hlam hD hJself h0 h1
+
+/-- **Spin-1/2 instance** of the bare anisotropic `Ĥ` `≤ 2` at `min(per-block mins)`. -/
+theorem spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_min_block_mins
+    {J : Λ → Λ → ℂ} {lam D : ℂ}
+    (hJ : ∀ x y, (J x y).im = 0) (hlam : lam.im = 0) (hD : D.im = 0)
+    (hJself : ∀ x, J x x = 0)
+    [Nonempty (parityConfigS Λ 1 0)] [Nonempty (parityConfigS Λ 1 1)]
+    (h0 : finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+        ((axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D 1).submatrix
+          (fun σ : parityConfigS Λ 1 0 => σ.1)
+          (fun σ : parityConfigS Λ 1 0 => σ.1)))
+          ((hermitianMinEigenvalue
+            (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+              (Λ := Λ) (N := 1) hJ hlam hD 0) : ℂ))) ≤ 1)
+    (h1 : finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+        ((axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D 1).submatrix
+          (fun σ : parityConfigS Λ 1 1 => σ.1)
+          (fun σ : parityConfigS Λ 1 1 => σ.1)))
+          ((hermitianMinEigenvalue
+            (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+              (Λ := Λ) (N := 1) hJ hlam hD 1) : ℂ))) ≤ 1) :
+    finrank ℂ (End.eigenspace (Matrix.toLin'
+      (anisotropicHeisenbergS (Λ := Λ) J lam D 1))
+      ((min
+          (hermitianMinEigenvalue
+            (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+              (Λ := Λ) (N := 1) hJ hlam hD 0))
+          (hermitianMinEigenvalue
+            (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+              (Λ := Λ) (N := 1) hJ hlam hD 1)) : ℝ) : ℂ)) ≤ 2 :=
+  anisotropicHeisenbergS_eigenspace_finrank_le_two_at_min_block_mins
+    axisSwapUnitarySpinHalf hJ hlam hD hJself h0 h1
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (i.8) bare anisotropic `Ĥ` eig `≤ 2` at `min(per-block mins)` via axis-swap

Wraps (i.7) #3854 with axis-swap unitary equivalence (#3753 family) to lift the
bound to the bare anisotropic Hamiltonian `Ĥ`.

## Theorems

| # | Theorem | Role |
|---|---|---|
| 1 | `anisotropicHeisenbergS_eigenspace_finrank_le_two_at_min_block_mins` | General `N` with `AxisSwapUnitaryS N` |
| 2 | `spinHalf_anisotropicHeisenbergS_..._at_min_block_mins` | `N = 1` instance via `axisSwapUnitarySpinHalf` |

## Why this matters

(i.X) chain analogue of (g.5) #3837 with per-block-min hypotheses threading the
Hermitian spectral chain. The remaining gap is PF eigenvalue identification with
`hermitianMinEigenvalue submatrix_p` — once that's done, the per-block-min hypotheses
discharge automatically, yielding the **unconditional ground-state degeneracy ≤ 2**
for bare anisotropic `Ĥ`.

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e)–(g.5) + docs | #3824–#3839 | merged |
| (h.1)-(h.4) + docs + refactor | #3840–#3845 | merged |
| (i.1)-(i.7) + docs + refactor | #3846–#3854 | merged |
| **(i.8) bare Ĥ axis-swap specialisation** | **#3855** | this PR |
| (i.9) PF eigenvalue = hermitianMinEigenvalue | TBD | next (final identification) |

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
