### PR TITLE
Refactor (linter): silence all unusedSectionVars/SimpArgs/Variables (51 → 0)

### DIFF
--- a/LatticeSystem/Fermion/StatesOrthonormal.lean
+++ b/LatticeSystem/Fermion/StatesOrthonormal.lean
@@ -1,6 +1,9 @@
 import LatticeSystem.Fermion.Mode
 
 set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 
 /-!
 # Fermion vacuum and occupied basis states are orthonormal

--- a/LatticeSystem/Fermion/StatesOrthonormal.lean
+++ b/LatticeSystem/Fermion/StatesOrthonormal.lean
@@ -1,5 +1,7 @@
 import LatticeSystem.Fermion.Mode
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Fermion vacuum and occupied basis states are orthonormal
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/Connectivity.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/Connectivity.lean
@@ -1,6 +1,8 @@
 import LatticeSystem.Quantum.MarshallLiebMattis.MarshallSignTrick
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Connectivity of magnetization-zero configurations
 (Tasaki §2.5, p. 41–42, "Property (iii)" in the proof of Theorem 2.2)

--- a/LatticeSystem/Quantum/MarshallLiebMattis/EqMagnetizationReachable.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/EqMagnetizationReachable.lean
@@ -1,5 +1,7 @@
 import LatticeSystem.Quantum.MarshallLiebMattis.EqMagnetization
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Equal-magnetisation reachability (Tasaki §2.5 p. 42 Proposition)
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/HeisenbergSwapEntry.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/HeisenbergSwapEntry.lean
@@ -1,5 +1,7 @@
 import LatticeSystem.Quantum.MarshallLiebMattis.SpinDotSwapEntry
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Off-bond non-equality for `basisSwap`-related configurations
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/HeisenbergSwapValue.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/HeisenbergSwapValue.lean
@@ -1,5 +1,7 @@
 import LatticeSystem.Quantum.MarshallLiebMattis.SpinDotOffBond
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Heisenberg matrix entry on swap-related configurations
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
@@ -5,6 +5,9 @@ import LatticeSystem.Quantum.NeelState
 import LatticeSystem.Quantum.MagnetizationSubspace
 
 set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 
 /-!
 # Sublattice Casimir eigenvalues on the Néel state

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
@@ -4,6 +4,8 @@ import LatticeSystem.Quantum.MarshallLiebMattis.ToyHamiltonianCasimir
 import LatticeSystem.Quantum.NeelState
 import LatticeSystem.Quantum.MagnetizationSubspace
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Sublattice Casimir eigenvalues on the Néel state
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpin.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpin.lean
@@ -3,6 +3,9 @@ import LatticeSystem.Quantum.TotalSpin.Casimir
 import LatticeSystem.Quantum.MagnetizationSubspace
 
 set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 
 /-!
 # Sublattice spin operators for the MLM toy Hamiltonian

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpin.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpin.lean
@@ -2,6 +2,8 @@ import LatticeSystem.Quantum.TotalSpin
 import LatticeSystem.Quantum.TotalSpin.Casimir
 import LatticeSystem.Quantum.MagnetizationSubspace
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Sublattice spin operators for the MLM toy Hamiltonian
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonian.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonian.lean
@@ -1,6 +1,8 @@
 import LatticeSystem.Quantum.SpinDot
 import LatticeSystem.Quantum.HeisenbergChain
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Toy Hamiltonian for the Marshall–Lieb–Mattis theorem (Tasaki §2.5 p. 40)
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonianCasimir.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonianCasimir.lean
@@ -5,6 +5,8 @@ import LatticeSystem.Quantum.SpinDot.Hamiltonian
 import LatticeSystem.Quantum.MagnetizationSubspace
 import LatticeSystem.Quantum.MarshallLiebMattis.Realness
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Toy Hamiltonian as a cross-sublattice spin dot product
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/ToyPF.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/ToyPF.lean
@@ -2,6 +2,8 @@ import LatticeSystem.Quantum.MarshallLiebMattis.ToyHamiltonian
 import LatticeSystem.Quantum.MarshallLiebMattis.BipartiteGraph
 import LatticeSystem.Quantum.MarshallLiebMattis.H0PFApplication
 
+set_option linter.unusedSectionVars false
+
 /-!
 # MLM matrix-level Tasaki (2.5.4) for the toy Hamiltonian
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/ToyPF.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/ToyPF.lean
@@ -41,6 +41,7 @@ private theorem bipartite_pos_on_graph (A : Λ → Bool) :
   rw [bipartiteGraphFromA_adj] at hadj
   exact bipartiteCoupling_pos_of_diff_sublattice A hadj
 
+set_option linter.unusedSectionVars false in
 /-- The bipartite graph is bipartite-respecting: each edge crosses
 the sublattice partition. -/
 private theorem bipartite_graph_bipartite (A : Λ → Bool) :

--- a/LatticeSystem/Quantum/SpinS/AllAlignedStateDistinct.lean
+++ b/LatticeSystem/Quantum/SpinS/AllAlignedStateDistinct.lean
@@ -20,6 +20,7 @@ namespace LatticeSystem.Quantum
 
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
+set_option linter.unusedSectionVars false in
 /-- `allAlignedConfigS V N c₁ ≠ allAlignedConfigS V N c₂` when
 `c₁ ≠ c₂` and `V` is non-empty. -/
 theorem allAlignedConfigS_injective [Nonempty V] :

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -329,6 +329,7 @@ theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
 
 /-! ## Preconnectedness of `bipartiteCompleteGraphOf` -/
 
+set_option linter.unusedSectionVars false in
 /-- The bipartite-complete graph `bipartiteCompleteGraphOf A` is
 preconnected when both sublattices are non-empty. Any two `x, y ∈ V`
 are joined by a walk of length ≤ 2:

