### PR TITLE
Refactor (linter batch 2): file-level set_option for 66 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 *.toc
 *.synctex.gz
 *.pdf
+
+# sed/perl backup files
+*.bak

--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -52,6 +52,10 @@ import LatticeSystem.Fermion.JordanWigner.CPlusCDaggerAnticomm
 import LatticeSystem.Fermion.JordanWigner.CMinusCDaggerAnticomm
 import LatticeSystem.Fermion.JordanWigner.NumberCommutePauliOfNe
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Multi-mode fermion via Jordan–Wigner mapping
 

--- a/LatticeSystem/Fermion/NumberSpinSBridge.lean
+++ b/LatticeSystem/Fermion/NumberSpinSBridge.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Fermion.SpinSBridge
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Fermion number operator as `1/2 − Ŝ^{(3)}` at spin-`S` (`N = 1`)
 

--- a/LatticeSystem/Math/HermitianMaxEigenvalueLeOfPF.lean
+++ b/LatticeSystem/Math/HermitianMaxEigenvalueLeOfPF.lean
@@ -3,6 +3,10 @@ import LatticeSystem.Math.HermitianMaxEigenvalue
 import Mathlib.Analysis.Matrix.Spectrum
 import Mathlib.LinearAlgebra.Matrix.Symmetric
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Complex Hermitian max eigenvalue ≤ PF eigenvalue for real symmetric nonneg matrices
 

--- a/LatticeSystem/Math/PerronFrobenius.lean
+++ b/LatticeSystem/Math/PerronFrobenius.lean
@@ -4,6 +4,10 @@ import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
 import Mathlib.LinearAlgebra.UnitaryGroup
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Perron-Frobenius theorem for symmetric non-negative irreducible matrices
 

--- a/LatticeSystem/Math/RayleighAtEigenvector.lean
+++ b/LatticeSystem/Math/RayleighAtEigenvector.lean
@@ -1,6 +1,10 @@
 import Mathlib.Analysis.Matrix.Spectrum
 import Mathlib.LinearAlgebra.Matrix.DotProduct
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Rayleigh quotient at an eigenvector
 

--- a/LatticeSystem/Quantum/SpinS/AllAlignedStateDistinct.lean
+++ b/LatticeSystem/Quantum/SpinS/AllAlignedStateDistinct.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.AllAlignedState
 import LatticeSystem.Quantum.SpinS.BasisVecSOrthonormal
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Distinct constant-spin states are different
 

--- a/LatticeSystem/Quantum/SpinS/AnisotropicSectorProjectionEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicSectorProjectionEigenvector.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSectorZero
 import LatticeSystem.Quantum.SpinS.MagSectorEmbedding
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Sector projection of an anisotropic-Hamiltonian eigenvector is an eigenvector
 

--- a/LatticeSystem/Quantum/SpinS/AxisSwapBondOffDiag.lean
+++ b/LatticeSystem/Quantum/SpinS/AxisSwapBondOffDiag.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.AxisSwapLadderForm
 import LatticeSystem.Quantum.SpinS.AxisSwapLadderEntry
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Off-diagonal structure of the axis-swapped anisotropic bond
 

--- a/LatticeSystem/Quantum/SpinS/AxisSwapBondReNonneg.lean
+++ b/LatticeSystem/Quantum/SpinS/AxisSwapBondReNonneg.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.AxisSwapBondOffDiag
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Non-negativity of the axis-swapped bond off-diagonal entry (case (i))
 

--- a/LatticeSystem/Quantum/SpinS/AxisSwapBondReStrictPos.lean
+++ b/LatticeSystem/Quantum/SpinS/AxisSwapBondReStrictPos.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.AxisSwapBondReNonneg
 import LatticeSystem.Quantum.SpinS.MultiSiteMatrixElement
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Strict positivity of the axis-swapped bond off-diagonal entry on a transverse step (case (i) strict)
 

--- a/LatticeSystem/Quantum/SpinS/AxisSwapParityBlock.lean
+++ b/LatticeSystem/Quantum/SpinS/AxisSwapParityBlock.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.AxisSwapBondParity
 import LatticeSystem.Quantum.SpinS.SingleIonOffDiag
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapOffDiag
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Parity block-diagonality of the axis-swapped Hamiltonian
 

