### PR TITLE
(j.3) hermitianMinEigenvalue ≤ μ from eigenvector existence (Hermitian) -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -197,6 +197,7 @@ import LatticeSystem.Quantum.SpinS.ParityBlockSubmatrixHermitian
 import LatticeSystem.Quantum.SpinS.SubmatrixEigenvalueReal
 import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
 import LatticeSystem.Quantum.SpinS.HermitianEigenspaceBotBelowMin
+import LatticeSystem.Quantum.SpinS.HermitianMinLeOfEigenvector
 import LatticeSystem.Quantum.SpinS.BlockEigBotBelowJointMin
 import LatticeSystem.Quantum.SpinS.BlockMinLeTwo
 import LatticeSystem.Quantum.SpinS.BareAxisSwapMinLeTwo

--- a/LatticeSystem/Quantum/SpinS/HermitianMinLeOfEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/HermitianMinLeOfEigenvector.lean
@@ -1,0 +1,41 @@
+import LatticeSystem.Quantum.SpinS.HermitianEigenspaceBotBelowMin
+
+/-!
+# Hermitian min eigenvalue `≤ μ` when an eigenvector at `μ` exists
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(j.3): for a Hermitian matrix `M` on a non-empty finite-dim complex space, if `w ≠ 0`
+satisfies `M w = (μ : ℂ) w` (for some `μ : ℝ`), then `hermitianMinEigenvalue M ≤ μ`.
+
+Proof via the contrapositive of (i.4) #3849: if `μ < hermitianMinEigenvalue M`, then
+the eigenspace at `(μ : ℂ)` is `⊥`, contradicting the existence of `w ≠ 0`.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+/-- **Hermitian min eigenvalue `≤ μ` from an eigenvector at `μ`**: contrapositive of (i.4)
+#3849. -/
+theorem hermitian_min_eigenvalue_le_of_eigenvector_exists
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian)
+    {μ : ℝ} {w : n → ℂ} (hw_ne : w ≠ 0)
+    (hw_eig : Matrix.mulVec M w = (μ : ℂ) • w) :
+    hermitianMinEigenvalue hM ≤ μ := by
+  by_contra hμ
+  push_neg at hμ
+  -- hμ : μ < hermitianMinEigenvalue hM
+  have h_bot := hermitian_eigenspace_eq_bot_of_real_lt_min hM hμ
+  -- w is in the eigenspace at (μ : ℂ).
+  have hw_mem : w ∈ End.eigenspace (Matrix.toLin' M) ((μ : ℂ)) := by
+    rw [End.mem_eigenspace_iff, Matrix.toLin'_apply]
+    exact hw_eig
+  rw [h_bot, Submodule.mem_bot] at hw_mem
+  exact hw_ne hw_mem
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (j.3) `hermitianMinEigenvalue ≤ μ` from eigenvector existence

For a Hermitian matrix `M` on a non-empty finite-dim complex space, if `w ≠ 0` satisfies
`M w = (μ : ℂ) w` (for some `μ : ℝ`), then `hermitianMinEigenvalue M ≤ μ`.

## Proof

Contrapositive of (i.4) #3849: if `μ < hermitianMinEigenvalue M`, then the eigenspace
at `(μ : ℂ)` is `⊥`, contradicting the existence of `w ≠ 0` in the eigenspace.

## Why this matters

Combined with (j.2) #3858, gives the **one direction** of the PF eigenvalue identification:
`hermitianMinEigenvalue submatrix_p_Herm ≤ ν_PF`.

The other direction (`ν_PF ≤ hermitianMinEigenvalue`, i.e., ν_PF IS the min) requires
the Collatz-Wielandt characterization "PF eigenvalue = max spectrum", which is deferred.

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e)–(g.5) + docs | #3824–#3839 | merged |
| (h.1)-(h.4) + docs + refactor | #3840–#3845 | merged |
| (i.1)-(i.8) + docs + refactor | #3846–#3856 | merged |
| (j.1) PF eigenvector existence (real) | #3857 | merged |
| (j.2) PF eigenvector lift to complex | #3858 | this PR's neighbour |
| **(j.3) min ≤ μ from eigenvector exists** | **#3859** | this PR |
| (j.4) Collatz-Wielandt: PF μ = max spectrum | TBD | next (closes identification) |

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
