### PR TITLE
Refactor (Phase E, batch 5): rename 5 more twin pairs -- #3921

### DIFF
--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -252,7 +252,7 @@ For an over site `x` and under site `y` with `x ≠ y`, the intermediate-
 existence hypothesis `h_intermediate` guarantees a transport when
 `A x = A y` (only used in the hard case). The conclusion combines
 both cases as a `RaiseLowerReachableS` (which subsumes a single step). -/
-theorem exists_raiseLowerReachableS_bipartite_of_over_under
+theorem exists_raiseLowerReachableS_bipartite_of_over_under_legacy
     {A : V → Bool} {σ σ' : V → Fin (N + 1)}
     {x y : V} (hxy : x ≠ y)
     (hover : (σ' x).val < (σ x).val)
@@ -290,7 +290,7 @@ subspace with balanced sublattices, away from the "all-saturated"
 extreme).
 
 Proof: strong induction on `configDistS`, using
-`exists_raiseLowerReachableS_bipartite_of_over_under` (PR #821) at
+`exists_raiseLowerReachableS_bipartite_of_over_under_legacy` (PR #821) at
 each step (which combines the easy and hard cases). -/
 theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
     (A : V → Bool)
@@ -321,7 +321,7 @@ theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
       have hint : A x = A y → ∃ z, A z ≠ A x ∧ (σ z).val < N :=
         fun _ => h_intermediate σ x
       obtain ⟨σ_2, hreach, hreduce⟩ :=
-        exists_raiseLowerReachableS_bipartite_of_over_under
+        exists_raiseLowerReachableS_bipartite_of_over_under_legacy
           hxy hover hunder hint
       have hmag_2 : magSumS σ_2 = magSumS σ :=
         magSumS_eq_of_raiseLowerReachableS hreach

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphAltPath.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphAltPath.lean
@@ -10,7 +10,7 @@ set_option linter.unusedVariables false
 Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 This file provides the **alternative path** for the same-sublattice over/under
-case in `exists_raiseLowerReachableS_bipartite_of_over_under`. The original path
+case in `exists_raiseLowerReachableS_bipartite_of_over_under_legacy`. The original path
 (`exists_raiseLowerReachableS_bipartite_of_over_under_eq_sublattice`,
 `LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean:152`) requires
 `(σ z).val < N` (z raisable). The alternative requires `(σ z).val > 0` (z

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
@@ -10,7 +10,7 @@ import LatticeSystem.Quantum.SpinS.ParityReachableMagSum
 Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 This file provides the **structural** version of
-`exists_raiseLowerReachableS_bipartite_of_over_under` that drops `h_intermediate`
+`exists_raiseLowerReachableS_bipartite_of_over_under_legacy` that drops `h_intermediate`
 entirely. Instead, it branches on whether the opposite-color site `z` has
 `(σ z).val < N` (use original `_eq_sublattice`) or `(σ z).val > 0` (use
 `_eq_sublattice_alt`). At any `N ≥ 1`, at least one of these holds for every
@@ -40,7 +40,7 @@ the alternative path (uses `σ z > 0`), at least one of which is satisfied.
 
 In the easy case `A x ≠ A y`, falls through to the direct step (no `z` needed).
 In the hard case `A x = A y`, picks the path based on `σ z`. -/
-theorem exists_raiseLowerReachableS_bipartite_of_over_under_structural
+theorem exists_raiseLowerReachableS_bipartite_of_over_under
     [Fintype V] [DecidableEq V]
     {A : V → Bool} {σ σ' : V → Fin (N + 1)}
     {x y : V} (hxy : x ≠ y)
@@ -115,7 +115,7 @@ theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural
       have hOppExists : A x = A y → ∃ z, A z ≠ A x :=
         fun _ => oppExists_of_hA_hB A hA_ne hB_ne x
       obtain ⟨σ_2, hreach, hreduce⟩ :=
-        exists_raiseLowerReachableS_bipartite_of_over_under_structural
+        exists_raiseLowerReachableS_bipartite_of_over_under
           hxy hover hunder hOppExists hN
       have hmag_2 : magSumS σ_2 = magSumS σ :=
         magSumS_eq_of_raiseLowerReachableS hreach

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
@@ -109,7 +109,7 @@ input on the subtype). Composition of:
 - Sector matrix-pow lift from reachability (#843).
 - Sector matrix non-negativity (#834).
 - Sector matrix step positivity (#842). -/
-theorem exists_matrixPow_pos_of_magConfigS_bipartite
+theorem exists_matrixPow_pos_of_magConfigS_bipartite_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -135,7 +135,7 @@ theorem exists_matrixPow_pos_of_magConfigS_bipartite
 /-- **Strict positive-length matrix-power positivity** on the sector
 for distinct configurations: for σ ≠ σ' in the same sector, the
 matrix-power is positive at some k ≥ 1 (excluding the trivial k = 0). -/
-theorem exists_matrixPow_pos_length_of_magConfigS_bipartite
+theorem exists_matrixPow_pos_length_of_magConfigS_bipartite_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -149,7 +149,7 @@ theorem exists_matrixPow_pos_length_of_magConfigS_bipartite
     {σ σ' : magConfigS V N M} (hne : σ ≠ σ') :
     ∃ k : ℕ, 1 ≤ k ∧
       0 < (shiftedDressedSReMatrixOnMagSector A J N c M ^ k) σ' σ := by
-  obtain ⟨k, hpos⟩ := exists_matrixPow_pos_of_magConfigS_bipartite A N c
+  obtain ⟨k, hpos⟩ := exists_matrixPow_pos_of_magConfigS_bipartite_legacy A N c
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc h_intermediate σ σ'
   refine ⟨k, ?_, hpos⟩
   rcases Nat.eq_zero_or_pos k with hk0 | hkpos
@@ -195,7 +195,7 @@ theorem isIrreducible_shiftedDressedSReMatrixOnMagSector
     linarith [hc_strict σ.1]
   · -- Off-diagonal: use #845.
     obtain ⟨k, hk_pos, hpos⟩ :=
-      exists_matrixPow_pos_length_of_magConfigS_bipartite A N c hJ_real hJ_pos
+      exists_matrixPow_pos_length_of_magConfigS_bipartite_legacy A N c hJ_real hJ_pos
         hJ_nn hJ_sym hJ_bipartite (fun σ => le_of_lt (hc_strict σ))
         h_intermediate (Ne.symm hne)
     exact ⟨k, hk_pos, hpos⟩
@@ -211,7 +211,7 @@ and a strictly positive eigenvector `v > 0` (componentwise) with
 Direct corollary of `Matrix.IsIrreducible` (#846) +
 `exists_positive_eigenvector_of_irreducible` from the project's
 Perron–Frobenius infrastructure. -/
-theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector
+theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -344,7 +344,7 @@ eigenvalue `c - r < c` (where `r > 0` is the Perron eigenvalue of
 the shifted matrix).
 
 Combines #847 (existence) with #849 (eigenvalue conversion). -/
-theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
+theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -360,7 +360,7 @@ theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
       μ < c ∧ (∀ σ, 0 < v σ) ∧
       (dressedHeisenbergSReMatrixOnMagSector A J N M).mulVec v = μ • v := by
   obtain ⟨r, v, hr_pos, hv_pos, hmul⟩ :=
-    exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector
+    exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_legacy
       (M := M) A N c
       hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
   refine ⟨c - r, v, by linarith, hv_pos, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
@@ -190,7 +190,7 @@ Marshall-sign-conjugated vector
 is an eigenvector of the (un-dressed) Heisenberg sector matrix with the
 same eigenvalue `μ`.
 
-Combined with `exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector`
+Combined with `exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_legacy`
 (γ-3 dressed-form, #850) this gives the Heisenberg-form ground state
 on the magnetization sector with the Marshall sign structure. -/
 theorem heisenbergHamiltonianSReMatrixOnMagSector_mulVec_of_dressed_eigenvec
@@ -252,7 +252,7 @@ with eigenvalue `μ < c` and the Marshall sign structure
 `w τ = (marshallSignS A τ.1).re * (positive function of τ)`.
 
 Composition of:
-- `exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector`
+- `exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_legacy`
   (#850, γ-3 dressed-form): ∃ μ < c, ∃ v > 0, dressed_sec.mulVec v = μ • v.
 - `heisenbergHamiltonianSReMatrixOnMagSector_mulVec_of_dressed_eigenvec`
   (Marshall-conjugation, this PR).
@@ -279,7 +279,7 @@ theorem exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSecto
         (fun σ => (marshallSignS A σ.1).re * v σ) =
         μ • (fun σ => (marshallSignS A σ.1).re * v σ) := by
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
+    exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_legacy
       (M := M) A N c
       hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
   exact ⟨μ, v, hμ, hv_pos,

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralMagSectorPF.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralMagSectorPF.lean
@@ -19,7 +19,7 @@ open LatticeSystem.Math.PerronFrobeniusMain
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural shifted-dressed sector PF positive eigenvector (no `h_intermediate`)**. -/
-theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_structural
+theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -39,7 +39,7 @@ theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_structura
   exact LatticeSystem.Math.PerronFrobeniusMain.exists_positive_eigenvector_of_irreducible hIrred
 
 /-- **Structural dressed Heisenberg sector PF positive eigenvector (no `h_intermediate`)**. -/
-theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_structural
+theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -53,7 +53,7 @@ theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_struct
       μ < c ∧ (∀ σ, 0 < v σ) ∧
       (dressedHeisenbergSReMatrixOnMagSector A J N M).mulVec v = μ • v := by
   obtain ⟨r, v, hr_pos, hv_pos, hmul⟩ :=
-    exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_structural
+    exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN
   refine ⟨c - r, v, by linarith, hv_pos, ?_⟩
   exact dressedHeisenbergSReMatrixOnMagSector_mulVec_of_shifted_eigenvec A J N c hmul
@@ -75,7 +75,7 @@ theorem exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSecto
         (fun σ => (marshallSignS A σ.1).re * v σ) =
         μ • (fun σ => (marshallSignS A σ.1).re * v σ) := by
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_structural
+    exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN
   exact ⟨μ, v, hμ, hv_pos,
     heisenbergHamiltonianSReMatrixOnMagSector_mulVec_of_dressed_eigenvec

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
@@ -36,7 +36,7 @@ theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph_structural
   exact raiseLowerReachableSMagSector_of_raiseLowerReachableS σ.2 σ'.2 hreach
 
 /-- **Structural matrix-power positivity (no `h_intermediate`)**. -/
-theorem exists_matrixPow_pos_of_magConfigS_bipartite_structural
+theorem exists_matrixPow_pos_of_magConfigS_bipartite
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -59,7 +59,7 @@ theorem exists_matrixPow_pos_of_magConfigS_bipartite_structural
       hA_ne hB_ne hN σ σ'
 
 /-- **Structural strict-positive-length matrix-power positivity**. -/
-theorem exists_matrixPow_pos_length_of_magConfigS_bipartite_structural
+theorem exists_matrixPow_pos_length_of_magConfigS_bipartite
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -72,7 +72,7 @@ theorem exists_matrixPow_pos_length_of_magConfigS_bipartite_structural
     {σ σ' : magConfigS V N M} (hne : σ ≠ σ') :
     ∃ k : ℕ, 1 ≤ k ∧
       0 < (shiftedDressedSReMatrixOnMagSector A J N c M ^ k) σ' σ := by
-  obtain ⟨k, hpos⟩ := exists_matrixPow_pos_of_magConfigS_bipartite_structural A c
+  obtain ⟨k, hpos⟩ := exists_matrixPow_pos_of_magConfigS_bipartite A c
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc hA_ne hB_ne hN σ σ'
   refine ⟨k, ?_, hpos⟩
   rcases Nat.eq_zero_or_pos k with hk0 | hkpos
@@ -104,7 +104,7 @@ theorem isIrreducible_shiftedDressedSReMatrixOnMagSector_structural
       shiftedDressedSReMatrix_apply_diag]
     linarith [hc_strict σ.1]
   · obtain ⟨k, hk_pos, hpos⟩ :=
-      exists_matrixPow_pos_length_of_magConfigS_bipartite_structural A c hJ_real hJ_pos
+      exists_matrixPow_pos_length_of_magConfigS_bipartite A c hJ_real hJ_pos
         hJ_nn hJ_sym hJ_bipartite (fun σ => le_of_lt (hc_strict σ))
         hA_ne hB_ne hN (Ne.symm hne)
     exact ⟨k, hk_pos, hpos⟩

--- a/LatticeSystem/Tests/SpinSBipartiteCompleteGraph.lean
+++ b/LatticeSystem/Tests/SpinSBipartiteCompleteGraph.lean
@@ -77,7 +77,7 @@ example {N : ℕ} [Fintype V] [DecidableEq V] {A : V → Bool}
     ∃ σ'' : V → Fin (N + 1),
       RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ σ'' ∧
         configDistS σ'' σ' + 2 = configDistS σ σ' :=
-  exists_raiseLowerReachableS_bipartite_of_over_under_structural
+  exists_raiseLowerReachableS_bipartite_of_over_under
     hxy hover hunder hOppExists hN
 
 /-- Bipartite reachability for equal-magnetization configurations


### PR DESCRIPTION
Tracked in #3921. Continues batch 4 (#3929) pattern. 5 more twin pairs renamed (twin→_legacy, structural→canonical). 8 files / 26 lines. Build green.