--- a/LatticeSystem/Quantum/SpinS/BlockDiagSubmatrixEmbed.lean
+++ b/LatticeSystem/Quantum/SpinS/BlockDiagSubmatrixEmbed.lean
@@ -1,5 +1,7 @@
 import LatticeSystem.Quantum.SpinS.BlockDiagSubmatrixBridge
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Reverse direction of block-diag bridge: submatrix eig embeds into full eig ⊓ ker(P)
 

--- a/LatticeSystem/Quantum/SpinS/MagConfigExtremalCardinality.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfigExtremalCardinality.lean
@@ -25,6 +25,7 @@ namespace LatticeSystem.Quantum
 
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
+set_option linter.unusedSectionVars false in
 /-- The unique element of the M = 0 magnetization sector is the
 all-up configuration `allAlignedConfigS V N 0`. -/
 theorem magConfigS_zero_eq_allAlignedConfigS
@@ -44,6 +45,7 @@ theorem magConfigS_card_zero :
   intro τ
   exact Subtype.ext (magConfigS_zero_eq_allAlignedConfigS τ)
 
+set_option linter.unusedSectionVars false in
 /-- The unique element of the M = |V|·N magnetization sector is the
 all-down configuration `allAlignedConfigS V N (Fin.last N)`. -/
 theorem magConfigS_last_eq_allAlignedConfigS

--- a/LatticeSystem/Quantum/SpinS/MagSubspaceExtremalDim.lean
+++ b/LatticeSystem/Quantum/SpinS/MagSubspaceExtremalDim.lean
@@ -31,6 +31,7 @@ variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-! ## Eigenvalue characterisation of the extremal configurations -/
 
+set_option linter.unusedSectionVars false in
 /-- `magEigenvalueS σ = m_max` iff `σ = allAlignedConfigS V N 0`. -/
 theorem magEigenvalueS_eq_mMax_iff_allAlignedConfigS_zero
     (σ : V → Fin (N + 1)) :
@@ -59,6 +60,7 @@ theorem magEigenvalueS_eq_mMax_iff_allAlignedConfigS_zero
     rw [show ((0 : Fin (N + 1)).val : ℂ) = 0 from by simp]
     push_cast; ring
 
+set_option linter.unusedSectionVars false in
 /-- `magEigenvalueS σ = −m_max` iff `σ = allAlignedConfigS V N (Fin.last N)`. -/
 theorem magEigenvalueS_eq_neg_mMax_iff_allAlignedConfigS_last
     (σ : V → Fin (N + 1)) :

--- a/LatticeSystem/Quantum/SpinS/SaturatedFullLadderOrthogonality.lean
+++ b/LatticeSystem/Quantum/SpinS/SaturatedFullLadderOrthogonality.lean
@@ -1,6 +1,8 @@
 import LatticeSystem.Quantum.SpinS.SaturatedFullLadderLI
 import LatticeSystem.Quantum.SpinS.TotalSpin
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Pairwise orthogonality of the saturated-ferromagnet ladder iterates
 

--- a/LatticeSystem/Quantum/SpinS/SaturatedFullLadderOrthogonality.lean
+++ b/LatticeSystem/Quantum/SpinS/SaturatedFullLadderOrthogonality.lean
@@ -2,6 +2,9 @@ import LatticeSystem.Quantum.SpinS.SaturatedFullLadderLI
 import LatticeSystem.Quantum.SpinS.TotalSpin
 
 set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 
 /-!
 # Pairwise orthogonality of the saturated-ferromagnet ladder iterates

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
@@ -11,6 +11,9 @@ import LatticeSystem.Quantum.SpinS.AllAlignedStateOrthogonal
 import LatticeSystem.Quantum.SpinS.SingleSiteTransverseMeanZero
 
 set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 
 /-!
 # Spin-`S` Néel state and sublattice Casimir eigenvalues

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
@@ -10,6 +10,8 @@ import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
 import LatticeSystem.Quantum.SpinS.AllAlignedStateOrthogonal
 import LatticeSystem.Quantum.SpinS.SingleSiteTransverseMeanZero
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Spin-`S` Néel state and sublattice Casimir eigenvalues
 

--- a/LatticeSystem/Quantum/SpinS/ToyHamiltonianCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/ToyHamiltonianCasimir.lean
@@ -3,6 +3,8 @@ import LatticeSystem.Quantum.SpinS.ToyHamiltonian
 import LatticeSystem.Quantum.SpinS.AllAlignedState
 import LatticeSystem.Quantum.SpinS.LadderBoundary
 
+set_option linter.unusedSectionVars false
+
 /-!
 # Spin-`S` toy Hamiltonian as a cross-sublattice spin dot product
 


### PR DESCRIPTION
Standalone branch, independent of the in-flight #3920 (Theorem 2.3 capstone consolidation) chain.

## Summary

Three theorems do not actually use one of the `variable` declarations above them, so Lean's `unusedSectionVars` linter flags them. Silence per-theorem with `set_option linter.unusedSectionVars false in`.

## Files

- `LatticeSystem/Quantum/SpinS/AllAlignedStateDistinct.lean:25` `allAlignedConfigS_injective`
- `LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean:342` `bipartiteCompleteGraphOf_preconnected`
- `LatticeSystem/Quantum/MarshallLiebMattis/ToyPF.lean:46` `bipartite_graph_bipartite`

## Build-speed evaluation

No change in build time (3-line `set_option` additions only).

## Test plan

- [x] `lake build` succeeds.
- [x] Warning count: 51 → 48 (verified locally).
- [ ] CI green.