### PR TITLE
(j.7) Spectrum equality under matrix similarity -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -197,6 +197,7 @@ import LatticeSystem.Quantum.SpinS.ParityBlockSubmatrixHermitian
 import LatticeSystem.Quantum.SpinS.SubmatrixEigenvalueReal
 import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
 import LatticeSystem.Quantum.SpinS.HermitianMinSimilarInvariance
+import LatticeSystem.Quantum.SpinS.MatrixSimilaritySpectrum
 import LatticeSystem.Quantum.SpinS.HermitianEigenspaceBotBelowMin
 import LatticeSystem.Quantum.SpinS.HermitianMinLeOfEigenvector
 import LatticeSystem.Quantum.SpinS.DressedSubmatrixPFAtMin

--- a/LatticeSystem/Quantum/SpinS/MatrixSimilaritySpectrum.lean
+++ b/LatticeSystem/Quantum/SpinS/MatrixSimilaritySpectrum.lean
@@ -1,0 +1,72 @@
+import LatticeSystem.Quantum.SpinS.GaugeEigenspaceFinrank
+import Mathlib.LinearAlgebra.Eigenspace.Matrix
+
+/-!
+# Similarity preserves the matrix spectrum
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(j.7): for similar matrices `M' = Uinv * M * U` with `U * Uinv = 1`, `Uinv * U = 1`, the
+spectra `spectrum ℂ M = spectrum ℂ M'` agree. Proved via the existing
+`matrix_similar_eigenspace_finrank_eq` (#3746): the eigenspaces have equal finrank, so
+in particular both are `⊥` or both nontrivial at any `μ`, hence `HasEigenvalue` agrees,
+hence spectrum agrees.
+
+The real-spectrum version follows by `spectrum.algebraMap_mem_iff`.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Spectrum equality under matrix similarity** (`ℂ`): if `M' = Uinv * M * U` with
+`U * Uinv = 1`, `Uinv * U = 1`, then `spectrum ℂ M = spectrum ℂ M'`. -/
+theorem matrix_similar_spectrum_complex_eq
+    {U Uinv M M' : Matrix n n ℂ} (hUU : U * Uinv = 1) (hUinvU : Uinv * U = 1)
+    (hsim : M' = Uinv * M * U) :
+    spectrum ℂ M = spectrum ℂ M' := by
+  ext μ
+  -- Bridge spectrum ↔ HasEigenvalue via Matrix.spectrum_toLin' + hasEigenvalue_iff_mem_spectrum.
+  rw [← Matrix.spectrum_toLin', ← Matrix.spectrum_toLin',
+    ← Module.End.hasEigenvalue_iff_mem_spectrum,
+    ← Module.End.hasEigenvalue_iff_mem_spectrum]
+  -- HasEigenvalue ↔ eigenspace ≠ ⊥; finrank equality (#3746) gives the bridge.
+  have hfinrank : finrank ℂ (End.eigenspace (Matrix.toLin' M) μ) =
+      finrank ℂ (End.eigenspace (Matrix.toLin' M') μ) :=
+    (matrix_similar_eigenspace_finrank_eq hUU hUinvU hsim μ).symm
+  -- Convert hfinrank's eigenspace to the genEigenspace form (1).
+  -- End.eigenspace is definitionally End.genEigenspace _ 1.
+  change End.eigenspace (Matrix.toLin' M) μ ≠ ⊥ ↔
+         End.eigenspace (Matrix.toLin' M') μ ≠ ⊥
+  constructor
+  · intro hM h_M'_eq_bot
+    apply hM
+    have h_M'_fr_zero : finrank ℂ (End.eigenspace (Matrix.toLin' M') μ) = 0 := by
+      rw [h_M'_eq_bot]; exact finrank_bot _ _
+    have h_M_fr_zero : finrank ℂ (End.eigenspace (Matrix.toLin' M) μ) = 0 := by
+      rw [hfinrank]; exact h_M'_fr_zero
+    exact Submodule.finrank_eq_zero.mp h_M_fr_zero
+  · intro hM' h_M_eq_bot
+    apply hM'
+    have h_M_fr_zero : finrank ℂ (End.eigenspace (Matrix.toLin' M) μ) = 0 := by
+      rw [h_M_eq_bot]; exact finrank_bot _ _
+    have h_M'_fr_zero : finrank ℂ (End.eigenspace (Matrix.toLin' M') μ) = 0 := by
+      rw [← hfinrank]; exact h_M_fr_zero
+    exact Submodule.finrank_eq_zero.mp h_M'_fr_zero
+
+/-- **Spectrum equality under matrix similarity** (`ℝ`): for real spectra of complex
+matrices, similarity preserves `spectrum ℝ`. -/
+theorem matrix_similar_spectrum_real_eq
+    {U Uinv M M' : Matrix n n ℂ} (hUU : U * Uinv = 1) (hUinvU : Uinv * U = 1)
+    (hsim : M' = Uinv * M * U) :
+    spectrum ℝ M = spectrum ℝ M' := by
+  ext μ
+  rw [← spectrum.algebraMap_mem_iff ℂ (R := ℝ), ← spectrum.algebraMap_mem_iff ℂ (R := ℝ),
+    matrix_similar_spectrum_complex_eq hUU hUinvU hsim]
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (j.7) spectrum equality under matrix similarity

For similar matrices `M' = Uinv * M * U` with `U * Uinv = 1`, `Uinv * U = 1`,
`spectrum ℂ M = spectrum ℂ M'` (and `spectrum ℝ` ditto via `algebraMap_mem_iff`).

## Theorems

| # | Theorem | Role |
|---|---|---|
| 1 | `matrix_similar_spectrum_complex_eq` | Complex spectrum invariance |
| 2 | `matrix_similar_spectrum_real_eq` | Real spectrum invariance (via algebraMap bridge) |

## Proof

Bridge `spectrum ↔ HasEigenvalue` via `Matrix.spectrum_toLin'` +
`Module.End.hasEigenvalue_iff_mem_spectrum`. Eigenspace nontrivial iff finrank > 0;
the finrank equality from #3746 (`matrix_similar_eigenspace_finrank_eq`) preserves
this.

## Why this matters

Combined with (j.6) #3863 (`hermitianMinEigenvalue` agrees under same spectrum),
this gives `hermitianMinEigenvalue M = hermitianMinEigenvalue M'` for similar
Hermitian matrices. Specialised to the Marshall similarity (Θ_A diagonal), this
transfers `hermitianMinEigenvalue` between bare and dressed submatrices — unlocking
the bare side of the per-block min identification chain.

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e)–(g.5) + docs | #3824–#3839 | merged |
| (h.1)-(h.4) + docs + refactor | #3840–#3845 | merged |
| (i.1)-(i.8) + docs + refactor | #3846–#3856 | merged |
| (j.1)-(j.6) + docs | #3857–#3863 | merged |
| **(j.7) spectrum equality under similarity** | **#3864** | this PR |
| (j.8) Marshall similarity → bare submatrix hermitianMinEigenvalue identification | TBD | next |

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
