### PR TITLE
Refactor (Phase E, batch 8): rename 5 more twin pairs -- #3921

### DIFF
--- a/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
@@ -60,7 +60,7 @@ theorem axisSwappedAnisotropicHeisenbergS_submatrix_finrank_le_one_at_hermitianM
     rw [Matrix.sub_mulVec, Matrix.smul_mulVec, Matrix.one_mulVec, hAv, sub_smul]
   -- Step 3: shifted is irreducible (structural).
   have hIrred :=
-    shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural
+    shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
       A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
       hA_ne hB_ne hN p
   -- Step 4: finrank ℝ eigenspace shifted (c - ν) ≤ 1 via Perron.

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -292,7 +292,7 @@ extreme).
 Proof: strong induction on `configDistS`, using
 `exists_raiseLowerReachableS_bipartite_of_over_under_legacy` (PR #821) at
 each step (which combines the easy and hard cases). -/
-theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
+theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy
     (A : V → Bool)
     (h_intermediate : ∀ τ : V → Fin (N + 1), ∀ x : V,
       ∃ z, A z ≠ A x ∧ (τ z).val < N)

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphStructural.lean
@@ -85,7 +85,7 @@ set_option linter.unusedDecidableInType false in
 /-- **Structural within-sector reachability (no `h_intermediate`)**: for any two
 same-magnetization configurations of the same complete bipartite graph,
 `RaiseLowerReachableS` connects them, using only `hA_ne + hB_ne + 1 ≤ N`. -/
-theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural
+theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
     [Fintype V] [DecidableEq V]
     (A : V → Bool)
     (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false) (hN : 1 ≤ N)
@@ -149,7 +149,7 @@ theorem parityReachableS_total
     omega
   have h_within :=
     parityReachableS_of_raiseLowerReachableS
-      (raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural
+      (raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
         A hA_ne hB_ne hN h_par_min)
   have h_back := parityReachableS_symm h'_reach_min
   exact (h_reach_min.trans h_within).trans h_back

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleStructural.lean
@@ -7,7 +7,7 @@ import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphStructural
 Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 (#3887.4): Structural variant of
-`shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible` that uses
+`shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy` that uses
 `parityReachableS_total` (#3887.3) instead of `parityReachableS_total_legacy`.
 
 Drops `h_intermediate`; requires `hA_ne + hB_ne + 1 ≤ N` instead. The result is
@@ -24,7 +24,7 @@ namespace LatticeSystem.Quantum
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **(#3887.4) Structural shifted parity-block irreducibility (no `h_intermediate`)**. -/
-theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural
+theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
@@ -27,7 +27,7 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **Parity-block shifted PF matrix is irreducible** (unconditional under case (i.2) strict).
 Discharges the totality hypothesis of #3797 via #3823 `parityReachableS_total_legacy`. -/
-theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
+theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
@@ -129,7 +129,7 @@ theorem exists_matrixPow_pos_of_magConfigS_bipartite_legacy
   · intro σ τ hstep
     exact shiftedDressedSReMatrixOnMagSector_apply_pos_of_raiseLowerStepSMagSector
       A N c M hJ_real hJ_pos hJ_sym hstep
-  · exact raiseLowerReachableSMagSector_bipartiteCompleteGraph A
+  · exact raiseLowerReachableSMagSector_bipartiteCompleteGraph_legacy A
       h_intermediate σ σ'
 
 /-- **Strict positive-length matrix-power positivity** on the sector
@@ -240,7 +240,7 @@ Direct corollary of `Matrix.IsIrreducible` (#846) and
 non-degeneracy half of Tasaki §2.5 Theorem 2.2 for general spin (the
 ground-state in each magnetization sector is unique up to a positive
 scalar, equivalently 1-dimensional). -/
-theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector
+theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
@@ -372,11 +372,11 @@ any two strictly positive eigenvectors of the dressed Heisenberg sector
 matrix with the same eigenvalue `μ` are positive scalar multiples of
 each other.
 
-Reduction to `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector`
+Reduction to `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_legacy`
 (#848): convert both `dressed_sec`-eigenvectors to `shifted_sec`-
 eigenvectors at the shifted eigenvalue `c - μ`, then apply PF
 uniqueness on the shifted matrix. -/
-theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
+theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -399,7 +399,7 @@ theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
     A J N c hv
   have hw' := shiftedDressedSReMatrixOnMagSector_mulVec_of_dressed_eigenvec
     A J N c hw
-  exact pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector A N c
+  exact pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_legacy A N c
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
     hv' hv_pos hw' hw_pos
 
@@ -439,7 +439,7 @@ theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSect
     A N hJ_real hw₂
   -- Apply dressed uniqueness.
   obtain ⟨r, hr_pos, hrel⟩ :=
-    pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
+    pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_legacy
       A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
       hv₁ hw₁_marshall_pos hv₂ hw₂_marshall_pos
   -- hrel : (fun σ => sign σ.1.re * w₂ σ) = r • (fun σ => sign σ.1.re * w₁ σ).

--- a/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvector.lean
@@ -62,7 +62,7 @@ theorem dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenv
     unfold Matrix.IsHermitian
     rw [Matrix.conjTranspose_eq_transpose_of_trivial]
     exact hSymm
-  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
+  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
     hA_ne hB_ne h_intermediate p
   -- Apply PF to get μ_PF, v > 0 with shifted v = μ_PF v.

--- a/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvectorStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvectorStructural.lean
@@ -12,7 +12,7 @@ Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 
 (#3887.5): Structural variant of (j.1)
 `dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_legacy`
-that uses `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural`
+that uses `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible`
 (#3887.4) instead of the h_intermediate-bearing original.
 
 Drops `h_intermediate`; requires `hA_ne + hB_ne + 1 ≤ N`. Otherwise identical
@@ -57,7 +57,7 @@ theorem dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenv
     unfold Matrix.IsHermitian
     rw [Matrix.conjTranspose_eq_transpose_of_trivial]
     exact hSymm
-  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_structural
+  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
     hA_ne hB_ne hN p
   obtain ⟨μ, v, hAv, _hvne, hv_pos⟩ := exists_pos_eigenvec_max hHerm hIrred

--- a/LatticeSystem/Quantum/SpinS/MagConfig.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfig.lean
@@ -169,14 +169,14 @@ chain in the bipartite complete graph.
 
 Proof: combine the full-type bipartite reachability theorem (#823)
 with the subtype lifting (#840). -/
-theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph
+theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph_legacy
     (A : V → Bool) {M : ℕ}
     (h_intermediate : ∀ τ : V → Fin (N + 1), ∀ x : V,
       ∃ z, A z ≠ A x ∧ (τ z).val < N)
     (σ σ' : magConfigS V N M) :
     RaiseLowerReachableSMagSector (bipartiteCompleteGraphOf A) σ σ' := by
   have hreach : RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ.1 σ'.1 :=
-    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS A
+    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy A
       h_intermediate (σ.2.trans σ'.2.symm)
   -- Lift to subtype.
   have := raiseLowerReachableSMagSector_of_raiseLowerReachableS σ.2 σ'.2 hreach

--- a/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
@@ -59,7 +59,7 @@ theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_perron_eigenspace_finrank
     rw [Matrix.conjTranspose_eq_transpose_of_trivial]
     exact hSymm
   -- Irreducibility unconditional via #3824.
-  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
+  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
     hA_ne hB_ne h_intermediate p
   -- Perron positive eigenvector + finrank ≤ 1 (#3779).

--- a/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
@@ -51,7 +51,7 @@ theorem parityReachableS_of_raiseLowerReachableS {G : SimpleGraph V} {σ σ' : V
 /-- **Within-sector ParityReachableS on the bipartite complete graph**: any two
 configurations sharing the same total magnetization are `ParityReachableS`-connected.
 
-Lifts `raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS` through the inclusion
+Lifts `raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy` through the inclusion
 `RaiseLowerStepS ⊆ ParityStepS`. -/
 theorem parityReachableS_bipartiteCompleteGraph_of_eq_magSumS
     (A : V → Bool)
@@ -60,6 +60,6 @@ theorem parityReachableS_bipartiteCompleteGraph_of_eq_magSumS
     {σ σ' : V → Fin (N + 1)} (hmag : magSumS σ = magSumS σ') :
     ParityReachableS (bipartiteCompleteGraphOf A) σ σ' :=
   parityReachableS_of_raiseLowerReachableS
-    (raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS A h_intermediate hmag)
+    (raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy A h_intermediate hmag)
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/ShiftedDressedMatrix.lean
+++ b/LatticeSystem/Quantum/SpinS/ShiftedDressedMatrix.lean
@@ -295,7 +295,7 @@ theorem exists_matrixPow_pos_length_of_eq_magSumS_bipartite
     (hmag : magSumS σ = magSumS σ') :
     ∃ k : ℕ, 1 ≤ k ∧ 0 < (shiftedDressedSReMatrix A J N c ^ k) σ' σ := by
   have hreach : RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ σ' :=
-    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS A
+    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy A
       h_intermediate hmag
   exact exists_matrixPow_pos_length_of_raiseLowerReachableS_bipartite A N c
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc hne hreach

--- a/LatticeSystem/Quantum/SpinS/Theorem23IntervalCommonEnergy.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23IntervalCommonEnergy.lean
@@ -76,7 +76,7 @@ theorem tasaki23_sector_lift_and_casimir
 Perron–Frobenius ground state in admissible sector `M` has energy `μ`, and `M` is not the
 right endpoint of the admissible interval, then the Marshall-positive ground state in the
 next sector `M + 1` also has energy `μ`. -/
-theorem tasaki23_common_energy_step
+theorem tasaki23_common_energy_step_legacy
     (A : V → Bool) (N : ℕ) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -137,7 +137,7 @@ theorem tasaki23_common_energy_step
 There is a single energy `μ` such that in *every* admissible sector
 `M ∈ tasaki23GroundStateSectors A N` the connected bipartite antiferromagnetic coupling `J`
 has a Marshall-positive Perron–Frobenius ground state of energy `μ`. -/
-theorem tasaki23_common_groundEnergy
+theorem tasaki23_common_groundEnergy_legacy
     (A : V → Bool) (N : ℕ) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -198,7 +198,7 @@ theorem tasaki23_common_groundEnergy
         magConfigS_nonempty_of_le_card_mul (le_trans hM_le hmax_le)
       haveI : Nonempty (magConfigS V N (M + 1)) :=
         magConfigS_nonempty_of_le_card_mul (le_trans hM1_le hmax_le)
-      exact tasaki23_common_energy_step A N c c_toy horient hsB hJ_real hJ_real' hJ_pos hJ_nn
+      exact tasaki23_common_energy_step_legacy A N c c_toy horient hsB hJ_real hJ_real' hJ_pos hJ_nn
         hJ_sym hJ_bipartite hc_strict hc_strict_toy h_intermediate hM_mem hM_lt hvM_pos hReEig_M
   intro M hM
   rw [tasaki23GroundStateSectors_mem_iff] at hM

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFBaseCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFBaseCasimir.lean
@@ -18,7 +18,7 @@ This module discharges the `hsource_cas` hypothesis of
 `tasaki23_successor_sector_existence_with_lowered_predictedCasimir` at the base
 extremal sector `M = min(|A|,|¬A|)·N`: the toy witness
 `tasaki23_toy_groundState_casimir_eq_predicted` (#3711) supplies `hw_cas`, and the
-overlap pin `tasaki23_pf_groundState_casimir_eq_predicted_of_witness` transfers the
+overlap pin `tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy` transfers the
 predicted Casimir to the `J`-ground state.  The adjacent-sector ladder chain then
 propagates the predicted value to the remaining sectors via `Ŝ⁻_tot`.
 
@@ -37,7 +37,7 @@ coupling `J` is a `(Ŝ_tot)²`-eigenvector at the predicted value
 `tasaki23PredictedCasimirValue A N`.
 
 The toy Hamiltonian's ground-state witness (#3711) supplies the predicted-Casimir
-state in the same sector, and `tasaki23_pf_groundState_casimir_eq_predicted_of_witness`
+state in the same sector, and `tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy`
 transfers the value to the `J`-ground state.  This discharges the `hsource_cas`
 hypothesis of the sector-existence chain at the base sector. -/
 theorem tasaki23_pf_groundState_casimir_eq_predicted_base
@@ -78,7 +78,7 @@ theorem tasaki23_pf_groundState_casimir_eq_predicted_base
   obtain ⟨w, hw_pos, hw_cas⟩ :=
     tasaki23_toy_groundState_casimir_eq_predicted A N c_toy horient hc_strict_toy
       h_intermediate
-  exact tasaki23_pf_groundState_casimir_eq_predicted_of_witness A N c hJ_real hJ_pos
+  exact tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy A N c hJ_real hJ_pos
     hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate hv_pos hw_pos hH hw_cas
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
@@ -69,7 +69,7 @@ Marshall-conjugates `φ` and `w` to eigenvectors of the shifted dressed sector
 matrix (where `marshallSignS · φ > 0` is the strictly positive Perron
 eigenvector), applies the geometric simplicity
 `tasaki23_shiftedDressed_sector_eigenvec_proportional`, and conjugates back. -/
-theorem tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive
+theorem tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -117,10 +117,10 @@ Since `[Ĥ, (Ŝtot)²] = 0`, `(Ŝtot)² Φ` is a Heisenberg eigenvector at the s
 `μ` supported in the same magnetization sector; its real and imaginary parts
 are real Heisenberg sector eigenvectors at `μ`, each a scalar multiple of the
 Marshall-positive ground state by the one-dimensionality
-`tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive`.  Recombining,
+`tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy`.  Recombining,
 `(Ŝtot)² Φ = γ Φ`.  This pins the total spin of the ground state (total-spin
 determination, Tasaki §2.5 p.42). -/
-theorem tasaki23_pf_groundState_casimir_eigenvector
+theorem tasaki23_pf_groundState_casimir_eigenvector_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -208,10 +208,10 @@ theorem tasaki23_pf_groundState_casimir_eigenvector
       N hJ_real hΨr_eig
   -- one-dimensionality ⟹ re, im parts are scalar multiples of φ
   obtain ⟨a, ha⟩ :=
-    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive A N c hJ_real
+    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy A N c hJ_real
       hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate hφ_eig hφ_pos hΨr_re
   obtain ⟨b, hb⟩ :=
-    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive A N c hJ_real
+    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy A N c hJ_real
       hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate hφ_eig hφ_pos hΨr_im
   -- assemble γ = a + b i
   refine ⟨⟨a, b⟩, ?_⟩
@@ -254,7 +254,7 @@ magnetization sector.
 This replaces the predicted-GS-membership hypothesis of
 `tasaki23_pf_ladder_link_succ_of_mem_predictedGS` by the minimal
 Casimir-non-vanishing condition, using that the ground state is a
-total-Casimir eigenvector (`tasaki23_pf_groundState_casimir_eigenvector`).
+total-Casimir eigenvector (`tasaki23_pf_groundState_casimir_eigenvector_legacy`).
 It is the form in which the sound chain applies directly to the actual
 Perron–Frobenius ground state. -/
 theorem tasaki23_pf_groundState_ladder_link_of_casimir_ne_kernel
@@ -301,7 +301,7 @@ theorem tasaki23_pf_groundState_ladder_link_of_casimir_ne_kernel
         magSubspaceS V N
           ((((Fintype.card V : ℂ) * (N : ℂ) / 2) - (M : ℂ)) - 1) := by
   obtain ⟨γ, hγ⟩ :=
-    tasaki23_pf_groundState_casimir_eigenvector A N c hJ_real hJ_pos hJ_nn
+    tasaki23_pf_groundState_casimir_eigenvector_legacy A N c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict h_intermediate hv_pos hH
   exact tasaki23_pf_ladder_link_succ hH hγ (hγ_ne γ hγ)
     (tasaki23_marshallPositive_magSectorEmbedding_ne_zero A hv_pos)

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirPredicted.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirPredicted.lean
@@ -78,10 +78,10 @@ toy-Hamiltonian ground state), the per-sector Perron–Frobenius ground state
 total-Casimir eigenvector at exactly the predicted value.
 
 Tasaki's overlap argument: `Φ` is a total-Casimir eigenvector at some real `γ`
-(`tasaki23_pf_groundState_casimir_eigenvector` + `isHermitian_eigenvalue_star_eq`);
+(`tasaki23_pf_groundState_casimir_eigenvector_legacy` + `isHermitian_eigenvalue_star_eq`);
 the Marshall-positive overlap with `w` is non-zero, so
 `tasaki23_marshallPositive_casimir_eigenvalue_eq` forces `γ = predicted`. -/
-theorem tasaki23_pf_groundState_casimir_eq_predicted_of_witness
+theorem tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -114,7 +114,7 @@ theorem tasaki23_pf_groundState_casimir_eq_predicted_of_witness
         magSectorEmbedding
           (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) := by
   obtain ⟨γ, hγ⟩ :=
-    tasaki23_pf_groundState_casimir_eigenvector A N c hJ_real hJ_pos hJ_nn
+    tasaki23_pf_groundState_casimir_eigenvector_legacy A N c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict h_intermediate hv_pos hH
   have hγ_real : star γ = γ :=
     isHermitian_eigenvalue_star_eq (totalSpinSSquared_isHermitian V N) hγ

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFSectorCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFSectorCasimir.lean
@@ -12,7 +12,7 @@ Tasaki's overlap step (§2.5, eq. 2.5.12): in any admissible sector `M`, the toy
 Hamiltonian's Marshall-positive ground state carries the predicted total Casimir
 (#3730), so the Marshall-positive Perron–Frobenius ground state of an *arbitrary*
 connected bipartite antiferromagnetic coupling `J` inherits it through the non-zero
-Marshall overlap (`tasaki23_pf_groundState_casimir_eq_predicted_of_witness`).  This
+Marshall overlap (`tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy`).  This
 discharges `hsource_cas` of the sector-existence chain at every admissible sector.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body
@@ -60,7 +60,7 @@ theorem tasaki23_pf_groundState_casimir_eq_predicted_sector
   obtain ⟨w, hw_pos, hw_cas⟩ :=
     tasaki23_toy_groundState_casimir_eq_predicted_at A N c_toy horient hsB hM hc_strict_toy
       h_intermediate
-  exact tasaki23_pf_groundState_casimir_eq_predicted_of_witness A N c hJ_real hJ_pos
+  exact tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy A N c hJ_real hJ_pos
     hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate hv_pos hw_pos hH hw_cas
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFToyJointCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFToyJointCasimir.lean
@@ -7,12 +7,12 @@ import LatticeSystem.Quantum.SpinS.SublatticeSpin
 
 Sound Perron–Frobenius route (Issue #3542; see
 `.self-local/docs/tasaki-2-5-pf-route-design.md`).  The previous overlap pin
-(`tasaki23_pf_groundState_casimir_eq_predicted_of_witness`) reduced Theorem 2.3
+(`tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy`) reduced Theorem 2.3
 to constructing a Marshall-positive total-Casimir witness at the predicted value,
 namely the toy-Hamiltonian ground state.
 
 This module generalises
-`tasaki23_pf_groundState_casimir_eigenvector` to an arbitrary operator commuting
+`tasaki23_pf_groundState_casimir_eigenvector_legacy` to an arbitrary operator commuting
 with the Heisenberg Hamiltonian and with `Ŝ_tot^(3)`, then instantiates it at the
 toy Hamiltonian `Ĥ_toy = heisenbergHamiltonianS (bipartiteCoupling A)` for the
 three Casimirs `(Ŝ_tot)²`, `(Ŝ_A)²`, `(Ŝ_¬A)²` (which all commute with `Ĥ_toy`,
@@ -31,7 +31,7 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 
 /-- **The per-sector Perron–Frobenius ground state is an eigenvector of any
 operator commuting with `Ĥ` and `Ŝ_tot^(3)`**: generalisation of
-`tasaki23_pf_groundState_casimir_eigenvector` from the total Casimir to an
+`tasaki23_pf_groundState_casimir_eigenvector_legacy` from the total Casimir to an
 arbitrary `B` with `Commute Ĥ B` and `Commute Ŝ_tot^(3) B`.
 
 The proof is the same one-dimensionality argument: `B Φ` is a Heisenberg
@@ -121,10 +121,10 @@ theorem tasaki23_pf_groundState_commuting_eigenvector
     heisenbergHamiltonianSReMatrixOnMagSector_mulVec_im_of_complex_eigenvec
       N hJ_real hΨr_eig
   obtain ⟨a, ha⟩ :=
-    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive A N c hJ_real
+    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy A N c hJ_real
       hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate hφ_eig hφ_pos hΨr_re
   obtain ⟨b, hb⟩ :=
-    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive A N c hJ_real
+    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy A N c hJ_real
       hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate hφ_eig hφ_pos hΨr_im
   refine ⟨⟨a, b⟩, ?_⟩
   funext ρ

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralCasimirEigenvec.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralCasimirEigenvec.lean
@@ -5,7 +5,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralReach
 # Structural Theorem 2.3 eigenvector proportionality (no `h_intermediate`)
 
 Extension of #3887 fix to `tasaki23_shiftedDressed_sector_eigenvec_proportional` /
-`tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive` via
+`tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy` via
 `isIrreducible_shiftedDressedSReMatrixOnMagSector`.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -40,7 +40,7 @@ theorem tasaki23_shiftedDressed_sector_eigenvec_proportional_structural
     hv hv_pos hw
 
 /-- **Structural Heisenberg sector eigenvector proportionality (no `h_intermediate`)**. -/
-theorem tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_structural
+theorem tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonEnergyStep.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonEnergyStep.lean
@@ -5,7 +5,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23PFConstancyCasimir
 /-!
 # Structural adjacent-sector common-energy step (no `h_intermediate`)
 
-(PR #3893): structural variant of `tasaki23_common_energy_step` (TIER 4 step) using
+(PR #3893): structural variant of `tasaki23_common_energy_step_legacy` (TIER 4 step) using
 - `tasaki23_sector_lift_and_casimir_structural` (Step 1)
 - `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`
   (Thm23-#3887.9)
@@ -20,7 +20,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural adjacent-sector common-energy step (no `h_intermediate`)**. -/
-theorem tasaki23_common_energy_step_structural
+theorem tasaki23_common_energy_step
     (A : V → Bool) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonGroundEnergy.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonGroundEnergy.lean
@@ -4,11 +4,11 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralCommonEnergyStep
 # Structural common ground-state energy across all admissible sectors
 (no `h_intermediate`)
 
-(PR #3893): structural variant of `tasaki23_common_groundEnergy` (TIER 4 constancy)
+(PR #3893): structural variant of `tasaki23_common_groundEnergy_legacy` (TIER 4 constancy)
 using
 - `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`
   (Thm23-#3887.9 from PR #3891)
-- `tasaki23_common_energy_step_structural` (Step 2 of this PR)
+- `tasaki23_common_energy_step` (Step 2 of this PR)
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
 Springer 2020, §2.5 Theorem 2.3, p. 42.
@@ -19,7 +19,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural common ground-state energy (no `h_intermediate`)**. -/
-theorem tasaki23_common_groundEnergy_structural
+theorem tasaki23_common_groundEnergy
     (A : V → Bool) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -76,7 +76,7 @@ theorem tasaki23_common_groundEnergy_structural
         magConfigS_nonempty_of_le_card_mul (le_trans hM_le hmax_le)
       haveI : Nonempty (magConfigS V N (M + 1)) :=
         magConfigS_nonempty_of_le_card_mul (le_trans hM1_le hmax_le)
-      exact tasaki23_common_energy_step_structural (N := N) A c c_toy horient hsB hJ_real
+      exact tasaki23_common_energy_step (N := N) A c c_toy horient hsB hJ_real
         hJ_real' hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy
         hA_ne hB_ne hN hM_mem hM_lt hvM_pos hReEig_M
   intro M hM

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
@@ -70,7 +70,7 @@ theorem tasaki_2_5_theorem_2_3_of_bipartiteCompletePositive
     · rfl
     · rw [hAb] at hbf; cases hbf
   obtain ⟨μ, hcommon⟩ :=
-    tasaki23_common_groundEnergy_structural (N := N) A c c_toy horient hsB
+    tasaki23_common_groundEnergy (N := N) A c c_toy horient hsB
       hJ_real hJ_real' hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy
       hA_ne hB_ne hN
   refine ⟨μ, ?_, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFCasimirPredicted.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFCasimirPredicted.lean
@@ -5,8 +5,8 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralPFJointCasimir
 # Structural Theorem 2.3 PF GS Casimir = predicted (no `h_intermediate`)
 
 (Thm23-#3887.8): structural variant of
-`tasaki23_pf_groundState_casimir_eq_predicted_of_witness` using
-`tasaki23_pf_groundState_casimir_eigenvector_structural` (Thm23-#3887.7).
+`tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy` using
+`tasaki23_pf_groundState_casimir_eigenvector` (Thm23-#3887.7).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
 Springer 2020, §2.5 Theorem 2.3, p. 42.
@@ -17,7 +17,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural PF GS Casimir = predicted via witness (no `h_intermediate`)**. -/
-theorem tasaki23_pf_groundState_casimir_eq_predicted_of_witness_structural
+theorem tasaki23_pf_groundState_casimir_eq_predicted_of_witness
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -49,7 +49,7 @@ theorem tasaki23_pf_groundState_casimir_eq_predicted_of_witness_structural
         magSectorEmbedding
           (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) := by
   obtain ⟨γ, hγ⟩ :=
-    tasaki23_pf_groundState_casimir_eigenvector_structural A c hJ_real hJ_pos hJ_nn
+    tasaki23_pf_groundState_casimir_eigenvector A c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN hv_pos hH
   have hγ_real : star γ = γ :=
     isHermitian_eigenvalue_star_eq (totalSpinSSquared_isHermitian V N) hγ

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFJointCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFJointCasimir.lean
@@ -9,7 +9,7 @@ Extension of #3887 fix to:
 - `tasaki23_pf_groundState_commuting_eigenvector`
 - `tasaki23_toy_groundState_joint_casimir_eigenvector`
 
-Both use `tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_structural`
+Both use `tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive`
 (Thm23-#3887.3) instead of the original h_intermediate-bearing variant.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -103,10 +103,10 @@ theorem tasaki23_pf_groundState_commuting_eigenvector_structural
     heisenbergHamiltonianSReMatrixOnMagSector_mulVec_im_of_complex_eigenvec
       N hJ_real hΨr_eig
   obtain ⟨a, ha⟩ :=
-    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_structural A c hJ_real
+    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive A c hJ_real
       hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN hφ_eig hφ_pos hΨr_re
   obtain ⟨b, hb⟩ :=
-    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_structural A c hJ_real
+    tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive A c hJ_real
       hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN hφ_eig hφ_pos hΨr_im
   refine ⟨⟨a, b⟩, ?_⟩
   funext ρ
@@ -222,7 +222,7 @@ theorem tasaki23_toy_groundState_sublattice_casimir_re_le_structural
 
 /-- **Structural PF GS Casimir eigenvector (no `h_intermediate`)**: specialisation of
 `tasaki23_pf_groundState_commuting_eigenvector_structural` to `B = (Ŝ_tot)²`. -/
-theorem tasaki23_pf_groundState_casimir_eigenvector_structural
+theorem tasaki23_pf_groundState_casimir_eigenvector
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFSectorCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFSectorCasimir.lean
@@ -7,7 +7,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralPFCasimirPredicted
 
 (Thm23-#3887.11): structural variant of `tasaki23_pf_groundState_casimir_eq_predicted_sector`
 using `tasaki23_toy_groundState_casimir_eq_predicted_at_structural` (Thm23-#3887.10) +
-`tasaki23_pf_groundState_casimir_eq_predicted_of_witness_structural` (Thm23-#3887.8).
+`tasaki23_pf_groundState_casimir_eq_predicted_of_witness` (Thm23-#3887.8).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
 Springer 2020, §2.5 Theorem 2.3, p. 42.
@@ -49,7 +49,7 @@ theorem tasaki23_pf_groundState_casimir_eq_predicted_sector_structural
   obtain ⟨w, hw_pos, hw_cas⟩ :=
     tasaki23_toy_groundState_casimir_eq_predicted_at_structural
       (N := N) (M := M) A c_toy horient hsB hM hc_strict_toy hA_ne hB_ne hN
-  exact tasaki23_pf_groundState_casimir_eq_predicted_of_witness_structural
+  exact tasaki23_pf_groundState_casimir_eq_predicted_of_witness
     (N := N) (M := M) A c hJ_real hJ_pos
     hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN hv_pos hw_pos hH hw_cas
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
@@ -11,8 +11,8 @@ set_option linter.unusedVariables false
 
 Extension of #3887 fix to the Tasaki §2.5 Theorem 2.3 dressed-Heisenberg chain.
 
-Provides `raiseLowerReachableSMagSector_bipartiteCompleteGraph_structural`
-using `raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural`
+Provides `raiseLowerReachableSMagSector_bipartiteCompleteGraph`
+using `raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS`
 (#3887.3) — drops `h_intermediate`, requires only `hA_ne + hB_ne + 1 ≤ N`.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -24,14 +24,14 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural MagSector reachability (no `h_intermediate`)**. -/
-theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph_structural
+theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph
     (A : V → Bool) {M : ℕ}
     (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false)
     (hN : 1 ≤ N)
     (σ σ' : magConfigS V N M) :
     RaiseLowerReachableSMagSector (bipartiteCompleteGraphOf A) σ σ' := by
   have hreach : RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ.1 σ'.1 :=
-    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural A
+    raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS A
       hA_ne hB_ne hN (σ.2.trans σ'.2.symm)
   exact raiseLowerReachableSMagSector_of_raiseLowerReachableS σ.2 σ'.2 hreach
 
@@ -55,7 +55,7 @@ theorem exists_matrixPow_pos_of_magConfigS_bipartite
   · intro σ τ hstep
     exact shiftedDressedSReMatrixOnMagSector_apply_pos_of_raiseLowerStepSMagSector
       A N c M hJ_real hJ_pos hJ_sym hstep
-  · exact raiseLowerReachableSMagSector_bipartiteCompleteGraph_structural A
+  · exact raiseLowerReachableSMagSector_bipartiteCompleteGraph A
       hA_ne hB_ne hN σ σ'
 
 /-- **Structural strict-positive-length matrix-power positivity**. -/

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralUniqueness.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralUniqueness.lean
@@ -14,8 +14,8 @@ uniqueness chain, swapping `pos_eigenvec_unique` at the bottom from the
 `isIrreducible_shiftedDressedSReMatrixOnMagSector` (Thm23-#3887.1).
 
 Provides four wrappers (bottom-up):
-- `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural`
-- `pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural`
+- `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector`
+- `pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector`
 - `marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector`
 - `marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector`
 
@@ -32,7 +32,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural shifted-dressed PF positive eigenvector uniqueness (no `h_intermediate`)**. -/
-theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural
+theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -55,7 +55,7 @@ theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural
     hv hv_pos hw hw_pos
 
 /-- **Structural dressed Heisenberg PF positive eigenvector uniqueness (no `h_intermediate`)**. -/
-theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural
+theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
     (A : V → Bool)
     {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -76,7 +76,7 @@ theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural
     A J N c hv
   have hw' := shiftedDressedSReMatrixOnMagSector_mulVec_of_dressed_eigenvec
     A J N c hw
-  exact pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_structural
+  exact pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector
     (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
     hA_ne hB_ne hN hv' hv_pos hw' hw_pos
 
@@ -104,7 +104,7 @@ theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSect
   have hv₂ := dressedHeisenbergSReMatrixOnMagSector_mulVec_of_heis_eigenvec
     A N hJ_real hw₂
   obtain ⟨r, hr_pos, hrel⟩ :=
-    pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_structural
+    pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector
       (N := N) (M := M) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       hA_ne hB_ne hN hv₁ hw₁_marshall_pos hv₂ hw₂_marshall_pos
   refine ⟨r, hr_pos, ?_⟩

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyWitness.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyWitness.lean
@@ -25,7 +25,7 @@ This threads: the joint Casimir eigenvector (#3657), the sublattice Casimir
 bounds (#3677), the toy energy formula (#3673, eigenvalue uniqueness against
 `Ĥ_toy Ψ = μ Ψ`), the extremal-sector magnetization (#3678), the two-sided pin
 (#3676), and the Hermitian realness of the eigenvalue.  It is exactly the witness
-required by `tasaki23_pf_groundState_casimir_eq_predicted_of_witness` (#3656).
+required by `tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy` (#3656).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body
 Systems*, Springer 2020, §2.5 Theorem 2.3, p. 42.

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyWitnessPredicted.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyWitnessPredicted.lean
@@ -24,7 +24,7 @@ Assembly (for `|¬A| ≤ |A|`, so the extremal sector is `M = min(|A|,|¬A|)·N 
   #3656) pins the total Casimir of the embedded PF ground state to the predicted value.
 
 This is exactly the `hw_cas` witness consumed by the overlap pin
-`tasaki23_pf_groundState_casimir_eq_predicted_of_witness` (#3656's downstream), which
+`tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy` (#3656's downstream), which
 transfers the predicted total Casimir to the actual antiferromagnetic ground state.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body

--- a/LatticeSystem/Tests/SpinSBipartiteCompleteGraph.lean
+++ b/LatticeSystem/Tests/SpinSBipartiteCompleteGraph.lean
@@ -86,7 +86,7 @@ example {N : ℕ} [Fintype V] [DecidableEq V] (A : V → Bool)
     (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false) (hN : 1 ≤ N)
     {σ σ' : V → Fin (N + 1)} (hmag : magSumS σ = magSumS σ') :
     RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ σ' :=
-  raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_structural
+  raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS
     A hA_ne hB_ne hN hmag
 
 end LatticeSystem.Tests.SpinSBipartiteCompleteGraph


### PR DESCRIPTION
Tracked in #3921. Continues batch 7 (#3932). 5 more pairs (tasaki23_common_energy_step/groundEnergy/heis_sector/casimir_eigenvector/casimir_eq_predicted). 15 files / 44 lines. Build green. Remaining: ~9.