### PR TITLE
(j.13.d) hermitianMaxEigenvalue ≥ μ from eigenvector existence -- #3871

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -7,6 +7,7 @@ import LatticeSystem.Math.PerronFrobenius
 import LatticeSystem.Math.RayleighAtEigenvector
 import LatticeSystem.Math.HermitianMaxEigenvalue
 import LatticeSystem.Math.HermitianEigenspaceBotAboveMax
+import LatticeSystem.Math.HermitianMaxGeOfEigenvector
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale
 import LatticeSystem.Quantum.Pauli

--- a/LatticeSystem/Math/HermitianMaxGeOfEigenvector.lean
+++ b/LatticeSystem/Math/HermitianMaxGeOfEigenvector.lean
@@ -1,0 +1,47 @@
+import LatticeSystem.Math.HermitianEigenspaceBotAboveMax
+
+/-!
+# Hermitian max eigenvalue `≥ μ` when an eigenvector at `μ` exists
+
+Issue #3871 (Tasaki §2.5 Theorem 2.4 PF identification chain).
+
+(j.13.d): For a Hermitian matrix `M` on a non-empty finite-dim complex space, if
+`w ≠ 0` satisfies `M w = (μ : ℂ) w` (for some `μ : ℝ`), then
+`μ ≤ hermitianMaxEigenvalue M`.
+
+Proof via the contrapositive of (j.13.c) (`hermitian_eigenspace_eq_bot_of_real_gt_max`):
+if `hermitianMaxEigenvalue M < μ`, then the eigenspace at `(μ : ℂ)` is `⊥`,
+contradicting the existence of `w ≠ 0`.
+
+Mirror of `LatticeSystem.Quantum.hermitian_min_eigenvalue_le_of_eigenvector_exists`
+((j.3) #3859, `LatticeSystem/Quantum/SpinS/HermitianMinLeOfEigenvector.lean`) on
+the maximum side.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43-44.
+-/
+
+namespace LatticeSystem.Math
+
+open Matrix Module
+
+/-- **Hermitian max eigenvalue `≥ μ` from an eigenvector at `μ`**: contrapositive of
+(j.13.c). -/
+theorem hermitian_max_eigenvalue_ge_of_eigenvector_exists
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian)
+    {μ : ℝ} {w : n → ℂ} (hw_ne : w ≠ 0)
+    (hw_eig : Matrix.mulVec M w = (μ : ℂ) • w) :
+    μ ≤ hermitianMaxEigenvalue hM := by
+  by_contra hμ
+  push Not at hμ
+  -- hμ : hermitianMaxEigenvalue hM < μ
+  have h_bot := hermitian_eigenspace_eq_bot_of_real_gt_max hM hμ
+  -- w is in the eigenspace at (μ : ℂ).
+  have hw_mem : w ∈ End.eigenspace (Matrix.toLin' M) ((μ : ℂ)) := by
+    rw [End.mem_eigenspace_iff, Matrix.toLin'_apply]
+    exact hw_eig
+  rw [h_bot, Submodule.mem_bot] at hw_mem
+  exact hw_ne hw_mem
+
+end LatticeSystem.Math


### PR DESCRIPTION
Tracked in #3871 (parent: #3739).

## (j.13.d) `hermitianMaxEigenvalue ≥ μ` from eigenvector existence

Mirror of `LatticeSystem.Quantum.hermitian_min_eigenvalue_le_of_eigenvector_exists`
((j.3) #3859, `LatticeSystem/Quantum/SpinS/HermitianMinLeOfEigenvector.lean`) on
the maximum side.

For a Hermitian matrix `M` on a non-empty finite-dim complex space, if `w ≠ 0`
satisfies `M w = (μ : ℂ) w` (for some `μ : ℝ`), then `μ ≤ hermitianMaxEigenvalue M`.

Proof: contrapositive of (j.13.c) `hermitian_eigenspace_eq_bot_of_real_gt_max`.

Uses new `push Not` syntax (replacing deprecated `push_neg`) — keeps the project
linter clean as the mathlib deprecation lands.

## Role in (j.13) chain

This is the key "downward" half: any eigenvalue of `M` lies `≤ hermitianMaxEigenvalue M`.
Combined with the upcoming (j.13.e) (Collatz-Wielandt upper bound:
`hermitianMaxEigenvalue B ≤ μ_PF` for nonneg irreducible `B`), this will give
`hermitianMaxEigenvalue B = μ_PF` (j.13.f), then via spectrum shift (j.13.g)
identify `hermitianMinEigenvalue dressed_re = c − μ_PF = ν_PF`, discharging the
(j.11)/(j.12) capstone hypothesis (j.13.h).

Placed in namespace `LatticeSystem.Math` (consistent with (j.13.a)-(j.13.c)).
Wired into `LatticeSystem.lean`.

## Reference

H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43-44.
