### PR TITLE
(j.13.h.3) Bare submatrix finrank ≤ 1 at hermitianMinEigenvalue (unconditional) -- #3871

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -16,6 +16,7 @@ import LatticeSystem.Math.HermitianMaxEqPF
 import LatticeSystem.Math.HermitianSpectrumShift
 import LatticeSystem.Math.HermitianMinEqOfShiftPF
 import LatticeSystem.Quantum.SpinS.DressedBareSubmatrixMinEqPF
+import LatticeSystem.Quantum.SpinS.BareSubmatrixFinrankLeOneAtMin
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale
 import LatticeSystem.Quantum.Pauli

--- a/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMin.lean
+++ b/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMin.lean
@@ -1,0 +1,135 @@
+import LatticeSystem.Quantum.SpinS.DressedBareSubmatrixMinEqPF
+import LatticeSystem.Quantum.SpinS.BareSubmatrixBoundAtMin
+import LatticeSystem.Quantum.SpinS.BareSubmatrixPFFinrank
+import LatticeSystem.Math.PerronFrobeniusFinrank
+import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducibleUnconditional
+import LatticeSystem.Quantum.SpinS.ComplexDressedParityBlockFinrank
+import LatticeSystem.Quantum.SpinS.MarshallSubmatrixMinEq
+import LatticeSystem.Quantum.SpinS.ParityBlockUnshiftedFinrank
+import LatticeSystem.Quantum.SpinS.GaugeEigenspaceFinrank
+
+/-!
+# Bare submatrix `finrank ≤ 1` at `hermitianMinEigenvalue` (unconditional)
+
+Issue #3871 (Tasaki §2.5 Theorem 2.4 PF identification chain).
+
+(j.13.h.3): The final discharge. Combines:
+- (j.13.h.2-bare) #PR3883: unconditional identification
+  `ν = hermitianMinEigenvalue bare.submatrix`.
+- A parameterised version of the (j.10) #3868 finrank bound at the specific PF ν
+  (derived inline using `eigenspace_finrank_le_one_of_pos_eigenvec` +
+  `eigenspace_smul_one_sub_finrank_eq` + ℝ → ℂ bridge + Marshall similarity).
+- (j.11) #3869 conditional bound: `finrank ≤ 1 at ν` + `ν = hermitianMinEigenvalue`
+  ⟹ `finrank ≤ 1 at hermitianMinEigenvalue`.
+
+Closes the conditional from (j.5) #3861 / (j.11) #3869 for the BARE submatrix.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43-44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **(j.13.h.3) Bare submatrix `finrank ℂ ≤ 1` at `hermitianMinEigenvalue`** (unconditional).
+
+Discharges the deferred PF=min identification, giving an unconditional bound on
+the bare `Ĥ'` parity-block submatrix eigenspace dimension at the Hermitian
+minimum eigenvalue. -/
+theorem axisSwappedAnisotropicHeisenbergS_submatrix_finrank_le_one_at_hermitianMinEigenvalue
+    (A : Λ → Bool) {J : Λ → Λ → ℂ}
+    (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
+    (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
+    (hJself : ∀ x, J x x = 0) (hJbip : ∀ x y, J x y ≠ 0 → A x ≠ A y)
+    {lam : ℂ} (hlam : lam.im = 0) (hlb : -1 < lam.re) (hub : lam.re < 1)
+    {D : ℂ} (hDim : D.im = 0) (hDpos : 0 < D.re)
+    {c : ℝ}
+    (hc_strict : ∀ σ : Λ → Fin (N + 1),
+      dressedAxisSwappedAnisotropicHeisenbergSReMatrix A J lam D N σ σ < c)
+    (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false)
+    (h_intermediate : ∀ τ : Λ → Fin (N + 1), ∀ x : Λ,
+      ∃ z, A z ≠ A x ∧ (τ z).val < N)
+    (p : ℕ)
+    [Nonempty (parityConfigS Λ N p)] :
+    finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+      ((axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D N).submatrix
+        (fun σ : parityConfigS Λ N p => σ.1)
+        (fun σ : parityConfigS Λ N p => σ.1)))
+      ((hermitianMinEigenvalue
+        (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
+          (Λ := Λ) (N := N) hJim hlam hDim p) : ℂ))) ≤ 1 := by
+  -- Step 1: Get ν, v from (j.13.h.2-bare).
+  obtain ⟨ν, v, hv_pos, hAv, hν_eq⟩ :=
+    axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
+      A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict hA_ne hB_ne
+      h_intermediate p
+  -- Step 2: shifted v = (c - ν) v.
+  have h_eig_shifted :
+      Matrix.mulVec (shiftedDressedAxisSwappedReMatrixOnParityBlock A J lam D N c p) v =
+        (c - ν) • v := by
+    rw [shiftedDressedAxisSwappedReMatrixOnParityBlock_eq_smul_one_sub
+          (N := N) A J lam D c p]
+    rw [Matrix.sub_mulVec, Matrix.smul_mulVec, Matrix.one_mulVec, hAv, sub_smul]
+  -- Step 3: shifted is irreducible.
+  have hIrred :=
+    shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
+      A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
+      hA_ne hB_ne h_intermediate p
+  -- Step 4: finrank ℝ eigenspace shifted (c - ν) ≤ 1 via Perron.
+  have h_finrank_shifted_R :
+      finrank ℝ ↥(End.eigenspace (Matrix.toLin'
+        (shiftedDressedAxisSwappedReMatrixOnParityBlock A J lam D N c p)) (c - ν)) ≤ 1 :=
+    LatticeSystem.Math.PerronFrobenius.eigenspace_finrank_le_one_of_pos_eigenvec
+      hIrred h_eig_shifted hv_pos
+  -- Step 5: Shift identity: finrank ℝ shifted (c - ν) = finrank ℝ M_real ν.
+  -- shifted = c•1 - M_real, and eigenspace_smul_one_sub_finrank_eq.
+  set M_real : Matrix (parityConfigS Λ N p) (parityConfigS Λ N p) ℝ :=
+    (dressedAxisSwappedAnisotropicHeisenbergSReMatrix A J lam D N).submatrix
+      (fun σ : parityConfigS Λ N p => σ.1)
+      (fun σ : parityConfigS Λ N p => σ.1) with hM_def
+  have hShift_eq :
+      shiftedDressedAxisSwappedReMatrixOnParityBlock A J lam D N c p =
+        c • (1 : Matrix (parityConfigS Λ N p) (parityConfigS Λ N p) ℝ) - M_real :=
+    shiftedDressedAxisSwappedReMatrixOnParityBlock_eq_smul_one_sub
+      (N := N) A J lam D c p
+  rw [hShift_eq] at h_finrank_shifted_R
+  rw [eigenspace_smul_one_sub_finrank_eq] at h_finrank_shifted_R
+  -- Now: finrank ℝ M_real (c - (c - ν)) ≤ 1, i.e., finrank ℝ M_real ν ≤ 1.
+  have h_finrank_M_R : finrank ℝ ↥(End.eigenspace (Matrix.toLin' M_real) ν) ≤ 1 := by
+    have : c - (c - ν) = ν := by ring
+    rw [← this]
+    exact h_finrank_shifted_R
+  -- Step 6: ℝ → ℂ bridge: finrank ℂ eigenspace (M_real.map ofReal) (ν : ℂ) ≤ 1.
+  have h_finrank_M_C :
+      finrank ℂ ↥(End.eigenspace (Matrix.toLin' (M_real.map ((↑) : ℝ → ℂ))) (ν : ℂ)) ≤ 1 :=
+    matrix_complex_eigenspace_finrank_le_one_of_real M_real ν h_finrank_M_R
+  -- Step 7: M_real.map ofReal = dressed_complex.submatrix.
+  have hMap :
+      M_real.map ((↑) : ℝ → ℂ) =
+        (dressedAxisSwappedAnisotropicHeisenbergS A J lam D N).submatrix
+          (fun σ : parityConfigS Λ N p => σ.1)
+          (fun σ : parityConfigS Λ N p => σ.1) :=
+    dressedAxisSwappedAnisotropicHeisenbergSReMatrix_submatrix_map_eq
+      A hJim hJself hlam hDim p
+  rw [hMap] at h_finrank_M_C
+  -- Step 8: Marshall similarity bridge from dressed to bare.
+  have h_finrank_bare :
+      finrank ℂ ↥(End.eigenspace (Matrix.toLin'
+        ((axisSwappedAnisotropicHeisenbergS (Λ := Λ) J lam D N).submatrix
+          (fun σ : parityConfigS Λ N p => σ.1)
+          (fun σ : parityConfigS Λ N p => σ.1))) (ν : ℂ)) ≤ 1 := by
+    have h_similarity_finrank :=
+      matrix_similar_eigenspace_finrank_eq
+        (marshallDiagonalOnParity_mul_self (Λ := Λ) (N := N) A p)
+        (marshallDiagonalOnParity_mul_self (Λ := Λ) (N := N) A p)
+        (dressedAxisSwapped_submatrix_eq_marshall_conj_bare A J lam D p) (ν : ℂ)
+    rw [h_similarity_finrank] at h_finrank_M_C
+    exact h_finrank_M_C
+  -- Step 9: Apply (j.11) conditional to swap ν with hermitianMinEigenvalue.
+  exact axisSwappedAnisotropicHeisenbergS_submatrix_finrank_le_one_at_min_conditional
+    hJim hlam hDim p ν h_finrank_bare hν_eq
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3871 (parent: #3739).

## (j.13.h.3) Bare submatrix `finrank ≤ 1` at `hermitianMinEigenvalue` (unconditional)

The final discharge of the (j.13) Perron-Frobenius identification chain.

**Theorem.** For the bare `Ĥ'` parity-block submatrix on `parityConfigS Λ N p`:
```
finrank ℂ (eigenspace bare.submatrix (hermitianMinEigenvalue : ℂ)) ≤ 1
```
unconditionally.

**Proof.** Combines:
- **(j.13.h.2-bare)** #3883: unconditional `ν = hermitianMinEigenvalue bare.submatrix`
  identification from PF positive eigenvector.
- **Inline parameterised finrank bound at the specific PF ν**:
  - `PerronFrobenius.eigenspace_finrank_le_one_of_pos_eigenvec` on shifted matrix
    (at eigenvalue `c - ν`).
  - `eigenspace_smul_one_sub_finrank_eq` shift identity (shifted ↔ unshifted).
  - `matrix_complex_eigenspace_finrank_le_one_of_real` (ℝ → ℂ bridge).
  - `dressedAxisSwappedAnisotropicHeisenbergSReMatrix_submatrix_map_eq` (real ↔ complex).
  - `matrix_similar_eigenspace_finrank_eq` (Marshall similarity to bare side).
- **(j.11) #3869 conditional bound**: `finrank ≤ 1 at ν` + `ν = hermitianMinEigenvalue` ⟹
  `finrank ≤ 1 at hermitianMinEigenvalue`.

## Role in (j.13) chain

| Substep | Statement | Status |
|---|---|---|
| (j.13.a)-(j.13.g) | Up to spectrum shift | ✅ |
| (j.13.h.1) | Generic shift identification | ✅ |
| (j.13.h.2) | Dressed/bare specialisation | ✅ |
| (j.13.h.3) | **Unconditional bare bound at min** | This PR |

## Role in Tasaki §2.5 Theorem 2.4

Discharges the deferred hypothesis (`ν = hermitianMinEigenvalue`) in (j.5) #3861 /
(j.11) #3869 conditional bounds for the BARE submatrix. Combined with the parity
`p ∈ {0, 1}` application at spin-1/2, this plugs into (j.12) #3870 capstone for
the full **unconditional** ground-state degeneracy `≤ 2` for the Mattis-Nishimori
anisotropic AFM Hamiltonian Tasaki §2.5 Theorem 2.4.

## Reference

H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,
§2.5 Theorem 2.4, p. 43-44.
