### PR TITLE
(j.13.a) Rayleigh quotient at eigenvector = μ -- #3871

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -4,6 +4,7 @@ import LatticeSystem.Math.PerronFrobeniusMain
 import LatticeSystem.Math.PerronFrobeniusSimple
 import LatticeSystem.Math.PerronFrobeniusFinrank
 import LatticeSystem.Math.PerronFrobenius
+import LatticeSystem.Math.RayleighAtEigenvector
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale
 import LatticeSystem.Quantum.Pauli

--- a/LatticeSystem/Math/RayleighAtEigenvector.lean
+++ b/LatticeSystem/Math/RayleighAtEigenvector.lean
@@ -1,0 +1,51 @@
+import Mathlib.Analysis.Matrix.Spectrum
+import Mathlib.LinearAlgebra.Matrix.DotProduct
+
+/-!
+# Rayleigh quotient at an eigenvector
+
+Issue #3871 (Tasaki §2.5 Theorem 2.4 PF identification chain).
+
+(j.13.a): For a real matrix `M` and a real eigenvector `v` of `M` at eigenvalue `μ`
+with `v ≠ 0`, the Rayleigh quotient `⟨v, Mv⟩ / ⟨v, v⟩` equals `μ`.
+
+This is the most elementary step in the Collatz-Wielandt chain identifying the
+Perron-Frobenius eigenvalue with the maximum Hermitian eigenvalue.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
+§2.5 Theorem 2.4, p. 43-44.
+-/
+
+namespace LatticeSystem.Math
+
+open Matrix Finset
+
+variable {n : Type*} [Fintype n]
+
+/-- **Rayleigh quotient at an eigenvector equals the eigenvalue**.
+
+For a real matrix `M` with a nonzero eigenvector `v` at eigenvalue `μ`:
+`(∑ i, v i * (M *ᵥ v) i) / (∑ i, v i * v i) = μ`.
+
+Proof: substitute `M *ᵥ v = μ • v`, then the numerator becomes `μ * ‖v‖²` and
+the quotient evaluates to `μ`. -/
+theorem rayleigh_quotient_at_eigenvector
+    {M : Matrix n n ℝ} {μ : ℝ} {v : n → ℝ}
+    (hv : M.mulVec v = μ • v) (hv_ne : v ≠ 0) :
+    (∑ i, v i * (M.mulVec v) i) / (∑ i, v i * v i) = μ := by
+  have h_denom_pos : 0 < ∑ i, v i * v i := by
+    have h_nn : ∀ i ∈ univ, 0 ≤ v i * v i := fun i _ => mul_self_nonneg _
+    obtain ⟨i, hi⟩ := Function.ne_iff.mp hv_ne
+    exact sum_pos' h_nn ⟨i, mem_univ i, mul_self_pos.mpr hi⟩
+  have h_denom_ne : (∑ i, v i * v i) ≠ 0 := ne_of_gt h_denom_pos
+  have h_num : (∑ i, v i * (M.mulVec v) i) = μ * (∑ i, v i * v i) := by
+    have : ∀ i, v i * (M.mulVec v) i = μ * (v i * v i) := fun i => by
+      have := congrFun hv i
+      simp [Pi.smul_apply, smul_eq_mul] at this
+      rw [this]; ring
+    rw [show (∑ i, v i * (M.mulVec v) i) = ∑ i, μ * (v i * v i) from
+      Finset.sum_congr rfl (fun i _ => this i)]
+    rw [← Finset.mul_sum]
+  rw [h_num, mul_div_assoc, div_self h_denom_ne, mul_one]
+
+end LatticeSystem.Math


### PR DESCRIPTION
Tracked in #3871 (parent: #3739).

## (j.13.a) Rayleigh quotient at eigenvector = μ

For a real matrix `M` with a nonzero eigenvector `v` at eigenvalue `μ`:

```
(∑ i, v i * (M *ᵥ v) i) / (∑ i, v i * v i) = μ
```

**First step in the (j.13) chain** identifying PF eigenvalue with max Hermitian
eigenvalue. Closing this chain discharges the deferred `ν_PF = hermitianMinEigenvalue`
hypothesis in (j.11) #3869 / (j.12) #3870 capstone for Tasaki §2.5 Theorem 2.4.

## Reference

Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, §2.5 Theorem 2.4.
