### PR TITLE
Refactor (Phase E, batch 7): rename 5 more twin pairs -- #3921

### DIFF
--- a/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
@@ -60,7 +60,7 @@ theorem axisSwappedAnisotropicHeisenbergS_submatrix_finrank_le_one_at_hermitianM
     rw [Matrix.sub_mulVec, Matrix.smul_mulVec, Matrix.one_mulVec, hAv, sub_smul]
   -- Step 3: shifted is irreducible (structural).
   have hIrred :=
-    shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural
+    shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
       A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
       hA_ne hB_ne hN p
   -- Step 4: finrank ℝ eigenspace shifted (c - ν) ≤ 1 via Perron.

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -292,7 +292,7 @@ extreme).
 Proof: strong induction on `configDistS`, using
 `exists_raiseLowerReachableS_bipartite_of_over_under_legacy` (PR #821) at
 each step (which combines the easy and hard cases). -/
-theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
+theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy
     (A : V → Bool)
     (h_intermediate : ∀ τ : V → Fin (N + 1), ∀ x : V,
       ∃ z, A z ≠ A x ∧ (τ z).val < N)

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
@@ -85,7 +85,7 @@ set_option linter.unusedDecidableInType false in
 /-- **Structural within-sector reachability (no `h_intermediate`)**: for any two
 same-magnetization configurations of the same complete bipartite graph,
 `RaiseLowerReachableS` connects them, using only `hA_ne + hB_ne + 1 ≤ N`. -/
-theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural
+theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
     [Fintype V] [DecidableEq V]
     (A : V → Bool)
     (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false) (hN : 1 ≤ N)
@@ -149,7 +149,7 @@ theorem parityReachableS_total
     omega
   have h_within :=
     parityReachableS_of_raiseLowerReachableS
-      (raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural
+      (raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
         A hA_ne hB_ne hN h_par_min)
   have h_back := parityReachableS_symm h'_reach_min
   exact (h_reach_min.trans h_within).trans h_back

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleStructural.lean
@@ -7,7 +7,7 @@ import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphStructural
 Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 (#3887.4): Structural variant of
-`shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible` that uses
+`shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy` that uses
 `parityReachableS_total` (#3887.3) instead of `parityReachableS_total_legacy`.
 
 Drops `h_intermediate`; requires `hA_ne + hB_ne + 1 ≤ N` instead. The result is
@@ -24,7 +24,7 @@ namespace LatticeSystem.Quantum
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **(#3887.4) Structural shifted parity-block irreducibility (no `h_intermediate`)**. -/
-theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural
+theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
@@ -27,7 +27,7 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **Parity-block shifted PF matrix is irreducible** (unconditional under case (i.2) strict).
 Discharges the totality hypothesis of #3797 via #3823 `parityReachableS_total_legacy`. -/
-theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
+theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
@@ -129,7 +129,7 @@ theorem exists_matrixPow_pos_of_magConfigS_bipartite_legacy
   · intro σ τ hstep
     exact shiftedDressedSReMatrixOnMagSector_apply_pos_of_raiseLowerStepSMagSector
       A N c M hJ_real hJ_pos hJ_sym hstep
-  · exact raiseLowerReachableSMagSector_bipartiteCompleteGraph A
+  · exact raiseLowerReachableSMagSector_bipartiteCompleteGraph_legacy A
       h_intermediate σ σ'
 
 /-- **Strict positive-length matrix-power positivity** on the sector
@@ -240,7 +240,7 @@ Direct corollary of `Matrix.IsIrreducible` (#846) and
 non-degeneracy half of Tasaki §2.5 Theorem 2.2 for general spin (the
 ground-state in each magnetization sector is unique up to a positive
 scalar, equivalently 1-dimensional). -/
-theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector
+theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
@@ -372,11 +372,11 @@ any two strictly positive eigenvectors of the dressed Heisenberg sector
 matrix with the same eigenvalue `μ` are positive scalar multiples of
 each other.
 
-Reduction to `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector`
+Reduction to `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_legacy`
 (#848): convert both `dressed_sec`-eigenvectors to `shifted_sec`-
 eigenvectors at the shifted eigenvalue `c - μ`, then apply PF
 uniqueness on the shifted matrix. -/
-theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
+theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -399,7 +399,7 @@ theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
     A J N c hv
   have hw' := shiftedDressedSReMatrixOnMagSector_mulVec_of_dressed_eigenvec
     A J N c hw
-  exact pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector A N c
+  exact pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_legacy A N c
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
     hv' hv_pos hw' hw_pos
 
@@ -439,7 +439,7 @@ theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSect
     A N hJ_real hw₂
   -- Apply dressed uniqueness.
   obtain ⟨r, hr_pos, hrel⟩ :=
-    pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
+    pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_legacy
       A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
       hv₁ hw₁_marshall_pos hv₂ hw₂_marshall_pos
   -- hrel : (fun σ => sign σ.1.re * w₂ σ) = r • (fun σ => sign σ.1.re * w₁ σ).

--- a/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvector.lean
@@ -62,7 +62,7 @@ theorem dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenv
     unfold Matrix.IsHermitian
     rw [Matrix.conjTranspose_eq_transpose_of_trivial]
     exact hSymm
-  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
+  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
     hA_ne hB_ne h_intermediate p
   -- Apply PF to get μ_PF, v > 0 with shifted v = μ_PF v.

--- a/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvectorStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvectorStructural.lean
@@ -12,7 +12,7 @@ Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 (#3887.5): Structural variant of (j.1)
 `dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_legacy`
-that uses `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural`
+that uses `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible`
 (#3887.4) instead of the h_intermediate-bearing original.
 
 Drops `h_intermediate`; requires `hA_ne + hB_ne + 1 ≤ N`. Otherwise identical
@@ -57,7 +57,7 @@ theorem dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenv
     unfold Matrix.IsHermitian
     rw [Matrix.conjTranspose_eq_transpose_of_trivial]
     exact hSymm
-  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural
+  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
     hA_ne hB_ne hN p
   obtain ⟨μ, v, hAv, _hvne, hv_pos⟩ := exists_pos_eigenvec_max hHerm hIrred

--- a/LatticeSystem/Quantum/SpinS/MagConfig.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfig.lean
@@ -169,14 +169,14 @@ chain in the bipartite complete graph.
 
 Proof: combine the full-type bipartite reachability theorem (#823)
 with the subtype lifting (#840). -/
-theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph
+theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph_legacy
     (A : V → Bool) {M : ℕ}
     (h_intermediate : ∀ τ : V → Fin (N + 1), ∀ x : V,
       ∃ z, A z ≠ A x ∧ (τ z).val < N)
     (σ σ' : magConfigS V N M) :
     RaiseLowerReachableSMagSector (bipartiteCompleteGraphOf A) σ σ' := by
   have hreach : RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ.1 σ'.1 :=
-    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS A
+    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy A
       h_intermediate (σ.2.trans σ'.2.symm)
   -- Lift to subtype.
   have := raiseLowerReachableSMagSector_of_raiseLowerReachableS σ.2 σ'.2 hreach

--- a/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
@@ -59,7 +59,7 @@ theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_perron_eigenspace_finrank
     rw [Matrix.conjTranspose_eq_transpose_of_trivial]
     exact hSymm
   -- Irreducibility unconditional via #3824.
-  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
+  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
     hA_ne hB_ne h_intermediate p
   -- Perron positive eigenvector + finrank ≤ 1 (#3779).

--- a/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
@@ -51,7 +51,7 @@ theorem parityReachableS_of_raiseLowerReachableS {G : SimpleGraph V} {σ σ' : V
 /-- **Within-sector ParityReachableS on the bipartite complete graph**: any two
 configurations sharing the same total magnetization are `ParityReachableS`-connected.
 
-Lifts `raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS` through the inclusion
+Lifts `raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy` through the inclusion
 `RaiseLowerStepS ⊆ ParityStepS`. -/
 theorem parityReachableS_bipartiteCompleteGraph_of_eq_magSumS
     (A : V → Bool)
@@ -60,6 +60,6 @@ theorem parityReachableS_bipartiteCompleteGraph_of_eq_magSumS
     {σ σ' : V → Fin (N + 1)} (hmag : magSumS σ = magSumS σ') :
     ParityReachableS (bipartiteCompleteGraphOf A) σ σ' :=
   parityReachableS_of_raiseLowerReachableS
-    (raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS A h_intermediate hmag)
+    (raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy A h_intermediate hmag)
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/ShiftedDressedMatrix.lean
+++ b/LatticeSystem/Quantum/SpinS/ShiftedDressedMatrix.lean
@@ -295,7 +295,7 @@ theorem exists_matrixPow_pos_length_of_eq_magSumS_bipartite
     (hmag : magSumS σ = magSumS σ') :
     ∃ k : ℕ, 1 ≤ k ∧ 0 < (shiftedDressedSReMatrix A J N c ^ k) σ' σ := by
   have hreach : RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ σ' :=
-    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS A
+    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy A
       h_intermediate hmag
   exact exists_matrixPow_pos_length_of_raiseLowerReachableS_bipartite A N c
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc hne hreach

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
@@ -11,8 +11,8 @@ set_option linter.unusedVariables false
 
 Extension of #3887 fix to the Tasaki §2.5 Theorem 2.3 dressed-Heisenberg chain.
 
-Provides `raiseLowerReachableSMagSector_bipartiteCompleteGraph_structural`
-using `raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural`
+Provides `raiseLowerReachableSMagSector_bipartiteCompleteGraph`
+using `raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS`
 (#3887.3) — drops `h_intermediate`, requires only `hA_ne + hB_ne + 1 ≤ N`.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -24,14 +24,14 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural MagSector reachability (no `h_intermediate`)**. -/
-theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph_structural
+theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph
     (A : V → Bool) {M : ℕ}
     (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false)
     (hN : 1 ≤ N)
     (σ σ' : magConfigS V N M) :
     RaiseLowerReachableSMagSector (bipartiteCompleteGraphOf A) σ σ' := by
   have hreach : RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ.1 σ'.1 :=
-    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural A
+    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS A
       hA_ne hB_ne hN (σ.2.trans σ'.2.symm)
   exact raiseLowerReachableSMagSector_of_raiseLowerReachableS σ.2 σ'.2 hreach
 
@@ -55,7 +55,7 @@ theorem exists_matrixPow_pos_of_magConfigS_bipartite
   · intro σ τ hstep
     exact shiftedDressedSReMatrixOnMagSector_apply_pos_of_raiseLowerStepSMagSector
       A N c M hJ_real hJ_pos hJ_sym hstep
-  · exact raiseLowerReachableSMagSector_bipartiteCompleteGraph_structural A
+  · exact raiseLowerReachableSMagSector_bipartiteCompleteGraph A
       hA_ne hB_ne hN σ σ'
 
 /-- **Structural strict-positive-length matrix-power positivity**. -/

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralUniqueness.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralUniqueness.lean
@@ -14,8 +14,8 @@ uniqueness chain, swapping `pos_eigenvec_unique` at the bottom from the
 `isIrreducible_shiftedDressedSReMatrixOnMagSector` (Thm23-#3887.1).
 
 Provides four wrappers (bottom-up):
-- `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural`
-- `pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural`
+- `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector`
+- `pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector`
 - `marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector`
 - `marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector`
 
@@ -32,7 +32,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural shifted-dressed PF positive eigenvector uniqueness (no `h_intermediate`)**. -/
-theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural
+theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -55,7 +55,7 @@ theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural
     hv hv_pos hw hw_pos
 
 /-- **Structural dressed Heisenberg PF positive eigenvector uniqueness (no `h_intermediate`)**. -/
-theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural
+theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -76,7 +76,7 @@ theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural
     A J N c hv
   have hw' := shiftedDressedSReMatrixOnMagSector_mulVec_of_dressed_eigenvec
     A J N c hw
-  exact pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural
+  exact pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector
     (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
     hA_ne hB_ne hN hv' hv_pos hw' hw_pos
 
@@ -104,7 +104,7 @@ theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSect
   have hv₂ := dressedHeisenbergSReMatrixOnMagSector_mulVec_of_heis_eigenvec
     A N hJ_real hw₂
   obtain ⟨r, hr_pos, hrel⟩ :=
-    pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural
+    pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       hA_ne hB_ne hN hv₁ hw₁_marshall_pos hv₂ hw₂_marshall_pos
   refine ⟨r, hr_pos, ?_⟩

--- a/LatticeSystem/Tests/SpinSBipartiteCompleteGraph.lean
+++ b/LatticeSystem/Tests/SpinSBipartiteCompleteGraph.lean
@@ -86,7 +86,7 @@ example {N : ℕ} [Fintype V] [DecidableEq V] (A : V → Bool)
     (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false) (hN : 1 ≤ N)
     {σ σ' : V → Fin (N + 1)} (hmag : magSumS σ = magSumS σ') :
     RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ σ' :=
-  raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural
+  raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
     A hA_ne hB_ne hN hmag
 
 end LatticeSystem.Tests.SpinSBipartiteCompleteGraph


### PR DESCRIPTION
Tracked in #3921. Continues batch 6 (#3931). 5 more pairs. 16 files / 34 lines. Build green. Remaining: ~14 (skipping tasaki_2_5_theorem_2_3 Prop def).