### PR TITLE
(j.13.e.2-4) Collatz-Wielandt lower bound at abs eigenvector -- #3871

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -9,6 +9,7 @@ import LatticeSystem.Math.HermitianMaxEigenvalue
 import LatticeSystem.Math.HermitianEigenspaceBotAboveMax
 import LatticeSystem.Math.HermitianMaxGeOfEigenvector
 import LatticeSystem.Math.CollatzWielandtUpperBoundSymmetric
+import LatticeSystem.Math.CollatzWielandtLowerBoundEigenvec
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale
 import LatticeSystem.Quantum.Pauli

--- a/LatticeSystem/Math/CollatzWielandt.lean
+++ b/LatticeSystem/Math/CollatzWielandt.lean
@@ -168,6 +168,20 @@ lemma lt_of_all_ratios_gt [Nonempty n] {A : Matrix n n ℝ} {x : n → ℝ} {c :
   rw [dif_pos h_supp, Finset.lt_inf'_iff h_supp]
   exact fun i hi => h i
 
+/-- **CW lower bound from support-ratio bound**: if `c ≤ (Ax)_i / x_i` for every `i` with
+`x_i > 0`, and at least one `x_j > 0`, then `c ≤ CW(x)`.
+
+Used by (j.13.e) to bound `|λ| ≤ CW(|w|)` for eigenvectors `w` (Issue #3871). -/
+lemma le_collatzWielandtFn_of_all_supp_ratios_le
+    {A : Matrix n n ℝ} {x : n → ℝ} {c : ℝ}
+    (hx : ∃ j, 0 < x j) (h : ∀ i, 0 < x i → c ≤ (A *ᵥ x) i / x i) :
+    c ≤ collatzWielandtFn A x := by
+  unfold collatzWielandtFn
+  obtain ⟨j, hj⟩ := hx
+  have h_supp : (supp x).Nonempty := ⟨j, mem_supp.mpr hj⟩
+  rw [dif_pos h_supp, Finset.le_inf'_iff]
+  exact fun i hi => h i (mem_supp.mp hi)
+
 /-! ## Upper-semicontinuity -/
 
 /-- The CW function is upper-semicontinuous on the standard simplex.

--- a/LatticeSystem/Math/CollatzWielandtLowerBoundEigenvec.lean
+++ b/LatticeSystem/Math/CollatzWielandtLowerBoundEigenvec.lean
@@ -1,0 +1,77 @@
+import LatticeSystem.Math.CollatzWielandt
+
+/-!
+# Collatz-Wielandt lower bound at the abs of an eigenvector
+
+Issue #3871 (Tasaki §2.5 Theorem 2.4 PF identification chain).
+
+(j.13.e.2-4): For a nonneg matrix `A : Matrix n n ℝ` and a real eigenvector `w`
+at eigenvalue `λ` (i.e., `A *ᵥ w = λ • w`) with `w ≠ 0`,
+`|λ| ≤ collatzWielandtFn A (fun j => |w j|)`.
+
+Built from three layered lemmas:
+- (e.2) `abs_mulVec_le_mulVec_abs`: triangle inequality `|A *ᵥ w|_i ≤ (A *ᵥ |w|)_i`.
+- (e.3) `abs_eigenvalue_mul_abs_le_mulVec_abs`: at an eigenvector, `|λ| * |w_i| ≤ (A *ᵥ |w|)_i`.
+- (e.4) `abs_eigenvalue_le_collatzWielandtFn_abs`: CW inf ≥ |λ| over the support of |w|.
+
+Used in (j.13.e) for `hermitianMaxEigenvalue B ≤ μ_PF` for nonneg symmetric
+irreducible `B`.
+
+Reference: E. Seneta, *Non-negative Matrices and Markov Chains* (3rd ed.),
+Springer 2006, §1.2.
+-/
+
+namespace LatticeSystem.Math.CollatzWielandt
+
+open Matrix Finset
+
+variable {n : Type*} [Fintype n]
+
+/-- **(j.13.e.2) Triangle inequality for matrix-vector product** (nonneg matrix):
+for nonneg `A` and real `w`, `|A *ᵥ w|_i ≤ (A *ᵥ |w|)_i`. -/
+theorem abs_mulVec_le_mulVec_abs
+    {A : Matrix n n ℝ} (hA : ∀ i j, 0 ≤ A i j) (w : n → ℝ) (i : n) :
+    |A.mulVec w i| ≤ A.mulVec (fun j => |w j|) i := by
+  simp only [Matrix.mulVec, dotProduct]
+  calc |∑ j, A i j * w j|
+      ≤ ∑ j, |A i j * w j| := Finset.abs_sum_le_sum_abs _ _
+    _ = ∑ j, A i j * |w j| := by
+        apply Finset.sum_congr rfl
+        intros j _
+        rw [abs_mul, abs_of_nonneg (hA i j)]
+
+/-- **(j.13.e.3) At an eigenvector, `|λ| * |w_i| ≤ (A *ᵥ |w|)_i`** (nonneg matrix). -/
+theorem abs_eigenvalue_mul_abs_le_mulVec_abs
+    {A : Matrix n n ℝ} (hA : ∀ i j, 0 ≤ A i j)
+    {lam : ℝ} {w : n → ℝ} (h_eig : A.mulVec w = lam • w) (i : n) :
+    |lam| * |w i| ≤ A.mulVec (fun j => |w j|) i := by
+  have h1 : |A.mulVec w i| = |lam| * |w i| := by
+    rw [h_eig]; simp [abs_mul]
+  rw [← h1]
+  exact abs_mulVec_le_mulVec_abs hA w i
+
+/-- **(j.13.e.4) CW lower bound at the abs of an eigenvector**.
+
+For a nonneg matrix `A` and real eigenvector `w ≠ 0` at eigenvalue `λ`,
+`|λ| ≤ collatzWielandtFn A (fun j => |w j|)`. -/
+theorem abs_eigenvalue_le_collatzWielandtFn_abs
+    {A : Matrix n n ℝ} (hA : ∀ i j, 0 ≤ A i j)
+    {lam : ℝ} {w : n → ℝ} (hw_ne : w ≠ 0)
+    (h_eig : A.mulVec w = lam • w) :
+    |lam| ≤ collatzWielandtFn A (fun j => |w j|) := by
+  -- Support of |w| is the set of indices with |w i| > 0, i.e., w i ≠ 0.
+  -- Since w ≠ 0, this is nonempty.
+  have h_supp_ne : ∃ j, 0 < |w j| := by
+    by_contra h
+    push Not at h
+    apply hw_ne
+    funext i
+    have : |w i| = 0 := le_antisymm (h i) (abs_nonneg _)
+    exact abs_eq_zero.mp this
+  apply le_collatzWielandtFn_of_all_supp_ratios_le h_supp_ne
+  intro i hwi_pos
+  have h_bd : |lam| * |w i| ≤ A.mulVec (fun j => |w j|) i :=
+    abs_eigenvalue_mul_abs_le_mulVec_abs hA h_eig i
+  exact (le_div_iff₀ hwi_pos).mpr h_bd
+
+end LatticeSystem.Math.CollatzWielandt


### PR DESCRIPTION
Tracked in #3871 (parent: #3739).

## (j.13.e.2-4) Collatz-Wielandt lower bound at abs of an eigenvector

Three layered lemmas (bundled because tightly coupled and small):

- **(e.2) `abs_mulVec_le_mulVec_abs`** — Triangle inequality:
  `|A *ᵥ w|_i ≤ (A *ᵥ |w|)_i` for nonneg `A` and any real `w`.

- **(e.3) `abs_eigenvalue_mul_abs_le_mulVec_abs`** — At an eigenvector at `λ`,
  `|λ| * |w_i| ≤ (A *ᵥ |w|)_i`.

- **(e.4) `abs_eigenvalue_le_collatzWielandtFn_abs`** — For `w ≠ 0` eigenvector
  at `λ` of nonneg `A`, `|λ| ≤ collatzWielandtFn A |w|`.

## New public CW lemma

`(e.4)` requires bounding `CW(x)` from below via support-ratio bounds, which
needs the private `supp` from `CollatzWielandt.lean`. We therefore add a small
public companion to the existing `lt_of_all_ratios_gt` (which gives the dual
strict-positive bound):

```lean
lemma le_collatzWielandtFn_of_all_supp_ratios_le
    {A : Matrix n n ℝ} {x : n → ℝ} {c : ℝ}
    (hx : ∃ j, 0 < x j) (h : ∀ i, 0 < x i → c ≤ (A *ᵥ x) i / x i) :
    c ≤ collatzWielandtFn A x
```

## Role in (j.13.e)

Combined with (j.13.e.1) (`collatzWielandtFn_le_of_pos_eigenvector`), this gives
`|λ| ≤ μ_PF` for any real eigenvalue of a symmetric nonneg irreducible matrix
`B` with positive PF eigenvector at `μ_PF`. That is the core of the Collatz-
Wielandt max characterization (the HARD step of (j.13)).

Remaining (j.13.e) steps:
- (e.5) Combine (e.1) + (e.4) → for any real eigenvalue λ, `λ ≤ μ_PF`.
- (e.6) Bridge to complex Hermitian: `hermitianMaxEigenvalue B_complex ≤ μ_PF`.

## Reference

E. Seneta, *Non-negative Matrices and Markov Chains* (3rd ed.), Springer 2006,
§1.2.
