### PR TITLE
Refactor (Phase E, batch 1): drop _structural suffix from 4 collision-free symbols -- #3921

### DIFF
--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralBipartiteToy.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralBipartiteToy.lean
@@ -79,7 +79,7 @@ coupling — at spin-1/2 (N=1) the original `tasaki_2_5_theorem_2_3_bipartiteToy
 vacuous because `h_intermediate` is unsatisfiable when `τ ≡ Fin.last 1`. The structural
 variant proves the same conclusion from `(hA_ne, hB_ne, hN)`, which are the genuine
 physical hypotheses. -/
-theorem tasaki_2_5_theorem_2_3_bipartiteToy_structural
+theorem tasaki_2_5_theorem_2_3_bipartiteToy
     (A : V → Bool) (N : ℕ) (c : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card) :
@@ -101,7 +101,7 @@ theorem tasaki_2_5_theorem_2_3_bipartiteToy_structural
   refine ⟨(bipartiteToyMinEnergyPredicted (Λ := V) A N).re, ?_, ?_⟩
   · intro M hM _hNe
     obtain ⟨vM, hE_lt, hvM_pos, hH_M, _hReEig, huniq⟩ :=
-      toy_sector_groundState_at_predicted_structural (N := N) A c horient hc_strict
+      toy_sector_groundState_at_predicted (N := N) A c horient hc_strict
         hA_ne hB_ne hN hM
     exact ⟨vM, hE_lt, hvM_pos, hH_M, huniq⟩
   · refine tasaki23_eigenvalue_ge_common A N c (bipartiteCoupling_im A)
@@ -119,7 +119,7 @@ theorem tasaki_2_5_theorem_2_3_bipartiteToy_structural
             (by rw [← tasaki23_card_filter_A_add_card_notA A]
                 exact max_le (Nat.le_add_right _ _) (Nat.le_add_left _ _))))
       obtain ⟨vM, _hE_lt, hvM_pos, _hH_M, hReEig, _huniq⟩ :=
-        toy_sector_groundState_at_predicted_structural (N := N) A c horient hc_strict
+        toy_sector_groundState_at_predicted (N := N) A c horient hc_strict
           hA_ne hB_ne hN hM
       exact ⟨vM, hvM_pos, hReEig⟩
     · intro M _hM_non μM φ hφ_ne hφ

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
@@ -38,13 +38,13 @@ the full `tasaki_2_5_theorem_2_3_structural` statement holds for any real symmet
 non-negative bipartite coupling `J` positive on the complete bipartite graph.
 
 This removes both:
-- the toy-coupling restriction of PR #3891's `tasaki_2_5_theorem_2_3_bipartiteToy_structural`,
+- the toy-coupling restriction of PR #3891's `tasaki_2_5_theorem_2_3_bipartiteToy`,
 - the vacuous-at-`N=1` `h_intermediate` restriction of PR #3738's
   `tasaki_2_5_theorem_2_3_of_bipartiteCompletePositive`.
 
 At spin-1/2 (`N = 1`) this is the first truly-unconditional Tasaki §2.5 Theorem 2.3
 closure for general bipartite J. -/
-theorem tasaki_2_5_theorem_2_3_of_bipartiteCompletePositive_structural
+theorem tasaki_2_5_theorem_2_3_of_bipartiteCompletePositive
     (A : V → Bool) (N : ℕ) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -72,7 +72,7 @@ theorem tasaki_2_5_theorem_2_3_of_bipartiteCompletePositive_structural
   refine ⟨μ, ?_, ?_⟩
   · intro M hM _hNe
     obtain ⟨μM, vM, hμM_lt, hvM_pos, hH_M, _hsupp, huniq⟩ :=
-      tasaki_2_5_theorem_2_3_sector_existence_structural (N := N) (M := M) A c
+      tasaki_2_5_theorem_2_3_sector_existence (N := N) (M := M) A c
         hJ_real hJ_real' hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN
     have hReEig_M : (heisenbergHamiltonianSReMatrixOnMagSector J N M).mulVec
         (fun σ => (marshallSignS A σ.1).re * vM σ) =

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorExistence.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorExistence.lean
@@ -16,7 +16,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural per-sector existence step toward Tasaki §2.5 Theorem 2.3 (no `h_intermediate`)**. -/
-theorem tasaki_2_5_theorem_2_3_sector_existence_structural
+theorem tasaki_2_5_theorem_2_3_sector_existence
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralToySectorGroundState.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralToySectorGroundState.lean
@@ -10,7 +10,7 @@ import LatticeSystem.Quantum.SpinS.BipartiteToyMinEnergy
 (Thm23-#3887.19): structural variant of the per-sector toy ground-state
 at predicted-energy package (the original `toy_sector_groundState_at_predicted`
 witness was removed together with `Theorem23ToyFinal.lean` in PR #3917). Uses
-- `tasaki_2_5_theorem_2_3_sector_existence_structural` (Thm23-#3887.16)
+- `tasaki_2_5_theorem_2_3_sector_existence` (Thm23-#3887.16)
 - `tasaki23_toy_sector_energy_ge_predicted_structural` (Thm23-#3887.17)
 - `tasaki23_toy_sector_groundEnergy_le_of_witness` (already h_intermediate-free)
 - `exists_predictedEnergy_sector_eigenvector_of_mem` (already h_intermediate-free)
@@ -25,7 +25,7 @@ variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural per-sector toy ground state at the predicted minimum energy
 (no `h_intermediate`)**. -/
-theorem toy_sector_groundState_at_predicted_structural
+theorem toy_sector_groundState_at_predicted
     (A : V → Bool) (c : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -53,7 +53,7 @@ theorem toy_sector_groundState_at_predicted_structural
   classical
   set E := (bipartiteToyMinEnergyPredicted (Λ := V) A N).re with hEdef
   obtain ⟨μM, vM, hμM_lt, hvM_pos, hH_M, _hsupp, huniq⟩ :=
-    tasaki_2_5_theorem_2_3_sector_existence_structural (M := M) A c (bipartiteCoupling_im A)
+    tasaki_2_5_theorem_2_3_sector_existence (M := M) A c (bipartiteCoupling_im A)
       (fun x y => by
         rw [Complex.star_def, Complex.conj_eq_iff_im]; exact bipartiteCoupling_im A x y)
       (fun x y hadj => by


### PR DESCRIPTION
Tracked in #3921.

## Summary

After #3920 (Theorem 2.3 capstone consolidation) merged 2026-05-30, four canonical names were freed (their original h_intermediate-threaded definitions were deleted). This PR drops the `_structural` suffix from the corresponding proof witnesses.

## Renames

| Old (`_structural`) | New (canonical) |
|--|--|
| `tasaki_2_5_theorem_2_3_bipartiteToy_structural` | `tasaki_2_5_theorem_2_3_bipartiteToy` |
| `tasaki_2_5_theorem_2_3_of_bipartiteCompletePositive_structural` | `tasaki_2_5_theorem_2_3_of_bipartiteCompletePositive` |
| `tasaki_2_5_theorem_2_3_sector_existence_structural` | `tasaki_2_5_theorem_2_3_sector_existence` |
| `toy_sector_groundState_at_predicted_structural` | `toy_sector_groundState_at_predicted` |

## Remaining work

~36 more `_structural` symbols still have name collisions with their non-`_structural` twins. Those require consumer redirects before suffix drop (separate follow-up PRs).

## Build

3507 jobs, green.

## Test plan

- [x] `lake build` succeeds (3507 jobs).
- [x] All references updated (perl rewrite of full word-bounded matches).
- [ ] CI green.