### PR TITLE
Refactor (Phase E, batch 6): rename 5 more twin pairs -- #3921

### DIFF
--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -252,7 +252,7 @@ For an over site `x` and under site `y` with `x ≠ y`, the intermediate-
 existence hypothesis `h_intermediate` guarantees a transport when
 `A x = A y` (only used in the hard case). The conclusion combines
 both cases as a `RaiseLowerReachableS` (which subsumes a single step). -/
-theorem exists_raiseLowerReachableS_bipartite_of_over_under
+theorem exists_raiseLowerReachableS_bipartite_of_over_under_legacy
     {A : V → Bool} {σ σ' : V → Fin (N + 1)}
     {x y : V} (hxy : x ≠ y)
     (hover : (σ' x).val < (σ x).val)
@@ -290,7 +290,7 @@ subspace with balanced sublattices, away from the "all-saturated"
 extreme).
 
 Proof: strong induction on `configDistS`, using
-`exists_raiseLowerReachableS_bipartite_of_over_under` (PR #821) at
+`exists_raiseLowerReachableS_bipartite_of_over_under_legacy` (PR #821) at
 each step (which combines the easy and hard cases). -/
 theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
     (A : V → Bool)
@@ -321,7 +321,7 @@ theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
       have hint : A x = A y → ∃ z, A z ≠ A x ∧ (σ z).val < N :=
         fun _ => h_intermediate σ x
       obtain ⟨σ_2, hreach, hreduce⟩ :=
-        exists_raiseLowerReachableS_bipartite_of_over_under
+        exists_raiseLowerReachableS_bipartite_of_over_under_legacy
           hxy hover hunder hint
       have hmag_2 : magSumS σ_2 = magSumS σ :=
         magSumS_eq_of_raiseLowerReachableS hreach

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphAltPath.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphAltPath.lean
@@ -10,7 +10,7 @@ set_option linter.unusedVariables false
 Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 This file provides the **alternative path** for the same-sublattice over/under
-case in `exists_raiseLowerReachableS_bipartite_of_over_under`. The original path
+case in `exists_raiseLowerReachableS_bipartite_of_over_under_legacy`. The original path
 (`exists_raiseLowerReachableS_bipartite_of_over_under_eq_sublattice`,
 `LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean:152`) requires
 `(σ z).val < N` (z raisable). The alternative requires `(σ z).val > 0` (z

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
@@ -131,7 +131,7 @@ set_option linter.unusedDecidableInType false in
 /-- **Structural `ParityReachableS` totality (no `h_intermediate`)**: any two
 configurations of the same total-magnetization parity are connected, using only
 `hA_ne + hB_ne + 1 ≤ N`. -/
-theorem parityReachableS_total_structural
+theorem parityReachableS_total
     [Fintype V] [DecidableEq V]
     (A : V → Bool)
     (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false)

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
@@ -10,7 +10,7 @@ import LatticeSystem.Quantum.SpinS.ParityReachableMagSum
 Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 This file provides the **structural** version of
-`exists_raiseLowerReachableS_bipartite_of_over_under` that drops `h_intermediate`
+`exists_raiseLowerReachableS_bipartite_of_over_under_legacy` that drops `h_intermediate`
 entirely. Instead, it branches on whether the opposite-color site `z` has
 `(σ z).val < N` (use original `_eq_sublattice`) or `(σ z).val > 0` (use
 `_eq_sublattice_alt`). At any `N ≥ 1`, at least one of these holds for every
@@ -40,7 +40,7 @@ the alternative path (uses `σ z > 0`), at least one of which is satisfied.
 
 In the easy case `A x ≠ A y`, falls through to the direct step (no `z` needed).
 In the hard case `A x = A y`, picks the path based on `σ z`. -/
-theorem exists_raiseLowerReachableS_bipartite_of_over_under_structural
+theorem exists_raiseLowerReachableS_bipartite_of_over_under
     [Fintype V] [DecidableEq V]
     {A : V → Bool} {σ σ' : V → Fin (N + 1)}
     {x y : V} (hxy : x ≠ y)
@@ -115,7 +115,7 @@ theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural
       have hOppExists : A x = A y → ∃ z, A z ≠ A x :=
         fun _ => oppExists_of_hA_hB A hA_ne hB_ne x
       obtain ⟨σ_2, hreach, hreduce⟩ :=
-        exists_raiseLowerReachableS_bipartite_of_over_under_structural
+        exists_raiseLowerReachableS_bipartite_of_over_under
           hxy hover hunder hOppExists hN
       have hmag_2 : magSumS σ_2 = magSumS σ :=
         magSumS_eq_of_raiseLowerReachableS hreach

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleStructural.lean
@@ -8,7 +8,7 @@ Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 (#3887.4): Structural variant of
 `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible` that uses
-`parityReachableS_total_structural` (#3887.3) instead of `parityReachableS_total`.
+`parityReachableS_total` (#3887.3) instead of `parityReachableS_total_legacy`.
 
 Drops `h_intermediate`; requires `hA_ne + hB_ne + 1 ≤ N` instead. The result is
 identical in conclusion — irreducibility of the shifted parity-block matrix —
@@ -42,7 +42,7 @@ theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural
   refine shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_parityReachable_total
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict p ?_
   intro σ' σ _hne
-  refine parityReachableS_total_structural A hA_ne hB_ne hN ?_
+  refine parityReachableS_total A hA_ne hB_ne hN ?_
   -- magSumS σ.1 % 2 = p = magSumS σ'.1 % 2 from parityConfigS membership.
   have hp_σ : magSumS σ.1 % 2 = p := σ.2
   have hp_σ' : magSumS σ'.1 % 2 = p := σ'.2

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
@@ -8,7 +8,7 @@ Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
 
 Discharges the `hreach_total` reachability-totality hypothesis of
 `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_parityReachable_total`
-(#3797) using `parityReachableS_total` (#3823): any two same-parity configurations on the
+(#3797) using `parityReachableS_total_legacy` (#3823): any two same-parity configurations on the
 bipartite complete graph are `ParityReachableS`-connected.
 
 This closes **(e) PR5** of Tasaki §2.5 Theorem 2.4 obligation (1): the parity-block shifted PF
@@ -26,7 +26,7 @@ open Matrix
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **Parity-block shifted PF matrix is irreducible** (unconditional under case (i.2) strict).
-Discharges the totality hypothesis of #3797 via #3823 `parityReachableS_total`. -/
+Discharges the totality hypothesis of #3797 via #3823 `parityReachableS_total_legacy`. -/
 theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
@@ -46,7 +46,7 @@ theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
   refine shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_parityReachable_total
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict p ?_
   intro σ' σ _hne
-  refine parityReachableS_total A hA_ne hB_ne h_intermediate ?_
+  refine parityReachableS_total_legacy A hA_ne hB_ne h_intermediate ?_
   -- magSumS σ.1 % 2 = p = magSumS σ'.1 % 2 from parityConfigS membership.
   have hp_σ : magSumS σ.1 % 2 = p := σ.2
   have hp_σ' : magSumS σ'.1 % 2 = p := σ'.2

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
@@ -109,7 +109,7 @@ input on the subtype). Composition of:
 - Sector matrix-pow lift from reachability (#843).
 - Sector matrix non-negativity (#834).
 - Sector matrix step positivity (#842). -/
-theorem exists_matrixPow_pos_of_magConfigS_bipartite
+theorem exists_matrixPow_pos_of_magConfigS_bipartite_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -135,7 +135,7 @@ theorem exists_matrixPow_pos_of_magConfigS_bipartite
 /-- **Strict positive-length matrix-power positivity** on the sector
 for distinct configurations: for σ ≠ σ' in the same sector, the
 matrix-power is positive at some k ≥ 1 (excluding the trivial k = 0). -/
-theorem exists_matrixPow_pos_length_of_magConfigS_bipartite
+theorem exists_matrixPow_pos_length_of_magConfigS_bipartite_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -149,7 +149,7 @@ theorem exists_matrixPow_pos_length_of_magConfigS_bipartite
     {σ σ' : magConfigS V N M} (hne : σ ≠ σ') :
     ∃ k : ℕ, 1 ≤ k ∧
       0 < (shiftedDressedSReMatrixOnMagSector A J N c M ^ k) σ' σ := by
-  obtain ⟨k, hpos⟩ := exists_matrixPow_pos_of_magConfigS_bipartite A N c
+  obtain ⟨k, hpos⟩ := exists_matrixPow_pos_of_magConfigS_bipartite_legacy A N c
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc h_intermediate σ σ'
   refine ⟨k, ?_, hpos⟩
   rcases Nat.eq_zero_or_pos k with hk0 | hkpos
@@ -195,7 +195,7 @@ theorem isIrreducible_shiftedDressedSReMatrixOnMagSector
     linarith [hc_strict σ.1]
   · -- Off-diagonal: use #845.
     obtain ⟨k, hk_pos, hpos⟩ :=
-      exists_matrixPow_pos_length_of_magConfigS_bipartite A N c hJ_real hJ_pos
+      exists_matrixPow_pos_length_of_magConfigS_bipartite_legacy A N c hJ_real hJ_pos
         hJ_nn hJ_sym hJ_bipartite (fun σ => le_of_lt (hc_strict σ))
         h_intermediate (Ne.symm hne)
     exact ⟨k, hk_pos, hpos⟩
@@ -211,7 +211,7 @@ and a strictly positive eigenvector `v > 0` (componentwise) with
 Direct corollary of `Matrix.IsIrreducible` (#846) +
 `exists_positive_eigenvector_of_irreducible` from the project's
 Perron–Frobenius infrastructure. -/
-theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector
+theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -344,7 +344,7 @@ eigenvalue `c - r < c` (where `r > 0` is the Perron eigenvalue of
 the shifted matrix).
 
 Combines #847 (existence) with #849 (eigenvalue conversion). -/
-theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
+theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -360,7 +360,7 @@ theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
       μ < c ∧ (∀ σ, 0 < v σ) ∧
       (dressedHeisenbergSReMatrixOnMagSector A J N M).mulVec v = μ • v := by
   obtain ⟨r, v, hr_pos, hv_pos, hmul⟩ :=
-    exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector
+    exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_legacy
       (M := M) A N c
       hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
   refine ⟨c - r, v, by linarith, hv_pos, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
@@ -170,7 +170,7 @@ Proof: combines the matrix-power positivity for distinct σ ≠ σ'
 (#845) with the diagonal positivity (`M σ σ = c - dressed σ σ > 0`
 when `c > dressed σ σ`) via the
 `Matrix.isIrreducible_iff_exists_pow_pos` characterization. -/
-theorem isIrreducible_shiftedDressedSReMatrixOnMagSector
+theorem isIrreducible_shiftedDressedSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -227,7 +227,7 @@ theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_legacy
       0 < r ∧ (∀ σ, 0 < v σ) ∧
       (shiftedDressedSReMatrixOnMagSector A J N c M).mulVec v = r • v :=
   LatticeSystem.Math.PerronFrobeniusMain.exists_positive_eigenvector_of_irreducible
-    (isIrreducible_shiftedDressedSReMatrixOnMagSector A N c hJ_real hJ_pos
+    (isIrreducible_shiftedDressedSReMatrixOnMagSector_legacy A N c hJ_real hJ_pos
       hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate)
 
 /-- **Uniqueness of the spin-S Perron eigenvector** (γ-3 FINAL): for the
@@ -259,7 +259,7 @@ theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector
     (hw_pos : ∀ σ, 0 < w σ) :
     ∃ r : ℝ, 0 < r ∧ w = r • v :=
   LatticeSystem.Math.PerronFrobenius.pos_eigenvec_unique
-    (isIrreducible_shiftedDressedSReMatrixOnMagSector A N c hJ_real hJ_pos
+    (isIrreducible_shiftedDressedSReMatrixOnMagSector_legacy A N c hJ_real hJ_pos
       hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate)
     hv hv_pos hw hw_pos
 

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorEigenvalueUnique.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorEigenvalueUnique.lean
@@ -421,7 +421,7 @@ and their real parts are positive scalar multiples of each other.
 
 Proof: extract real parts via PR #861 to reduce to the real-form
 Marshall-positive uniqueness theorems (PRs #854, #856). -/
-theorem marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector
+theorem marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -458,7 +458,7 @@ theorem marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixO
   subst hμ_eq
   -- Same-eigenvalue eigenvector uniqueness on heis_sec.
   obtain ⟨r, hr_pos, hrel⟩ :=
-    marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector
+    marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector_legacy
       A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
       hW₁_re hW₁_marshall_pos hW₂_re hW₂_marshall_pos
   exact ⟨r, hr_pos, fun σ => congrFun hrel σ⟩
@@ -510,7 +510,7 @@ theorem marshallLiebMattis_spinS_heisenbergSector_complexGroundState_full
     rw [← mul_assoc, hsq, one_mul]
     exact hv_pos σ
   obtain ⟨hμ_eq, r, hr_pos, hrel⟩ :=
-    marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector
+    marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector_legacy
       A N c hJ_real hJ_real' hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       h_intermediate hmul hΦ_marshall_pos hW hW_marshall_pos
   refine ⟨hμ_eq.symm, r, hr_pos, fun σ => ?_⟩

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
@@ -414,7 +414,7 @@ Reduction: by inverse Marshall conjugation, the conjugates `vᵢ := sign · wᵢ
 are positive eigenvectors of the dressed sector matrix at `μ`. By dressed
 sector uniqueness (this PR) `v₂ = r • v₁` for some `r > 0`. Multiplying
 both sides by `sign` (which squares to 1) gives `w₂ = r • w₁`. -/
-theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector
+theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -483,7 +483,7 @@ scalar multiple of it.
 Bundles the existence theorem
 (`exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy`,
 PR #853) with the same-eigenvalue uniqueness theorem
-(`marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector`,
+(`marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector_legacy`,
 PR #854) into the form most directly usable downstream. -/
 theorem marshallLiebMattis_spinS_heisenbergSector_groundState
     (A : V → Bool)
@@ -520,7 +520,7 @@ theorem marshallLiebMattis_spinS_heisenbergSector_groundState
       marshallSignS_re_sq A σ.1
     rw [← mul_assoc, hsq, one_mul]
     exact hv_pos σ
-  exact marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector
+  exact marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector_legacy
     A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
     hmul hsign_v_pos hw hw_pos
 

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
@@ -190,7 +190,7 @@ Marshall-sign-conjugated vector
 is an eigenvector of the (un-dressed) Heisenberg sector matrix with the
 same eigenvalue `μ`.
 
-Combined with `exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector`
+Combined with `exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_legacy`
 (γ-3 dressed-form, #850) this gives the Heisenberg-form ground state
 on the magnetization sector with the Marshall sign structure. -/
 theorem heisenbergHamiltonianSReMatrixOnMagSector_mulVec_of_dressed_eigenvec
@@ -252,7 +252,7 @@ with eigenvalue `μ < c` and the Marshall sign structure
 `w τ = (marshallSignS A τ.1).re * (positive function of τ)`.
 
 Composition of:
-- `exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector`
+- `exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_legacy`
   (#850, γ-3 dressed-form): ∃ μ < c, ∃ v > 0, dressed_sec.mulVec v = μ • v.
 - `heisenbergHamiltonianSReMatrixOnMagSector_mulVec_of_dressed_eigenvec`
   (Marshall-conjugation, this PR).
@@ -279,7 +279,7 @@ theorem exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSecto
         (fun σ => (marshallSignS A σ.1).re * v σ) =
         μ • (fun σ => (marshallSignS A σ.1).re * v σ) := by
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
+    exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_legacy
       (M := M) A N c
       hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
   exact ⟨μ, v, hμ, hv_pos,

--- a/LatticeSystem/Quantum/SpinS/MagSectorEmbedding.lean
+++ b/LatticeSystem/Quantum/SpinS/MagSectorEmbedding.lean
@@ -733,7 +733,7 @@ the §2.5 ground state on the actual quantum Heisenberg Hamiltonian.
 This is the COMPLEX-Hilbert-space form of Tasaki §2.5 Theorem 2.2 on
 the actual quantum Heisenberg Hamiltonian, lifted from the magnetization
 sector form (PRs #847–#865). -/
-theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full
+theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -805,7 +805,7 @@ theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full
       rw [Pi.smul_apply, magSectorEmbedding_apply_subtype, smul_eq_mul]
     -- Apply complex sector uniqueness (#862).
     obtain ⟨hμ_eq, r, hr_pos, hrel⟩ :=
-      marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector
+      marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector_legacy
         A N c hJ_real hJ_real' hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
         h_intermediate hsec_ground (by
           intro τ

--- a/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
@@ -28,7 +28,7 @@ open Module Matrix
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **Parity-block Perron eigenspace `finrank ≤ 1`**: under case (i.2) strict (plus the
-intermediate-site and sublattice non-emptyness hypotheses needed by `parityReachableS_total`),
+intermediate-site and sublattice non-emptyness hypotheses needed by `parityReachableS_total_legacy`),
 the Perron eigenspace of the shifted parity-block PF matrix is at most one-dimensional. -/
 theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_perron_eigenspace_finrank_le_one
     (A : Λ → Bool) {J : Λ → Λ → ℂ}

--- a/LatticeSystem/Quantum/SpinS/ParityReachToMinMagSum.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachToMinMagSum.lean
@@ -10,7 +10,7 @@ every configuration reaches some `σ_min` with `magSumS σ_min < 2` — i.e. eit
 config (for even parity) or a single-1-site config (for odd parity).
 
 Combined with the within-sector reachability lift (#3817) and `ParityReachableS` symmetry
-(#3816), this is the penultimate step before the full `parityReachableS_total` discharging the
+(#3816), this is the penultimate step before the full `parityReachableS_total_legacy` discharging the
 parity-block matrix irreducibility theorem (#3797).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,

--- a/LatticeSystem/Quantum/SpinS/ParityReachTotal.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachTotal.lean
@@ -8,7 +8,7 @@ import LatticeSystem.Quantum.SpinS.ParityReachableMagSum
 
 Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
 
-`parityReachableS_total`: for any two configurations sharing the same total-magnetization parity
+`parityReachableS_total_legacy`: for any two configurations sharing the same total-magnetization parity
 (`magSumS σ ≡ magSumS σ' (mod 2)`), `ParityReachableS` connects them.
 
 This closes the (d.3) reachability totality plan by chaining:
@@ -37,7 +37,7 @@ set_option linter.unusedDecidableInType false in
 /-- **`ParityReachableS` totality on the bipartite complete graph**: any two configurations of
 the same total-magnetization parity are `ParityReachableS`-connected.  Discharges the
 `hreach_total` hypothesis of the parity-block matrix irreducibility theorem #3797. -/
-theorem parityReachableS_total
+theorem parityReachableS_total_legacy
     (A : V → Bool)
     (hA_ne : ∃ a, A a = true)
     (hB_ne : ∃ b, A b = false)

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
@@ -56,7 +56,7 @@ theorem tasaki23_shiftedDressed_sector_eigenvec_proportional
     (hw : (shiftedDressedSReMatrixOnMagSector A J N c M).mulVec w = r • w) :
     ∃ s : ℝ, w = s • v :=
   eigenvec_proportional_of_pos_eigenvec
-    (isIrreducible_shiftedDressedSReMatrixOnMagSector A N c hJ_real hJ_pos
+    (isIrreducible_shiftedDressedSReMatrixOnMagSector_legacy A N c hJ_real hJ_pos
       hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate)
     hv hv_pos hw
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23SectorExistence.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23SectorExistence.lean
@@ -21,7 +21,7 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 statement** as a `Prop`.
 
 The hypothesis bundle matches the per-sector bundled Theorem 2.2
-`marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full`
+`marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full_legacy`
 (PR #869) exactly. Given:
 - real symmetric coupling `J` (`(J x y).im = 0`, `star (J x y) = J x y`,
   `J x y = J y x`, `0 ≤ (J x y).re`);

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralCasimirEigenvec.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralCasimirEigenvec.lean
@@ -6,7 +6,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralReach
 
 Extension of #3887 fix to `tasaki23_shiftedDressed_sector_eigenvec_proportional` /
 `tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive` via
-`isIrreducible_shiftedDressedSReMatrixOnMagSector_structural`.
+`isIrreducible_shiftedDressedSReMatrixOnMagSector`.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
 Springer 2020, §2.5 Theorem 2.3, p. 42.
@@ -35,7 +35,7 @@ theorem tasaki23_shiftedDressed_sector_eigenvec_proportional_structural
     (hw : (shiftedDressedSReMatrixOnMagSector A J N c M).mulVec w = r • w) :
     ∃ s : ℝ, w = s • v :=
   eigenvec_proportional_of_pos_eigenvec
-    (isIrreducible_shiftedDressedSReMatrixOnMagSector_structural A c hJ_real hJ_pos
+    (isIrreducible_shiftedDressedSReMatrixOnMagSector A c hJ_real hJ_pos
       hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN)
     hv hv_pos hw
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralMLMFull.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralMLMFull.lean
@@ -10,11 +10,11 @@ set_option linter.unusedVariables false
 # Structural Tasaki §2.5 Theorem 2.2 bundled full-Hilbert form (no `h_intermediate`)
 
 (Thm23-#3887.15): structural variant of
-`marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full` bundling
+`marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full_legacy` bundling
 - existence (Thm23-#3887.13 `exists_marshallSign_eigenvector_heisenbergHamiltonianS_full`)
 - support (zero outside sector — direct from `magSectorEmbedding_apply_of_not_mem`)
 - uniqueness (Thm23-#3887.14
-  `marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector_structural`)
+  `marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector`)
 into the textbook statement of the §2.5 Theorem 2.2 ground state on the actual quantum
 Heisenberg Hamiltonian, with `(hA_ne, hB_ne, hN)` instead of `h_intermediate`.
 
@@ -27,7 +27,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural Tasaki §2.5 Theorem 2.2 bundled (no `h_intermediate`)**. -/
-theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full_structural
+theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -82,7 +82,7 @@ theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full_structu
         (μ : ℂ) * (((marshallSignS A τ.1).re * v τ : ℝ) : ℂ)
       rw [Pi.smul_apply, magSectorEmbedding_apply_subtype, smul_eq_mul]
     obtain ⟨hμ_eq, r, hr_pos, hrel⟩ :=
-      marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector_structural
+      marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector
         (N := N) (M := M) A c hJ_real hJ_real' hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
         hA_ne hB_ne hN hsec_ground (by
           intro τ

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralMagSectorPF.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralMagSectorPF.lean
@@ -19,7 +19,7 @@ open LatticeSystem.Math.PerronFrobeniusMain
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural shifted-dressed sector PF positive eigenvector (no `h_intermediate`)**. -/
-theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_structural
+theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -39,7 +39,7 @@ theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_structura
   exact LatticeSystem.Math.PerronFrobeniusMain.exists_positive_eigenvector_of_irreducible hIrred
 
 /-- **Structural dressed Heisenberg sector PF positive eigenvector (no `h_intermediate`)**. -/
-theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_structural
+theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -53,7 +53,7 @@ theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_struct
       μ < c ∧ (∀ σ, 0 < v σ) ∧
       (dressedHeisenbergSReMatrixOnMagSector A J N M).mulVec v = μ • v := by
   obtain ⟨r, v, hr_pos, hv_pos, hmul⟩ :=
-    exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_structural
+    exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN
   refine ⟨c - r, v, by linarith, hv_pos, ?_⟩
   exact dressedHeisenbergSReMatrixOnMagSector_mulVec_of_shifted_eigenvec A J N c hmul
@@ -75,7 +75,7 @@ theorem exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSecto
         (fun σ => (marshallSignS A σ.1).re * v σ) =
         μ • (fun σ => (marshallSignS A σ.1).re * v σ) := by
   obtain ⟨μ, v, hμ, hv_pos, hmul⟩ :=
-    exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_structural
+    exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN
   exact ⟨μ, v, hμ, hv_pos,
     heisenbergHamiltonianSReMatrixOnMagSector_mulVec_of_dressed_eigenvec

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralMagSectorPF.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralMagSectorPF.lean
@@ -5,7 +5,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralReach
 # Structural sector PF positive eigenvector wrappers (no `h_intermediate`)
 
 (Thm23-#3887.9): structural variants of the sector PF positive-eigenvector
-existence theorems using `isIrreducible_shiftedDressedSReMatrixOnMagSector_structural`
+existence theorems using `isIrreducible_shiftedDressedSReMatrixOnMagSector`
 (Thm23-#3887.1).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -33,7 +33,7 @@ theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector
       0 < r ∧ (∀ σ, 0 < v σ) ∧
       (shiftedDressedSReMatrixOnMagSector A J N c M).mulVec v = r • v := by
   have hIrred : (shiftedDressedSReMatrixOnMagSector A J N c M).IsIrreducible :=
-    isIrreducible_shiftedDressedSReMatrixOnMagSector_structural (N := N) (M := M)
+    isIrreducible_shiftedDressedSReMatrixOnMagSector (N := N) (M := M)
       A c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN
   exact LatticeSystem.Math.PerronFrobeniusMain.exists_positive_eigenvector_of_irreducible hIrred

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
@@ -36,7 +36,7 @@ theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph_structural
   exact raiseLowerReachableSMagSector_of_raiseLowerReachableS σ.2 σ'.2 hreach
 
 /-- **Structural matrix-power positivity (no `h_intermediate`)**. -/
-theorem exists_matrixPow_pos_of_magConfigS_bipartite_structural
+theorem exists_matrixPow_pos_of_magConfigS_bipartite
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -59,7 +59,7 @@ theorem exists_matrixPow_pos_of_magConfigS_bipartite_structural
       hA_ne hB_ne hN σ σ'
 
 /-- **Structural strict-positive-length matrix-power positivity**. -/
-theorem exists_matrixPow_pos_length_of_magConfigS_bipartite_structural
+theorem exists_matrixPow_pos_length_of_magConfigS_bipartite
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -72,7 +72,7 @@ theorem exists_matrixPow_pos_length_of_magConfigS_bipartite_structural
     {σ σ' : magConfigS V N M} (hne : σ ≠ σ') :
     ∃ k : ℕ, 1 ≤ k ∧
       0 < (shiftedDressedSReMatrixOnMagSector A J N c M ^ k) σ' σ := by
-  obtain ⟨k, hpos⟩ := exists_matrixPow_pos_of_magConfigS_bipartite_structural A c
+  obtain ⟨k, hpos⟩ := exists_matrixPow_pos_of_magConfigS_bipartite A c
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc hA_ne hB_ne hN σ σ'
   refine ⟨k, ?_, hpos⟩
   rcases Nat.eq_zero_or_pos k with hk0 | hkpos
@@ -104,7 +104,7 @@ theorem isIrreducible_shiftedDressedSReMatrixOnMagSector_structural
       shiftedDressedSReMatrix_apply_diag]
     linarith [hc_strict σ.1]
   · obtain ⟨k, hk_pos, hpos⟩ :=
-      exists_matrixPow_pos_length_of_magConfigS_bipartite_structural A c hJ_real hJ_pos
+      exists_matrixPow_pos_length_of_magConfigS_bipartite A c hJ_real hJ_pos
         hJ_nn hJ_sym hJ_bipartite (fun σ => le_of_lt (hc_strict σ))
         hA_ne hB_ne hN (Ne.symm hne)
     exact ⟨k, hk_pos, hpos⟩

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
@@ -82,7 +82,7 @@ theorem exists_matrixPow_pos_length_of_magConfigS_bipartite
   · exact hkpos
 
 /-- **Structural sector-irreducibility (no `h_intermediate`)**. -/
-theorem isIrreducible_shiftedDressedSReMatrixOnMagSector_structural
+theorem isIrreducible_shiftedDressedSReMatrixOnMagSector
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     (hJ_real : ∀ x y, (J x y).im = 0)

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorExistence.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorExistence.lean
@@ -8,7 +8,7 @@ set_option linter.unusedVariables false
 # Structural Tasaki §2.5 Theorem 2.3 sector-existence wrapper (no `h_intermediate`)
 
 (Thm23-#3887.16): structural variant of `tasaki_2_5_theorem_2_3_sector_existence`
-wrapping `marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full_structural`
+wrapping `marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full`
 (Thm23-#3887.15).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -46,7 +46,7 @@ theorem tasaki_2_5_theorem_2_3_sector_existence
         μ' = μ ∧ ∃ r : ℝ, 0 < r ∧
           ∀ τ : magConfigS V N M,
             (Ψ' τ.1).re = r * ((marshallSignS A τ.1).re * v τ)) :=
-  marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full_structural
+  marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full
     (N := N) (M := M) A c hJ_real hJ_real' hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
     hA_ne hB_ne hN
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralUniqueness.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralUniqueness.lean
@@ -11,13 +11,13 @@ set_option linter.unusedVariables false
 (Thm23-#3887.14): structural variants of the Marshall-positive sector eigenvector
 uniqueness chain, swapping `pos_eigenvec_unique` at the bottom from the
 `h_intermediate`-dependent irreducibility to the structural irreducibility
-`isIrreducible_shiftedDressedSReMatrixOnMagSector_structural` (Thm23-#3887.1).
+`isIrreducible_shiftedDressedSReMatrixOnMagSector` (Thm23-#3887.1).
 
 Provides four wrappers (bottom-up):
 - `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural`
 - `pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural`
-- `marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector_structural`
-- `marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector_structural`
+- `marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector`
+- `marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector`
 
 The eigenvalue-uniqueness side (`pos_eigenvec_eigenvalue_unique_*`,
 `marshallPositive_eigenvec_eigenvalue_unique_*`) already does NOT use `h_intermediate`,
@@ -50,7 +50,7 @@ theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural
     (hw_pos : ∀ σ, 0 < w σ) :
     ∃ r : ℝ, 0 < r ∧ w = r • v :=
   LatticeSystem.Math.PerronFrobenius.pos_eigenvec_unique
-    (isIrreducible_shiftedDressedSReMatrixOnMagSector_structural (N := N) (M := M)
+    (isIrreducible_shiftedDressedSReMatrixOnMagSector (N := N) (M := M)
       A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN)
     hv hv_pos hw hw_pos
 
@@ -82,7 +82,7 @@ theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural
 
 /-- **Structural Marshall-positive Heisenberg sector eigenvector uniqueness
 (no `h_intermediate`)**. -/
-theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector_structural
+theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -135,7 +135,7 @@ theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSect
 
 /-- **Structural Marshall-positive complex sector eigenvector uniqueness
 (no `h_intermediate`)**. -/
-theorem marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector_structural
+theorem marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -168,7 +168,7 @@ theorem marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixO
   refine ⟨hμ_eq, ?_⟩
   subst hμ_eq
   obtain ⟨r, hr_pos, hrel⟩ :=
-    marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector_structural
+    marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       hA_ne hB_ne hN hW₁_re hW₁_marshall_pos hW₂_re hW₂_marshall_pos
   exact ⟨r, hr_pos, fun σ => congrFun hrel σ⟩

--- a/LatticeSystem/Tests/SpinSBipartiteCompleteGraph.lean
+++ b/LatticeSystem/Tests/SpinSBipartiteCompleteGraph.lean
@@ -77,7 +77,7 @@ example {N : ℕ} [Fintype V] [DecidableEq V] {A : V → Bool}
     ∃ σ'' : V → Fin (N + 1),
       RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ σ'' ∧
         configDistS σ'' σ' + 2 = configDistS σ σ' :=
-  exists_raiseLowerReachableS_bipartite_of_over_under_structural
+  exists_raiseLowerReachableS_bipartite_of_over_under
     hxy hover hunder hOppExists hN
 
 /-- Bipartite reachability for equal-magnetization configurations


### PR DESCRIPTION
Tracked in #3921. Continues batch 5 (#3930). 5 more twin pairs (twin→_legacy, structural→canonical). 18 files / 41 lines. Build green. Remaining: ~19.