### PR TITLE
Refactor (Phase E, batch 4): rename 5 more twin pairs (twin→_legacy, structural→canonical) -- #3921

### DIFF
--- a/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
@@ -48,7 +48,7 @@ theorem axisSwappedAnisotropicHeisenbergS_submatrix_finrank_le_one_at_hermitianM
           (Λ := Λ) (N := N) hJim hlam hDim p) : ℂ))) ≤ 1 := by
   -- Step 1: (j.13.h.2-bare structural).
   obtain ⟨ν, v, hv_pos, hAv, hν_eq⟩ :=
-    axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf_structural
+    axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
       A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict hA_ne hB_ne
       hN p
   -- Step 2: shifted v = (c - ν) v.

--- a/LatticeSystem/Quantum/SpinS/ComplexDressedSubmatrixPFEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/ComplexDressedSubmatrixPFEigenvector.lean
@@ -51,7 +51,7 @@ theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_complex_eigenvector_e
           (fun σ : parityConfigS Λ N p => σ.1)) w = (ν : ℂ) • w := by
   -- (j.1): get positive real eigenvector.
   obtain ⟨ν, v, hv_pos, hvEq⟩ :=
-    dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists
+    dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_legacy
       A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
       hA_ne hB_ne h_intermediate p
   refine ⟨ν, fun i => (v i : ℂ), ?_, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPF.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPF.lean
@@ -61,7 +61,7 @@ theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalu
           (Λ := Λ) (N := N) A hJim hlam hDim p) := by
   -- (j.1): extract positive PF eigenvector v at ν of dressed.submatrix.
   obtain ⟨ν, v, hv_pos, hAv⟩ :=
-    dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists
+    dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_legacy
       (N := N) A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos
       hc_strict hA_ne hB_ne h_intermediate p
   refine ⟨ν, v, hv_pos, hAv, ?_⟩
@@ -130,7 +130,7 @@ theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalu
 /-- **(j.13.h.2-bare) Bare submatrix hermitianMinEigenvalue identification**.
 
 Transfer (j.13.h.2-dressed) via Marshall similarity (j.8) #3865. -/
-theorem axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
+theorem axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf_legacy
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPFStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPFStructural.lean
@@ -49,7 +49,7 @@ theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalu
         (dressedAxisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
           (Λ := Λ) (N := N) A hJim hlam hDim p) := by
   obtain ⟨ν, v, hv_pos, hAv⟩ :=
-    dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_structural
+    dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists
       (N := N) A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos
       hc_strict hA_ne hB_ne hN p
   refine ⟨ν, v, hv_pos, hAv, ?_⟩
@@ -109,7 +109,7 @@ theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalu
   linarith [h_min_lift, h_min_bridge]
 
 /-- **(#3887.6-bare) Bare submatrix hermitianMinEigenvalue identification (no `h_intermediate`)**. -/
-theorem axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf_structural
+theorem axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorEigenvalueUnique.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorEigenvalueUnique.lean
@@ -307,11 +307,11 @@ strictly Marshall-positive complex ground-state eigenvector
 sign at `σ`) at some real eigenvalue `μ < c`.
 
 Composition of:
