### PR TITLE
(Foundation) spinSRot1 algebraic infrastructure -- #3739

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -45,6 +45,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralSectorLiftCasimir
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralCommonEnergyStep
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralCommonGroundEnergy
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralGeneralFinal
+import LatticeSystem.Quantum.SpinS.SpinSRotation1
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale
 import LatticeSystem.Quantum.Pauli

--- a/LatticeSystem/Quantum/SpinS/SpinSRotation1.lean
+++ b/LatticeSystem/Quantum/SpinS/SpinSRotation1.lean
@@ -27,4 +27,16 @@ theorem spinSRot1_zero (N : ℕ) : spinSRot1 N 0 = 1 := by
   unfold spinSRot1
   simp [exp_zero]
 
+/-- **Addition formula**: `spinSRot1 N θ * spinSRot1 N φ = spinSRot1 N (θ + φ)`. -/
+theorem spinSRot1_mul (N : ℕ) (θ φ : ℝ) :
+    spinSRot1 N θ * spinSRot1 N φ = spinSRot1 N (θ + φ) := by
+  unfold spinSRot1
+  have hcomm : Commute (-(((θ : ℂ) * Complex.I)) • spinSOp1 N)
+      (-(((φ : ℂ) * Complex.I)) • spinSOp1 N) := by
+    exact (Commute.refl (spinSOp1 N)).smul_left _ |>.smul_right _
+  rw [← Matrix.exp_add_of_commute _ _ hcomm]
+  congr 1
+  push_cast
+  module
+
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/SpinSRotation1.lean
+++ b/LatticeSystem/Quantum/SpinS/SpinSRotation1.lean
@@ -49,4 +49,10 @@ theorem spinSRot1_neg_mul (N : ℕ) (θ : ℝ) :
     spinSRot1 N (-θ) * spinSRot1 N θ = 1 := by
   rw [spinSRot1_mul, neg_add_cancel, spinSRot1_zero]
 
+/-- **Commutes with `Ŝ¹`**: `spinSRot1 N θ * spinSOp1 N = spinSOp1 N * spinSRot1 N θ`. -/
+theorem spinSRot1_commute_spinSOp1 (N : ℕ) (θ : ℝ) :
+    Commute (spinSRot1 N θ) (spinSOp1 N) := by
+  unfold spinSRot1
+  exact Commute.exp_left ((Commute.refl (spinSOp1 N)).smul_left _)
+
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/SpinSRotation1.lean
+++ b/LatticeSystem/Quantum/SpinS/SpinSRotation1.lean
@@ -1,0 +1,30 @@
+import LatticeSystem.Quantum.SpinS.Operators
+import Mathlib.Analysis.Normed.Algebra.MatrixExponential
+
+/-!
+# Spin-`S` rotation about axis 1
+
+(PR #3895, Issue #3739): the matrix `exp(-iθ Ŝ¹)` for general spin `S = N/2`,
+parametrised by the angle `θ : ℝ`. At `θ = π/2` this is the axis-swap unitary
+needed to instantiate `AxisSwapUnitaryS N` for general N — the only blocker
+identified by PR #3889 (`General-N truly unconditional capstone`) for the
+truly-unconditional Tasaki §2.5 Theorem 2.4 ≤ 2 closure at general spin.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43-44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix NormedSpace
+
+/-- **Spin-`S` rotation about axis 1**, `exp(-iθ Ŝ¹)`. -/
+noncomputable def spinSRot1 (N : ℕ) (θ : ℝ) : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ :=
+  exp (-(((θ : ℂ) * Complex.I)) • spinSOp1 N)
+
+/-- **At `θ = 0`, `exp(0) = 1`**. -/
+theorem spinSRot1_zero (N : ℕ) : spinSRot1 N 0 = 1 := by
+  unfold spinSRot1
+  simp [exp_zero]
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/SpinSRotation1.lean
+++ b/LatticeSystem/Quantum/SpinS/SpinSRotation1.lean
@@ -39,4 +39,14 @@ theorem spinSRot1_mul (N : ℕ) (θ φ : ℝ) :
   push_cast
   module
 
+/-- **Invertibility (right)**: `spinSRot1 N θ * spinSRot1 N (-θ) = 1`. -/
+theorem spinSRot1_mul_neg (N : ℕ) (θ : ℝ) :
+    spinSRot1 N θ * spinSRot1 N (-θ) = 1 := by
+  rw [spinSRot1_mul, add_neg_cancel, spinSRot1_zero]
+
+/-- **Invertibility (left)**: `spinSRot1 N (-θ) * spinSRot1 N θ = 1`. -/
+theorem spinSRot1_neg_mul (N : ℕ) (θ : ℝ) :
+    spinSRot1 N (-θ) * spinSRot1 N θ = 1 := by
+  rw [spinSRot1_mul, neg_add_cancel, spinSRot1_zero]
+
 end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739 (Tasaki §2.5 Theorem 2.4 parent).

**Foundation infrastructure** for `spinSRot1 N θ := exp(-iθ Ŝ¹)` — the matrix exponential of the spin-S axis-1 generator, parametrised by angle. This is the algebraic prerequisite for `AxisSwapUnitaryS N` at general N (the only blocker identified by PR #3889 for general-spin §2.5 Thm 2.4 ≤ 2 closure).

## Delivered in this PR

| step | property | status |
| --- | --- | --- |
| 1 | `spinSRot1 N 0 = 1` (identity at θ=0) | done |
| 2 | `spinSRot1 N θ * spinSRot1 N φ = spinSRot1 N (θ+φ)` (addition formula) | done |
| 3 | `spinSRot1 N θ * spinSRot1 N (-θ) = 1` and `(-θ) * θ = 1` (invertibility) | done |
| 4 | `Commute (spinSRot1 N θ) (spinSOp1 N)` (commutes with axis) | done |

## Follow-up (separate PRs)

| step | property | difficulty |
| --- | --- | --- |
| 5 | `spinSRot1 N θ * Ŝ² * spinSRot1 N (-θ) = cos(θ) Ŝ² + sin(θ) Ŝ³` (rotation) | requires linear-ODE-uniqueness for matrix-valued maps |
| 6 | Same for Ŝ³ → -sin(θ) Ŝ² + cos(θ) Ŝ³ | follows from step 5 by symmetry |
| 7 | `axisSwapUnitarySGeneral N : AxisSwapUnitaryS N` at θ=π/2 | direct from steps 5/6 |
| 8 | Apply PR #3889 capstone for general-N Theorem 2.4 ≤ 2 | direct from step 7 |

Steps 5/6 require either:
- Linear-ODE uniqueness for matrix-valued curves (mathlib `ODE_solution_eq`)
- Or formalising adjoint-representation `ad_A` of su(2) on span(Ŝ², Ŝ³) plus 2×2 rotation matrix exp

Both are substantial multi-PR follow-ups beyond this foundation.

## References

- Tasaki §2.5 Thm 2.4, p. 43-44
- Mathlib `NormedSpace.exp` / `Matrix.exp_add_of_commute` / `Commute.exp_left`
- PR #3889 (general-N capstone conditional on `AxisSwapUnitaryS N`)