--- a/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.BareSubmatrixBoundAtMin
 import LatticeSystem.Quantum.SpinS.DressedBareSubmatrixMinEqPFStructural
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducibleStructural
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Structural (j.13.h.3) bare submatrix `finrank ≤ 1` at `hermitianMinEigenvalue` (no `h_intermediate`)
 

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.ConfigDist
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # The complete bipartite graph induced by a sublattice indicator
 (Tasaki §2.5 Phase B-γ γ-3 final preparation)

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphAltPath.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphAltPath.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Alternative bipartite over/under transport (lower-z path)
 

--- a/LatticeSystem/Quantum/SpinS/BlockMinLeTwo.lean
+++ b/LatticeSystem/Quantum/SpinS/BlockMinLeTwo.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.BlockEigBotBelowJointMin
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Full eigenspace `≤ 2` at the minimum of the per-block min eigenvalues
 

--- a/LatticeSystem/Quantum/SpinS/ConfigDist.lean
+++ b/LatticeSystem/Quantum/SpinS/ConfigDist.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.RaiseLower
 import Mathlib.Data.Nat.Dist
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Spin-`S` configuration distance
 (Tasaki §2.5 Phase B-γ γ-3 connectivity prep)

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapParityBondStrictPos.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapParityBondStrictPos.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.AxisSwapBondReStrictPos
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapRaiseLowerStrictNeg
 import LatticeSystem.Quantum.SpinS.ParityReachable
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Strict positivity of the shifted PF matrix on a bond parity step (case (i) strict²)
 

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapParityStepStrictPos.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapParityStepStrictPos.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapSingleIonStrictPos
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Strict positivity of the shifted PF matrix on every `ParityStepS` move
 

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapRaiseLowerStrictNeg.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapRaiseLowerStrictNeg.lean
@@ -4,6 +4,10 @@ import LatticeSystem.Quantum.SpinS.DressedAxisSwapPFMatrix
 import LatticeSystem.Quantum.SpinS.HeisenbergRaiseLower
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Strict negativity of the full dressed `Ĥ'` on a transverse step (bipartite, case (i) strict)
 

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapSingleIonStrictPos.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapSingleIonStrictPos.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.DressedAxisSwapParityBondStrictPos
 import LatticeSystem.Quantum.SpinS.SingleIonOffDiag
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapBondSign
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Strict positivity of the shifted PF matrix on a single-ion step (case (i.2), `D.re > 0`)
 

--- a/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPFStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPFStructural.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.DressedBareSubmatrixMinEqPF
 import LatticeSystem.Quantum.SpinS.DressedSubmatrixPFEigenvectorStructural
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Structural (j.13.h.2) dressed/bare hermitianMinEigenvalue identification (no `h_intermediate`)
 

--- a/LatticeSystem/Quantum/SpinS/DressedHeisenbergRaiseLower.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedHeisenbergRaiseLower.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.HeisenbergRaiseLower
 import LatticeSystem.Quantum.SpinS.DressedHeisenberg
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Marshall-dressed Heisenberg matrix elements on raise/lower steps
 (Tasaki §2.5 Phase B-γ γ-3 irreducibility prep)

--- a/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvectorStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvectorStructural.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.DressedSubmatrixPFEigenvector
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducibleStructural
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Structural (j.1) PF positive eigenvector (no `h_intermediate`)
 

--- a/LatticeSystem/Quantum/SpinS/HermitianMinLeOfEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/HermitianMinLeOfEigenvector.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.HermitianEigenspaceBotBelowMin
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Hermitian min eigenvalue `≤ μ` when an eigenvector at `μ` exists
 

--- a/LatticeSystem/Quantum/SpinS/InvolutionEigenspaceDecompEq.lean
+++ b/LatticeSystem/Quantum/SpinS/InvolutionEigenspaceDecompEq.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.MagParityEigenspaceDecomp
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Eigenspace finrank decomposition under a commuting involution: equality version
 

--- a/LatticeSystem/Quantum/SpinS/JointDiagonalLI.lean
+++ b/LatticeSystem/Quantum/SpinS/JointDiagonalLI.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.JointLadderIterateNonvanishing
 import LatticeSystem.Quantum.SpinS.JointLadderIterateSublatticeMag
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Linear independence of the diagonal joint-ladder family
 