-- `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`
+- `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy`
   (PR #853, real-form existence).
 - `heisenbergHamiltonianSMatrixOnMagSector_mulVec_ofReal`
   (PR #858, real → complex eigenvector lift). -/
-theorem exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector
+theorem exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -329,7 +329,7 @@ theorem exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMag
         (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) =
         (μ : ℂ) • (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) := by
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
       (M := M) A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       h_intermediate
   exact ⟨μ, v, hμ, hv_pos,
@@ -495,7 +495,7 @@ theorem marshallLiebMattis_spinS_heisenbergSector_complexGroundState_full
         μ' = μ ∧ ∃ r : ℝ, 0 < r ∧
           ∀ σ, (W σ).re = r * ((marshallSignS A σ.1).re * v σ)) := by
   obtain ⟨μ, v, hμ_lt, hv_pos, hmul⟩ :=
-    exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector
+    exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_legacy
       (M := M) A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       h_intermediate
   refine ⟨μ, v, hμ_lt, hv_pos, hmul, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
@@ -261,7 +261,7 @@ The eigenvector `w τ := sign A τ.1 .re * v τ` has `|w τ| = v τ > 0`,
 so `w` is everywhere non-zero. The sign of `w` matches the Marshall sign
 structure. This is the ground-state half of Tasaki §2.5 Theorem 2.2 in
 the magnetization sector. -/
-theorem exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
+theorem exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -481,7 +481,7 @@ Marshall-positive eigenvector at the SAME eigenvalue `μ` is a positive
 scalar multiple of it.
 
 Bundles the existence theorem
-(`exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`,
+(`exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy`,
 PR #853) with the same-eigenvalue uniqueness theorem
 (`marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector`,
 PR #854) into the form most directly usable downstream. -/
@@ -509,7 +509,7 @@ theorem marshallLiebMattis_spinS_heisenbergSector_groundState
         ∃ r : ℝ, 0 < r ∧
           w = r • (fun σ => (marshallSignS A σ.1).re * v σ)) := by
   obtain ⟨μ, v, hμ_lt, hv_pos, hmul⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
       (M := M) A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       h_intermediate
   refine ⟨μ, v, hμ_lt, hv_pos, hmul, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvector.lean
@@ -33,7 +33,7 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **Existence of a strictly positive eigenvector for the unshifted dressed-`Ĥ'` parity-block
 submatrix**, derived from PF on the shifted matrix. -/
-theorem dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists
+theorem dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_legacy
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvectorStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvectorStructural.lean
@@ -11,7 +11,7 @@ set_option linter.unusedVariables false
 Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 (#3887.5): Structural variant of (j.1)
-`dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists`
+`dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_legacy`
 that uses `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural`
 (#3887.4) instead of the h_intermediate-bearing original.
 
@@ -30,7 +30,7 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **(#3887.5) (j.1) structural variant: PF positive eigenvector for the un-shifted
 dressed-`Ĥ'` parity-block submatrix without `h_intermediate`**. -/
-theorem dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_structural
+theorem dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/MagSectorEmbedding.lean
+++ b/LatticeSystem/Quantum/SpinS/MagSectorEmbedding.lean
@@ -590,7 +590,7 @@ some real eigenvalue `μ < c`, supported entirely on the magnetization-
 with `v > 0` componentwise on the sector.
 
 Composition of:
-- `exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector`
+- `exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_legacy`
   (PR #860, complex sector existence).
 - `heisenbergHamiltonianS_mulVec_magSectorEmbedding`
   (this PR, sector → full lift).
@@ -598,7 +598,7 @@ Composition of:
 This is the COMPLEX-Hilbert-space form of Tasaki §2.5 Theorem 2.2 on
 the actual quantum Heisenberg Hamiltonian, lifted from the sector
 form (PRs #847–#865). -/
-theorem exists_marshallSign_eigenvector_heisenbergHamiltonianS_full
+theorem exists_marshallSign_eigenvector_heisenbergHamiltonianS_full_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -616,7 +616,7 @@ theorem exists_marshallSign_eigenvector_heisenbergHamiltonianS_full
         (magSectorEmbedding (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ))) =
         (μ : ℂ) • magSectorEmbedding (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) := by
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector
+    exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_legacy
       (M := M) A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       h_intermediate
   exact ⟨μ, v, hμ, hv_pos,
@@ -762,7 +762,7 @@ theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full
             (Ψ' τ.1).re = r * ((marshallSignS A τ.1).re * v τ)) := by
   -- Existence half (combining sector existence + lift).
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianS_full
+    exists_marshallSign_eigenvector_heisenbergHamiltonianS_full_legacy
       (M := M) A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       h_intermediate
   refine ⟨μ, v, hμ, hv_pos, hmul, ?_, ?_⟩
@@ -783,7 +783,7 @@ theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full
           (μ : ℂ) • (fun τ : magConfigS V N M =>
             (((marshallSignS A τ.1).re * v τ : ℝ) : ℂ)) := by
       -- This is exactly what `exists_marshallSign_complexEigenvector...` gave us.
-      have := exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector
+      have := exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_legacy
         (M := M) A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
         h_intermediate
       -- We need to show that the SAME (μ, v) witnesses also satisfy the sector

--- a/LatticeSystem/Quantum/SpinS/Theorem23IntervalCommonEnergy.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23IntervalCommonEnergy.lean
@@ -9,7 +9,7 @@ Issue #3542 (sound Perron–Frobenius route to Tasaki §2.5 Theorem 2.3), option
 
 For a connected bipartite antiferromagnetic coupling `J` the Marshall-positive
 Perron–Frobenius ground state of the dressed sector matrix exists in every magnetisation
-sector (`exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`).  In
+sector (`exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy`).  In
 every *admissible* sector `M ∈ tasaki23GroundStateSectors A N` that ground state carries
 the predicted total Casimir (#3731), and the adjacent-sector Casimir constancy (#3713)
 then forces equal energies between neighbouring admissible sectors.  Iterating along the
@@ -115,7 +115,7 @@ theorem tasaki23_common_energy_step
     hReEig_M
   -- Marshall-positive ground state in sector M + 1, with its full-space lift and Casimir.
   obtain ⟨μ', vM1, _hμ'_lt, hvM1_pos, hReEig_M1⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
       (M := M + 1) A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
   obtain ⟨hH_M1, hCas_M1⟩ := tasaki23_sector_lift_and_casimir A N c c_toy horient hsB hM1_mem
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy h_intermediate hvM1_pos
@@ -172,7 +172,7 @@ theorem tasaki23_common_groundEnergy
     magConfigS_nonempty_of_le_card_mul
       (le_trans (Nat.mul_le_mul_right N (min_le_max)) hmax_le)
   obtain ⟨μ, v₀, _hμ_lt, hv₀_pos, hReEig₀⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
       (M := min cardA cardB * N) A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       h_intermediate
   refine ⟨μ, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonEnergyStep.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonEnergyStep.lean
@@ -7,7 +7,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23PFConstancyCasimir
 
 (PR #3893): structural variant of `tasaki23_common_energy_step` (TIER 4 step) using
 - `tasaki23_sector_lift_and_casimir_structural` (Step 1)
-- `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural`
+- `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`
   (Thm23-#3887.9)
 - `tasaki23_pf_sector_energy_eq_of_casimir` (already h_intermediate-free)
 
@@ -57,7 +57,7 @@ theorem tasaki23_common_energy_step_structural
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy
     hA_ne hB_ne hN hvM_pos hReEig_M
   obtain ⟨μ', vM1, _hμ'_lt, hvM1_pos, hReEig_M1⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
       (N := N) (M := M + 1) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       hA_ne hB_ne hN
   obtain ⟨hH_M1, hCas_M1⟩ := tasaki23_sector_lift_and_casimir_structural

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonGroundEnergy.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonGroundEnergy.lean
@@ -6,7 +6,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralCommonEnergyStep
 
 (PR #3893): structural variant of `tasaki23_common_groundEnergy` (TIER 4 constancy)
 using
-- `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural`
+- `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`
   (Thm23-#3887.9 from PR #3891)
 - `tasaki23_common_energy_step_structural` (Step 2 of this PR)
 
@@ -51,7 +51,7 @@ theorem tasaki23_common_groundEnergy_structural
     magConfigS_nonempty_of_le_card_mul
       (le_trans (Nat.mul_le_mul_right N (min_le_max)) hmax_le)
   obtain ⟨μ, v₀, _hμ_lt, hv₀_pos, hReEig₀⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
       (N := N) (M := min cardA cardB * N) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       hA_ne hB_ne hN
   refine ⟨μ, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralComplexSectorEigenvec.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralComplexSectorEigenvec.lean
@@ -5,8 +5,8 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralMagSectorPF
 # Structural complex sector Marshall-positive eigenvector (no `h_intermediate`)
 
 (Thm23-#3887.12): structural variant of
-`exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector`
-wrapping `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural`
+`exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_legacy`
+wrapping `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`
 (Thm23-#3887.9).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -18,7 +18,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural complex sector Marshall-positive eigenvector (no `h_intermediate`)**. -/
-theorem exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_structural
+theorem exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -35,7 +35,7 @@ theorem exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMag
         (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) =
         (μ : ℂ) • (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) := by
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       hA_ne hB_ne hN
   exact ⟨μ, v, hμ, hv_pos,

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralFullHilbertEigenvec.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralFullHilbertEigenvec.lean
@@ -5,8 +5,8 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralComplexSectorEigenvec
 # Structural full-Hilbert-space Marshall eigenvector (no `h_intermediate`)
 
 (Thm23-#3887.13): structural variant of
-`exists_marshallSign_eigenvector_heisenbergHamiltonianS_full` lifting
-`exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_structural`
+`exists_marshallSign_eigenvector_heisenbergHamiltonianS_full_legacy` lifting
+`exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector`
 (Thm23-#3887.12) via `heisenbergHamiltonianS_mulVec_magSectorEmbedding`.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -18,7 +18,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural full-Hilbert-space Marshall ground-state existence (no `h_intermediate`)**. -/
-theorem exists_marshallSign_eigenvector_heisenbergHamiltonianS_full_structural
+theorem exists_marshallSign_eigenvector_heisenbergHamiltonianS_full
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -36,7 +36,7 @@ theorem exists_marshallSign_eigenvector_heisenbergHamiltonianS_full_structural
         (μ : ℂ) • magSectorEmbedding
           (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) := by
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_structural
+    exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       hA_ne hB_ne hN
   exact ⟨μ, v, hμ, hv_pos,

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralMLMFull.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralMLMFull.lean
@@ -11,7 +11,7 @@ set_option linter.unusedVariables false
 
 (Thm23-#3887.15): structural variant of
 `marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full` bundling
-- existence (Thm23-#3887.13 `exists_marshallSign_eigenvector_heisenbergHamiltonianS_full_structural`)
+- existence (Thm23-#3887.13 `exists_marshallSign_eigenvector_heisenbergHamiltonianS_full`)
 - support (zero outside sector — direct from `magSectorEmbedding_apply_of_not_mem`)
 - uniqueness (Thm23-#3887.14
   `marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector_structural`)
@@ -54,7 +54,7 @@ theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full_structu
           ∀ τ : magConfigS V N M,
             (Ψ' τ.1).re = r * ((marshallSignS A τ.1).re * v τ)) := by
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianS_full_structural
+    exists_marshallSign_eigenvector_heisenbergHamiltonianS_full
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       hA_ne hB_ne hN
   refine ⟨μ, v, hμ, hv_pos, hmul, ?_, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralMagSectorPF.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralMagSectorPF.lean
@@ -59,7 +59,7 @@ theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_struct
   exact dressedHeisenbergSReMatrixOnMagSector_mulVec_of_shifted_eigenvec A J N c hmul
 
 /-- **Structural Heisenberg sector Marshall-sign eigenvector (no `h_intermediate`)**. -/
-theorem exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural
+theorem exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralToyGSPredictedCasimirAt.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralToyGSPredictedCasimirAt.lean
@@ -11,7 +11,7 @@ set_option linter.unusedVariables false
 
 (Thm23-#3887.10): structural variant of
 `tasaki23_toy_groundState_casimir_eq_predicted_at` using
-- `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural` (Thm23-#3887.9)
+- `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector` (Thm23-#3887.9)
 - `tasaki23_toy_groundState_joint_casimir_eigenvector_structural` (Thm23-#3887.5)
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -40,7 +40,7 @@ theorem tasaki23_toy_groundState_casimir_eq_predicted_at_structural
           magSectorEmbedding (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) := by
   classical
   obtain ⟨μ, v, _hμ_lt_c, hv_pos, hReEig⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
       (N := N) (M := M) A c (bipartiteCoupling_im A)
       (fun x y hadj => by
         rw [bipartiteCompleteGraphOf_adj_iff] at hadj

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralToySectorLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralToySectorLowerBound.lean
@@ -9,7 +9,7 @@ import LatticeSystem.Quantum.SpinS.BipartiteToyMinEnergy
 # Structural toy sector energy lower bound (no `h_intermediate`)
 
 (Thm23-#3887.17): structural variant of `tasaki23_toy_sector_energy_ge_predicted`
-using `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural`
+using `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`
 (Thm23-#3887.9) and `tasaki23_toy_groundState_joint_casimir_eigenvector_structural`
 (Thm23-#3887.5).
 
@@ -37,7 +37,7 @@ theorem tasaki23_toy_sector_energy_ge_predicted_structural
     (bipartiteToyMinEnergyPredicted (Λ := V) A N).re ≤ μM := by
   classical
   obtain ⟨μGS, v, _hμGS_lt, hv_pos, hReEig⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_structural
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
       (N := N) (M := M) A c (bipartiteCoupling_im A)
       (fun x y hadj => by
         rw [bipartiteCompleteGraphOf_adj_iff] at hadj

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyGSPredictedCasimirAt.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyGSPredictedCasimirAt.lean
@@ -49,7 +49,7 @@ theorem tasaki23_toy_groundState_casimir_eq_predicted_at
   classical
   -- The Perron–Frobenius ground state of the bipartite toy Hamiltonian on sector M.
   obtain ⟨μ, v, _hμ_lt_c, hv_pos, hReEig⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
       (M := M) A N c (bipartiteCoupling_im A)
       (fun x y hadj => by
         rw [bipartiteCompleteGraphOf_adj_iff] at hadj

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToySectorEnergyLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToySectorEnergyLowerBound.lean
@@ -49,7 +49,7 @@ theorem tasaki23_toy_sector_energy_ge_predicted
   classical
   -- Marshall-positive Perron–Frobenius ground state of the toy matrix in sector M.
   obtain ⟨μGS, v, _hμGS_lt, hv_pos, hReEig⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
       (M := M) A N c (bipartiteCoupling_im A)
       (fun x y hadj => by
         rw [bipartiteCompleteGraphOf_adj_iff] at hadj

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyWitnessPredicted.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyWitnessPredicted.lean
@@ -13,7 +13,7 @@ Assembly (for `|¬A| ≤ |A|`, so the extremal sector is `M = min(|A|,|¬A|)·N 
 
 * The Perron–Frobenius ground state of the bipartite toy Hamiltonian on the sector
   `M` exists and is Marshall positive
-  (`exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`),
+  (`exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy`),
   giving `v > 0` with `Ĥ_re (sign·v) = μ (sign·v)`.
 * The predicted-energy sector eigenvector `φ` (#3710) sits at
   `E = predicted − s_A(s_A+1) − s_B(s_B+1)`; by Marshall positivity of the PF ground
@@ -66,7 +66,7 @@ theorem tasaki23_toy_groundState_casimir_eq_predicted
       (Finset.univ.filter (fun x : V => (! A x) = true)).card * N with hM
   -- The Perron–Frobenius ground state of the bipartite toy Hamiltonian on sector M.
   obtain ⟨μ, v, _hμ_lt_c, hv_pos, hReEig⟩ :=
-    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
+    exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
       (M := M) A N c (bipartiteCoupling_im A)
       (fun x y hadj => by
         rw [bipartiteCompleteGraphOf_adj_iff] at hadj


### PR DESCRIPTION
Tracked in #3921. Continues the Phase E batch 3 (#3928) pattern.

## Summary

5 more `_structural` symbols freed via the rename-only pattern:

| # | Symbol |
|--:|--|
| 1 | `axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf` |
| 2 | `dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists` |
| 3 | `exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector` |
| 4 | `exists_marshallSign_eigenvector_heisenbergHamiltonianS_full` |
| 5 | `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector` |

For each: twin `..._foo` → `..._foo_legacy`; structural `..._foo_structural` → `..._foo` (canonical).

## Stats

- 21 files modified, 47 lines changed.
- Remaining `_structural` collisions: ~30 (was 35).

## Build

3506 jobs, green.

## Test plan

- [x] `lake build` succeeds.
- [ ] CI green.