### PR TITLE
Refactor (Phase E, batch 3): rename twin → _legacy + structural → canonical for 1 pair -- #3921

### DIFF
--- a/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPF.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPF.lean
@@ -35,7 +35,7 @@ Combining (j.1) positive PF eigenvector existence + (j.13.h.1) generic shift
 identification + matrix-identity bridge between real-lifted and complex submatrix,
 the dressed submatrix's `hermitianMinEigenvalue` equals the un-shifted PF value
 `ν = c - μ_PF`. -/
-theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
+theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf_legacy
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
@@ -155,7 +155,7 @@ theorem axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
         (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
           (Λ := Λ) (N := N) hJim hlam hDim p) := by
   obtain ⟨ν, v, hv_pos, hAv, hν_eq⟩ :=
-    dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
+    dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf_legacy
       A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict hA_ne hB_ne
       h_intermediate p
   refine ⟨ν, v, hv_pos, hAv, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPFStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPFStructural.lean
@@ -21,7 +21,7 @@ open Matrix Module
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **(#3887.6-dressed) Dressed submatrix hermitianMinEigenvalue identification (no `h_intermediate`)**. -/
-theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf_structural
+theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
@@ -129,7 +129,7 @@ theorem axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
         (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
           (Λ := Λ) (N := N) hJim hlam hDim p) := by
   obtain ⟨ν, v, hv_pos, hAv, hν_eq⟩ :=
-    dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf_structural
+    dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
       A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict hA_ne hB_ne
       hN p
   refine ⟨ν, v, hv_pos, hAv, ?_⟩


### PR DESCRIPTION
Tracked in #3921.

## Summary

Apply the "rename-only" approach (no file deletion) to free the canonical name `dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf`:

1. Rename the h_intermediate twin: `..._eq_pf` → `..._eq_pf_legacy`.
2. Rename the structural variant: `..._eq_pf_structural` → `..._eq_pf` (canonical).

## Why rename-only

Phase E batch 2 step 2 attempted file deletion (`DressedBareSubmatrixMinEqPF.lean`) and failed with cross-theorem elaboration-state coupling errors (see retrospective in `.self-local/docs/structural-consolidation-2026-05-30.md`). The rename-only approach avoids that risk: both theorems still exist, just under different names.

The `_legacy` suffix marks the twin as candidate for eventual deletion when its dependencies (currently the bare twin in the same file) are also cleaned up.

## Changes

2 files modified, 4 lines changed.

## Build

3506 jobs, green.

## Test plan

- [x] `lake build` succeeds.
- [ ] CI green.

## Generalization

This pattern (twin → `_legacy` + structural → canonical) is mechanical and can be repeated for the ~34 remaining `_structural` symbols (Phase E batch 4+).