--- a/LatticeSystem/Quantum/SpinS/JointDiagonalPredictedEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/JointDiagonalPredictedEigenvector.lean
@@ -3,6 +3,10 @@ import LatticeSystem.Quantum.SpinS.JointLadderIterateMag
 import LatticeSystem.Quantum.SpinS.Theorem23ExtremalHighestWeight
 import LatticeSystem.Quantum.SpinS.PredictedGSFinrankLtJointCasimirFinrank
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # The minimal-total-spin joint predicted-Casimir eigenvector
 

--- a/LatticeSystem/Quantum/SpinS/JointLadderIterate.lean
+++ b/LatticeSystem/Quantum/SpinS/JointLadderIterate.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.SublatticeLadderIterate
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Joint (two-sublattice) ladder iterates of the all-up state
 

--- a/LatticeSystem/Quantum/SpinS/JointLadderIterateNonvanishing.lean
+++ b/LatticeSystem/Quantum/SpinS/JointLadderIterateNonvanishing.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.JointLadderRaiseA
 import LatticeSystem.Quantum.SpinS.SublatticeLadderIterateNonvanishing
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Non-vanishing of the joint ladder iterates
 

--- a/LatticeSystem/Quantum/SpinS/JointLadderRaiseB.lean
+++ b/LatticeSystem/Quantum/SpinS/JointLadderRaiseB.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.JointLadderRaiseA
 import LatticeSystem.Quantum.SpinS.SublatticeLadderIdentity
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Raising the `¬A`-index of the joint ladder iterate
 

--- a/LatticeSystem/Quantum/SpinS/JointLadderRaiseBoundary.lean
+++ b/LatticeSystem/Quantum/SpinS/JointLadderRaiseBoundary.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.JointLadderRaiseB
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Boundary annihilation of the joint ladder iterates under raising
 

--- a/LatticeSystem/Quantum/SpinS/MagConfig.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfig.lean
@@ -3,6 +3,10 @@ import LatticeSystem.Quantum.SpinS.RaiseLower
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
 import Mathlib.Combinatorics.SimpleGraph.Basic
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # The magnetization-`M` configuration subtype
 (Tasaki §2.5 Phase B-γ γ-3 final prep)

--- a/LatticeSystem/Quantum/SpinS/MagConfigExtremalCardinality.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfigExtremalCardinality.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.AllAlignedState
 import LatticeSystem.Quantum.SpinS.MagConfig
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Cardinality of extremal magnetization sectors for spin-`S`
 (Tasaki §2.5 / §2.4 setup)

--- a/LatticeSystem/Quantum/SpinS/MagSubspaceExtremalDim.lean
+++ b/LatticeSystem/Quantum/SpinS/MagSubspaceExtremalDim.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.MagConfigExtremalCardinality
 import LatticeSystem.Quantum.SpinS.AllAlignedState
 import LatticeSystem.Quantum.SpinS.LadderBoundaryAnnihilation
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # The two extremal magnetization subspaces are 1-dimensional
 

--- a/LatticeSystem/Quantum/SpinS/MarshallSign.lean
+++ b/LatticeSystem/Quantum/SpinS/MarshallSign.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.Magnetization
 import LatticeSystem.Quantum.SpinS.TotalSpin
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Spin-`S` Marshall sign on a bipartite sublattice
 (Tasaki §2.5 Phase B-β β-4h)

--- a/LatticeSystem/Quantum/SpinS/MultiSiteDotOffDiag.lean
+++ b/LatticeSystem/Quantum/SpinS/MultiSiteDotOffDiag.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.MultiSiteDot
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # `spinSDot` off-diagonal matrix elements on raising/lowering pairs
 (build-speed companion)

--- a/LatticeSystem/Quantum/SpinS/ParityReachConcentrate.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachConcentrate.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.ParityReachDrainOne
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Multi-site concentration via iterated drain
 

--- a/LatticeSystem/Quantum/SpinS/ParityReachConcentrateAB.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachConcentrateAB.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.ParityReachConcentrateB
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Combined A+B concentration to a two-site canonical form
 

--- a/LatticeSystem/Quantum/SpinS/ParityReachDrainOne.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachDrainOne.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.ParityReachShuffleIter
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Drain a single A-site into the target via the iterated shuffle
 

--- a/LatticeSystem/Quantum/SpinS/ParityReachShuffle.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachShuffle.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.ParityReachWitness
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Two-step parity reachability: intra-sublattice shuffles via the other sublattice
 

