### PR TITLE
(j.13.c) Hermitian eigenspace = bot above max eigenvalue -- #3871

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -6,6 +6,7 @@ import LatticeSystem.Math.PerronFrobeniusFinrank
 import LatticeSystem.Math.PerronFrobenius
 import LatticeSystem.Math.RayleighAtEigenvector
 import LatticeSystem.Math.HermitianMaxEigenvalue
+import LatticeSystem.Math.HermitianEigenspaceBotAboveMax
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale
 import LatticeSystem.Quantum.Pauli

--- a/LatticeSystem/Math/HermitianEigenspaceBotAboveMax.lean
+++ b/LatticeSystem/Math/HermitianEigenspaceBotAboveMax.lean
@@ -1,0 +1,50 @@
+import LatticeSystem.Math.HermitianMaxEigenvalue
+import Mathlib.LinearAlgebra.Eigenspace.Matrix
+
+/-!
+# Hermitian eigenspace is `⊥` for any value strictly above the maximum eigenvalue
+
+Issue #3871 (Tasaki §2.5 Theorem 2.4 PF identification chain).
+
+(j.13.c): For a Hermitian matrix `M` on a non-empty finite-dim complex space, if
+`hermitianMaxEigenvalue M < μ`, then the eigenspace at `(μ : ℂ)` is `⊥`.
+
+Mirror of `LatticeSystem.Quantum.hermitian_eigenspace_eq_bot_of_real_lt_min`
+((i.4) #3849, `LatticeSystem/Quantum/SpinS/HermitianEigenspaceBotBelowMin.lean`) on
+the maximum side, needed by (j.13.d) for `hermitianMaxEigenvalue ≥ μ` from
+eigenvector existence.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43-44.
+-/
+
+namespace LatticeSystem.Math
+
+open Matrix Module
+
+/-- **Hermitian eigenspace = `⊥` above the maximum eigenvalue** (generic, on `(μ : ℂ)`).
+
+For a Hermitian matrix `M` on a non-empty finite-dim complex space, if
+`hermitianMaxEigenvalue M < μ`, then the eigenspace at `(μ : ℂ)` is `⊥` (no
+eigenvectors above the spectrum maximum).
+
+Mirror of (i.4) `hermitian_eigenspace_eq_bot_of_real_lt_min` (#3849). -/
+theorem hermitian_eigenspace_eq_bot_of_real_gt_max
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian)
+    {μ : ℝ} (hμ : hermitianMaxEigenvalue hM < μ) :
+    End.eigenspace (Matrix.toLin' M) (μ : ℂ) = ⊥ := by
+  by_contra h_ne
+  have h_eigen : End.HasEigenvalue (Matrix.toLin' M) (μ : ℂ) := h_ne
+  have h_spec : (μ : ℂ) ∈ spectrum ℂ (Matrix.toLin' M) :=
+    h_eigen.mem_spectrum
+  rw [Matrix.spectrum_toLin'] at h_spec
+  have h_real_spec : μ ∈ spectrum ℝ M := by
+    rw [← spectrum.algebraMap_mem_iff ℂ (R := ℝ)]
+    exact h_spec
+  rw [hM.spectrum_real_eq_range_eigenvalues] at h_real_spec
+  obtain ⟨i, hi⟩ := h_real_spec
+  have hle : hM.eigenvalues i ≤ hermitianMaxEigenvalue hM := hermitian_eigenvalue_le_max hM i
+  linarith
+
+end LatticeSystem.Math


### PR DESCRIPTION
Tracked in #3871 (parent: #3739).

## (j.13.c) Hermitian eigenspace = ⊥ above max eigenvalue

Mirror of `hermitian_eigenspace_eq_bot_of_real_lt_min` ((i.4) #3849,
`LatticeSystem/Quantum/SpinS/HermitianEigenspaceBotBelowMin.lean`) on the max side.

For a Hermitian matrix `M` on a non-empty finite-dim complex space, if
`hermitianMaxEigenvalue M < μ`, then `End.eigenspace (toLin' M) (μ : ℂ) = ⊥`.

Proof: contrapositive of (j.13.b). If μ has an eigenvector, then μ ∈ spectrum ℝ M
= range of `hM.eigenvalues`, so `eigenvalues i = μ` for some i, contradicting
`eigenvalues i ≤ hermitianMaxEigenvalue M < μ`.

## Role in (j.13) chain

Used by (j.13.d) (mirror of (j.3) #3859) to derive `hermitianMaxEigenvalue M ≥ μ`
from the existence of a nonzero eigenvector at μ. Substep design simplified from
original full-Rayleigh approach to (i.4)/(j.3) mirror — see memory
`project_tasaki_2_4_j13_design`.

Placed in namespace `LatticeSystem.Math` (consistent with (j.13.a)/(j.13.b)).
Wired into `LatticeSystem.lean`.

## Reference

H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43-44.
