### PR TITLE
(j.6) hermitianMinEigenvalue agrees under same ℝ-spectrum (Hermitian) -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -196,6 +196,7 @@ import LatticeSystem.Quantum.SpinS.SubmatrixSimpleEigLeTwo
 import LatticeSystem.Quantum.SpinS.ParityBlockSubmatrixHermitian
 import LatticeSystem.Quantum.SpinS.SubmatrixEigenvalueReal
 import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
+import LatticeSystem.Quantum.SpinS.HermitianMinSimilarInvariance
 import LatticeSystem.Quantum.SpinS.HermitianEigenspaceBotBelowMin
 import LatticeSystem.Quantum.SpinS.HermitianMinLeOfEigenvector
 import LatticeSystem.Quantum.SpinS.DressedSubmatrixPFAtMin

--- a/LatticeSystem/Quantum/SpinS/HermitianMinSimilarInvariance.lean
+++ b/LatticeSystem/Quantum/SpinS/HermitianMinSimilarInvariance.lean
@@ -1,0 +1,51 @@
+import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
+import Mathlib.Analysis.Matrix.Spectrum
+
+/-!
+# `hermitianMinEigenvalue` similarity invariance
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(j.6): for similar Hermitian matrices `M' = Uinv * M * U`, the `hermitianMinEigenvalue`
+is invariant. Proof: the `ℝ`-spectrum is the same (similarity), and
+`spectrum_real_eq_range_eigenvalues` identifies the spectrum with the range of the
+eigenvalue function. Thus the `Finset.image hM.eigenvalues Finset.univ` (as a set of real
+numbers) is the same, and so is its minimum.
+
+This enables transferring `hermitianMinEigenvalue` bounds (e.g., from (j.5) #3861) between
+the dressed and bare submatrices via the Marshall similarity.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+/-- **Hermitian eigenvalue ranges agree under same `ℝ`-spectrum**: if two Hermitian
+matrices have the same `ℝ`-spectrum, their `Finset.image eigenvalues Finset.univ` are equal
+as Finsets. -/
+private theorem hermitian_eigenvalues_image_eq_of_spectrum_eq
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    {M M' : Matrix n n ℂ} (hM : M.IsHermitian) (hM' : M'.IsHermitian)
+    (hspec : spectrum ℝ M = spectrum ℝ M') :
+    (Finset.univ : Finset n).image hM.eigenvalues =
+      (Finset.univ : Finset n).image hM'.eigenvalues := by
+  ext x
+  simp only [Finset.mem_image, Finset.mem_univ, true_and]
+  rw [← Set.mem_range, ← Set.mem_range,
+      ← hM.spectrum_real_eq_range_eigenvalues,
+      ← hM'.spectrum_real_eq_range_eigenvalues, hspec]
+
+/-- **`hermitianMinEigenvalue` agrees on Hermitian matrices with the same `ℝ`-spectrum**. -/
+theorem hermitianMinEigenvalue_eq_of_spectrum_eq
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    {M M' : Matrix n n ℂ} (hM : M.IsHermitian) (hM' : M'.IsHermitian)
+    (hspec : spectrum ℝ M = spectrum ℝ M') :
+    hermitianMinEigenvalue hM = hermitianMinEigenvalue hM' := by
+  unfold hermitianMinEigenvalue
+  congr 1
+  exact hermitian_eigenvalues_image_eq_of_spectrum_eq hM hM' hspec
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (j.6) `hermitianMinEigenvalue` agrees under same `ℝ`-spectrum (Hermitian)

For two Hermitian matrices with the same `ℝ`-spectrum, the `hermitianMinEigenvalue`
is the same. Proof via `spectrum_real_eq_range_eigenvalues`: the spectrum equals the
range of the eigenvalue function, so the `Finset.image`s are equal, hence `min'`.

## Theorems

| # | Theorem | Role |
|---|---|---|
| 1 | `hermitian_eigenvalues_image_eq_of_spectrum_eq` (private) | `Finset.image` equality from spectrum equality |
| 2 | `hermitianMinEigenvalue_eq_of_spectrum_eq` | Main: min agrees under same spectrum |

## Why this matters

Enables transferring `hermitianMinEigenvalue` bounds (e.g., from (j.5) #3861) between the
dressed and bare submatrices: similar matrices have the same spectrum, hence the same
`hermitianMinEigenvalue`.

Stops short of providing the actual similarity → spectrum equality bridge (which needs
charpoly + similarity invariance). The user/consumer provides spectrum equality as a
hypothesis.

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e)–(g.5) + docs | #3824–#3839 | merged |
| (h.1)-(h.4) + docs + refactor | #3840–#3845 | merged |
| (i.1)-(i.8) + docs + refactor | #3846–#3856 | merged |
| (j.1)-(j.5) + docs | #3857–#3862 | merged |
| **(j.6) hermitianMinEigenvalue spectrum invariance** | **#3863** | this PR |
| (j.7) Marshall similarity → bare/dressed submatrix spectrum equality | TBD | next |

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