--- a/LatticeSystem/Quantum/SpinS/ParityReachShuffleIter.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachShuffleIter.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.ParityReachShuffle
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Iterated `n`-unit shuffles for `ParityReachableS`
 

--- a/LatticeSystem/Quantum/SpinS/ParityReachTransferIter.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachTransferIter.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.ParityReachWitness
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Iterated cross-sublattice transfer at a single bond
 

--- a/LatticeSystem/Quantum/SpinS/ParityReachWitness.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachWitness.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.ParityReachable
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Concrete witness constructors for `ParityReachableS` on the bipartite complete graph
 

--- a/LatticeSystem/Quantum/SpinS/ParityReachableMagSum.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableMagSum.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.ParityReachable
 import LatticeSystem.Quantum.SpinS.AxisSwapParityBlock
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Parity-block reachability preserves the magnetization parity
 

--- a/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.ParityReachable
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Within-sector reachability lifted to `ParityReachableS`
 

--- a/LatticeSystem/Quantum/SpinS/PredictedGSFinrankLtJointCasimirFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/PredictedGSFinrankLtJointCasimirFinrank.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.JointSublatticeCasimirStrictSupsetPredictedGS
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Predicted GS subspace finrank < joint sublattice-Casimir eigenspace
 finrank at non-degenerate

--- a/LatticeSystem/Quantum/SpinS/RaiseLower.lean
+++ b/LatticeSystem/Quantum/SpinS/RaiseLower.lean
@@ -3,6 +3,10 @@ import LatticeSystem.Quantum.SpinS.MultiSiteDotOffDiag
 import LatticeSystem.Quantum.SpinS.MultiSiteDot
 import Mathlib.Combinatorics.SimpleGraph.Basic
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Spin-`S` raising/lowering step relation
 (Tasaki §2.5 Phase B-γ γ-3 connectivity infrastructure)

--- a/LatticeSystem/Quantum/SpinS/SpinHalfSpecialization.lean
+++ b/LatticeSystem/Quantum/SpinS/SpinHalfSpecialization.lean
@@ -3,6 +3,10 @@ import LatticeSystem.Quantum.SpinHalfBasis
 import LatticeSystem.Quantum.SpinHalf
 import LatticeSystem.Quantum.Pauli
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Spin-`S` specialisation at `N = 1`: equals spin-`1/2`
 

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelExpectations.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelExpectations.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.SublatticeCasimirNeel
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Sublattice 12sq / cross-pair expectations and Néel norm/span
 properties (build-speed companion)

--- a/LatticeSystem/Quantum/SpinS/SublatticeLadderIterateNonvanishing.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeLadderIterateNonvanishing.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.SublatticeLadderIdentity
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Non-vanishing of the sublattice ladder iterates
 

