### PR TITLE
(j.9) Bare submatrix hermitianMinEigenvalue ≤ ν_PF via Marshall transfer -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -199,6 +199,7 @@ import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
 import LatticeSystem.Quantum.SpinS.HermitianMinSimilarInvariance
 import LatticeSystem.Quantum.SpinS.MatrixSimilaritySpectrum
 import LatticeSystem.Quantum.SpinS.MarshallSubmatrixMinEq
+import LatticeSystem.Quantum.SpinS.BareSubmatrixMinLePF
 import LatticeSystem.Quantum.SpinS.HermitianEigenspaceBotBelowMin
 import LatticeSystem.Quantum.SpinS.HermitianMinLeOfEigenvector
 import LatticeSystem.Quantum.SpinS.DressedSubmatrixPFAtMin

--- a/LatticeSystem/Quantum/SpinS/BareSubmatrixMinLePF.lean
+++ b/LatticeSystem/Quantum/SpinS/BareSubmatrixMinLePF.lean
@@ -1,0 +1,62 @@
+import LatticeSystem.Quantum.SpinS.MarshallSubmatrixMinEq
+import LatticeSystem.Quantum.SpinS.DressedSubmatrixPFAtMin
+
+/-!
+# Bare submatrix `hermitianMinEigenvalue ≤ ν_PF` via Marshall transfer
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
+
+(j.9): combines (j.4) #3860 (dressed: `hermitianMinEigenvalue dressed.submatrix ≤ ν_PF`)
+with (j.8) #3865 (`hermitianMinEigenvalue bare.submatrix = hermitianMinEigenvalue
+dressed.submatrix` via Marshall similarity) to give the bare-side bound:
+
+```
+hermitianMinEigenvalue bare.submatrix ≤ ν_PF (the PF eigenvalue).
+```
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Bare submatrix `hermitianMinEigenvalue ≤ PF ν`** via the Marshall similarity transfer
+from the dressed side (j.4) #3860 + (j.8) #3865. -/
+theorem axisSwappedAnisotropicHeisenbergS_submatrix_min_le_pf_eigenvalue
+    (A : Λ → Bool) {J : Λ → Λ → ℂ}
+    (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
+    (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
+    (hJself : ∀ x, J x x = 0) (hJbip : ∀ x y, J x y ≠ 0 → A x ≠ A y)
+    {lam : ℂ} (hlam : lam.im = 0) (hlb : -1 < lam.re) (hub : lam.re < 1)
+    {D : ℂ} (hDim : D.im = 0) (hDpos : 0 < D.re)
+    {c : ℝ}
+    (hc_strict : ∀ σ : Λ → Fin (N + 1),
+      dressedAxisSwappedAnisotropicHeisenbergSReMatrix A J lam D N σ σ < c)
+    (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false)
+    (h_intermediate : ∀ τ : Λ → Fin (N + 1), ∀ x : Λ,
+      ∃ z, A z ≠ A x ∧ (τ z).val < N)
+    (p : ℕ)
+    [Nonempty (parityConfigS Λ N p)] :
+    ∃ ν : ℝ,
+      hermitianMinEigenvalue
+        (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+          (Λ := Λ) (N := N) hJim hlam hDim p) ≤ ν ∧
+      ∃ w : parityConfigS Λ N p → ℂ, w ≠ 0 ∧
+        Matrix.mulVec
+          ((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N).submatrix
+            (fun σ : parityConfigS Λ N p => σ.1)
+            (fun σ : parityConfigS Λ N p => σ.1)) w = (ν : ℂ) • w := by
+  obtain ⟨ν, hν_min_le, hν_witness⟩ :=
+    dressedAxisSwappedAnisotropicHeisenbergS_submatrix_min_le_pf_eigenvalue
+      A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
+      hA_ne hB_ne h_intermediate p
+  refine ⟨ν, ?_, hν_witness⟩
+  -- Bridge: bare min = dressed min via (j.8); then bare min ≤ ν follows.
+  rw [bare_dressed_submatrix_hermitianMinEigenvalue_eq A hJim hlam hDim p]
+  exact hν_min_le
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739.

## (j.9) bare submatrix `hermitianMinEigenvalue ≤ ν_PF` via Marshall transfer

Combines (j.4) #3860 (dressed: `hermitianMinEigenvalue dressed.submatrix ≤ ν_PF`)
with (j.8) #3865 (`hermitianMinEigenvalue bare.submatrix = hermitianMinEigenvalue
dressed.submatrix` via Marshall similarity) to give the bare-side bound:

```
∃ ν : ℝ, hermitianMinEigenvalue bare.submatrix ≤ ν ∧
  ∃ w ≠ 0, dressed.submatrix *ᵥ w = (ν : ℂ) • w
```

## Why this matters

Bare analogue of (j.4) #3860. Combined with PF = min identification (still deferred —
Collatz-Wielandt's "PF eigenvalue = max spectrum"), would discharge (i.7) #3854's
per-block bare hypotheses for the unconditional `≤ 2` bound.

## Pipeline status

| Stage | PR | Status |
|---|---|---|
| (e)–(g.5) + docs | #3824–#3839 | merged |
| (h.1)-(h.4) + docs + refactor | #3840–#3845 | merged |
| (i.1)-(i.8) + docs + refactor | #3846–#3856 | merged |
| (j.1)-(j.8) + docs | #3857–#3865 | merged |
| **(j.9) bare min ≤ ν_PF via Marshall** | **#3866** | this PR |
| (j.10) Collatz-Wielandt: ν_PF ≤ min (closes identification) | TBD | next |

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43–44.