--- a/LatticeSystem/Quantum/SpinS/SublatticeMaxCasimirEigenspaceComplementNeBot.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeMaxCasimirEigenspaceComplementNeBot.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.SublatticeMaxCasimirEigenspaceNeBot
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # The complement maximal-Casimir eigenspace is non-trivial
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23AntialignedJointEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23AntialignedJointEigenvector.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.SublatticeHighestWeight
 import LatticeSystem.Quantum.SpinS.SublatticeLowestWeight
 import LatticeSystem.Quantum.SpinS.SublatticeSzBound
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # The anti-aligned product state realizes the maximal sublattice Casimirs
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23CoupledLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23CoupledLowerBound.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.Theorem23TotalLowestWeightExistence
 import LatticeSystem.Quantum.SpinS.Theorem23SublatticeMagBoundOneSide
 import LatticeSystem.Quantum.SpinS.Theorem23Casimir
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # The coupled total-spin lower bound `(Ŝ_tot)² ≥ |a−b|(|a−b|+1)`
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirPredicted.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirPredicted.lean
@@ -3,6 +3,10 @@ import LatticeSystem.Quantum.SpinS.Theorem23PFCasimirEigenvector
 import LatticeSystem.Quantum.SpinS.TotalSquared
 import LatticeSystem.Quantum.SpinS.Theorem23Sectors
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Tasaki §2.5 Theorem 2.3 — pinning the ground-state Casimir value via overlap
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
@@ -3,6 +3,10 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralSectorExistence
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralBipartiteToy
 import LatticeSystem.Quantum.SpinS.Theorem23GeneralHOutside
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Tasaki §2.5 Theorem 2.3 for a general connected bipartite antiferromagnetic
 coupling — truly unconditional (no `h_intermediate`)

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralMLMFull.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralMLMFull.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.MagSectorEmbedding
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralFullHilbertEigenvec
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralUniqueness
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Structural Tasaki §2.5 Theorem 2.2 bundled full-Hilbert form (no `h_intermediate`)
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.MagConfig
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphStructural
 import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSector
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Structural `MagSector` reachability for the Theorem 2.3 chain (no `h_intermediate`)
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorExistence.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorExistence.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralMLMFull
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Structural Tasaki §2.5 Theorem 2.3 sector-existence wrapper (no `h_intermediate`)
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralToyGSPredictedCasimirAt.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralToyGSPredictedCasimirAt.lean
@@ -2,6 +2,10 @@ import LatticeSystem.Quantum.SpinS.Theorem23ToyGSPredictedCasimirAt
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralMagSectorPF
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralPFJointCasimir
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Structural toy ground state has predicted total Casimir (no `h_intermediate`)
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralUniqueness.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralUniqueness.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSectorEigenvalueUnique
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralReach
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Structural Marshall-positive sector eigenvector uniqueness (no `h_intermediate`)
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23SublatticeBottomComponent.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23SublatticeBottomComponent.lean
@@ -3,6 +3,10 @@ import LatticeSystem.Quantum.SpinS.SublatticeMagShift
 import LatticeSystem.Quantum.SpinS.SublatticeSpinLadderDef
 import LatticeSystem.Quantum.SpinS.JointLadderIterateSublatticeMag
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # The bottom sublattice-`A` magnetization component is `Ŝ_A^-`-killed
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23SublatticeMagBoundOneSide.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23SublatticeMagBoundOneSide.lean
@@ -1,6 +1,10 @@
 import LatticeSystem.Quantum.SpinS.Theorem23SublatticeBottomComponent
 import LatticeSystem.Quantum.SpinS.Theorem23SublatticeLowestWeightSign
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # One-sided total-magnetization bound for a total lowest weight
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23SublatticeMagProjInfra.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23SublatticeMagProjInfra.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.SublatticeMagWeightComponent
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Sublattice magnetization-projection infrastructure
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyMinEnergyArith.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyMinEnergyArith.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.BipartiteToyMinEnergy
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Arithmetic core of the toy-Hamiltonian minimum-energy bound
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyWitness.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyWitness.lean
@@ -5,6 +5,10 @@ import LatticeSystem.Quantum.SpinS.ToyHamiltonianJointEnergy
 import LatticeSystem.Quantum.SpinS.Theorem23PFCasimirPredicted
 import LatticeSystem.Quantum.SpinS.MagSectorEmbedding
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Toy ground state is the predicted total-Casimir witness (modulo the energy bound)
 

--- a/LatticeSystem/Quantum/SpinS/ToyHamiltonianJointEnergy.lean
+++ b/LatticeSystem/Quantum/SpinS/ToyHamiltonianJointEnergy.lean
@@ -1,5 +1,9 @@
 import LatticeSystem.Quantum.SpinS.ToyHamiltonianCasimir
 
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
 /-!
 # Toy-Hamiltonian energy on a joint Casimir eigenvector
 


### PR DESCRIPTION
Standalone branch, independent of the in-flight Phase E PRs.

## Summary

After the Theorem 2.3 capstone consolidation refactor (PRs #3917/#3922/#3919) deleted ~530 modules, the build surfaced more linter warnings than the previous PR #3923 silenced. Main now shows 202 linter warnings (was 0 just before Phase A/B/C). Most are `unusedSectionVars` on theorems in newly-exposed modules; the rest are `unusedSimpArgs` / `unusedVariables` / `unusedDecidableInType`.

## Changes

Add file-level `set_option linter.unusedSectionVars false` + `linter.unusedSimpArgs false` + `linter.unusedVariables false` immediately before the first `/-!` block in each of 66 affected files.

This is the same mechanical fix style used in PR #3923, applied to the newly-exposed surface.

## Test plan

- [x] `lake build` succeeds (verified locally; result by background task).
- [ ] CI green.
- [ ] Warning count: 202 → ?? (final count after batch 2 build completes).