### PR TITLE
Refactor (Phase E, batch 9): rename last 8 twin pairs (except Prop) -- #3921

### DIFF
--- a/LatticeSystem/Quantum/SpinS/Theorem23IntervalCommonEnergy.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23IntervalCommonEnergy.lean
@@ -33,7 +33,7 @@ Given the Marshall-positive real sector eigen-equation `hReEig` of a connected b
 antiferromagnetic coupling `J` in an admissible sector `M`, the embedded vector is a
 full-space `H`-eigenvector at the same energy and a `(Ŝ_tot)²`-eigenvector at
 `tasaki23PredictedCasimirValue A N`. -/
-theorem tasaki23_sector_lift_and_casimir
+theorem tasaki23_sector_lift_and_casimir_legacy
     (A : V → Bool) (N : ℕ) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -69,7 +69,7 @@ theorem tasaki23_sector_lift_and_casimir
   have hH := heisenbergHamiltonianS_mulVec_magSectorEmbedding J
     (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) hComplex
   refine ⟨hH, ?_⟩
-  exact tasaki23_pf_groundState_casimir_eq_predicted_sector A N c c_toy horient hsB hM
+  exact tasaki23_pf_groundState_casimir_eq_predicted_sector_legacy A N c c_toy horient hsB hM
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy h_intermediate hv_pos hH
 
 /-- **Adjacent-sector common-energy step (Casimir route).** If the Marshall-positive
@@ -110,14 +110,14 @@ theorem tasaki23_common_energy_step_legacy
   have hM1_mem : M + 1 ∈ tasaki23GroundStateSectors (V := V) A N :=
     tasaki23GroundStateSectors_succ_mem_of_mem_of_lt_right A N hM_mem hM_lt
   -- Full-space lift and predicted Casimir for sector M.
-  obtain ⟨hH_M, hCas_M⟩ := tasaki23_sector_lift_and_casimir A N c c_toy horient hsB hM_mem
+  obtain ⟨hH_M, hCas_M⟩ := tasaki23_sector_lift_and_casimir_legacy A N c c_toy horient hsB hM_mem
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy h_intermediate hvM_pos
     hReEig_M
   -- Marshall-positive ground state in sector M + 1, with its full-space lift and Casimir.
   obtain ⟨μ', vM1, _hμ'_lt, hvM1_pos, hReEig_M1⟩ :=
     exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
       (M := M + 1) A N c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate
-  obtain ⟨hH_M1, hCas_M1⟩ := tasaki23_sector_lift_and_casimir A N c c_toy horient hsB hM1_mem
+  obtain ⟨hH_M1, hCas_M1⟩ := tasaki23_sector_lift_and_casimir_legacy A N c c_toy horient hsB hM1_mem
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy h_intermediate hvM1_pos
     hReEig_M1
   -- Casimir constancy forces equal energies.

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
@@ -39,7 +39,7 @@ eigenvalue `r` (with strictly positive Perron eigenvector `v`) is a scalar
 multiple of `v`.  Specialisation of
 `PerronFrobenius.eigenvec_proportional_of_pos_eigenvec` to the irreducible
 shifted dressed sector matrix. -/
-theorem tasaki23_shiftedDressed_sector_eigenvec_proportional
+theorem tasaki23_shiftedDressed_sector_eigenvec_proportional_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -68,7 +68,7 @@ same sector matrix at the same `μ` is a scalar multiple of `φ`.
 Marshall-conjugates `φ` and `w` to eigenvectors of the shifted dressed sector
 matrix (where `marshallSignS · φ > 0` is the strictly positive Perron
 eigenvector), applies the geometric simplicity
-`tasaki23_shiftedDressed_sector_eigenvec_proportional`, and conjugates back. -/
+`tasaki23_shiftedDressed_sector_eigenvec_proportional_legacy`, and conjugates back. -/
 theorem tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -92,7 +92,7 @@ theorem tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy
     shiftedDressedSReMatrixOnMagSector_mulVec_of_dressed_eigenvec A J N c
       (dressedHeisenbergSReMatrixOnMagSector_mulVec_of_heis_eigenvec A N hJ_real hw)
   obtain ⟨s, hs⟩ :=
-    tasaki23_shiftedDressed_sector_eigenvec_proportional A N c hJ_real hJ_pos
+    tasaki23_shiftedDressed_sector_eigenvec_proportional_legacy A N c hJ_real hJ_pos
       hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate hφs hφ_pos hws
   refine ⟨s, ?_⟩
   funext σ

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFSectorCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFSectorCasimir.lean
@@ -28,7 +28,7 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 `M ∈ tasaki23GroundStateSectors A N`, the Marshall-positive Perron–Frobenius ground state
 of an arbitrary connected bipartite antiferromagnetic coupling `J` is a `(Ŝ_tot)²`-
 eigenvector at `tasaki23PredictedCasimirValue A N`. -/
-theorem tasaki23_pf_groundState_casimir_eq_predicted_sector
+theorem tasaki23_pf_groundState_casimir_eq_predicted_sector_legacy
     (A : V → Bool) (N : ℕ) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -58,7 +58,7 @@ theorem tasaki23_pf_groundState_casimir_eq_predicted_sector
       ((tasaki23PredictedCasimirValue (V := V) A N : ℝ) : ℂ) •
         magSectorEmbedding (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) := by
   obtain ⟨w, hw_pos, hw_cas⟩ :=
-    tasaki23_toy_groundState_casimir_eq_predicted_at A N c_toy horient hsB hM hc_strict_toy
+    tasaki23_toy_groundState_casimir_eq_predicted_at_legacy A N c_toy horient hsB hM hc_strict_toy
       h_intermediate
   exact tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy A N c hJ_real hJ_pos
     hJ_nn hJ_sym hJ_bipartite hc_strict h_intermediate hv_pos hw_pos hH hw_cas

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFToyJointCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFToyJointCasimir.lean
@@ -38,7 +38,7 @@ The proof is the same one-dimensionality argument: `B Φ` is a Heisenberg
 eigenvector at the same `μ` (commutation with `Ĥ`) supported in the same
 magnetization sector (commutation with `Ŝ_tot^(3)`), so its real/imaginary parts
 are scalar multiples of the Marshall-positive ground state, giving `B Φ = γ Φ`. -/
-theorem tasaki23_pf_groundState_commuting_eigenvector
+theorem tasaki23_pf_groundState_commuting_eigenvector_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -160,7 +160,7 @@ eigenvector.  All three Casimirs commute with `Ĥ_toy` (it is their linear
 combination) and with `Ŝ_tot^(3)`, so the one-dimensionality of the ground
 eigenspace makes the ground state an eigenvector of each.  Pinning the three
 eigenvalues to the predicted values is the remaining variational obligation. -/
-theorem tasaki23_toy_groundState_joint_casimir_eigenvector
+theorem tasaki23_toy_groundState_joint_casimir_eigenvector_legacy
     (A : V → Bool) (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hc_strict : ∀ σ,
@@ -195,15 +195,15 @@ theorem tasaki23_toy_groundState_joint_casimir_eigenvector
   have hJ_bipartite : ∀ x y, A x = A y → bipartiteCoupling A x y = 0 :=
     fun _ _ h => bipartiteCoupling_eq_zero_of_same_sublattice A h
   refine ⟨?_, ?_, ?_⟩
-  · exact tasaki23_pf_groundState_commuting_eigenvector A N c hJ_real hJ_pos hJ_nn
+  · exact tasaki23_pf_groundState_commuting_eigenvector_legacy A N c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict h_intermediate (totalSpinSSquared V N)
       (heisenbergToyHamiltonianS_commute_totalSpinSSquared (N := N) (A := A))
       (totalSpinSSquared_commute_totalSpinSOp3 (Λ := V) (N := N)).symm hv_pos hH
-  · exact tasaki23_pf_groundState_commuting_eigenvector A N c hJ_real hJ_pos hJ_nn
+  · exact tasaki23_pf_groundState_commuting_eigenvector_legacy A N c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict h_intermediate (sublatticeSpinSquaredS N A)
       (heisenbergToyHamiltonianS_commute_sublatticeSpinSquaredS (N := N) (A := A))
       (sublatticeSpinSquaredS_commute_totalSpinSOp3 (Λ := V) (N := N) A).symm hv_pos hH
-  · exact tasaki23_pf_groundState_commuting_eigenvector A N c hJ_real hJ_pos hJ_nn
+  · exact tasaki23_pf_groundState_commuting_eigenvector_legacy A N c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict h_intermediate (sublatticeSpinSquaredS N (fun x => ! A x))
       (heisenbergToyHamiltonianS_commute_sublatticeSpinSquaredS_complement (N := N) (A := A))
       (sublatticeSpinSquaredS_commute_totalSpinSOp3 (Λ := V) (N := N) (fun x => ! A x)).symm

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralBipartiteToy.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralBipartiteToy.lean
@@ -124,7 +124,7 @@ theorem tasaki_2_5_theorem_2_3_bipartiteToy
       exact ⟨vM, hvM_pos, hReEig⟩
     · intro M _hM_non μM φ hφ_ne hφ
       haveI : Nonempty (magConfigS V N M) := nonempty_magConfigS_of_fn_ne_zero_structural hφ_ne
-      exact tasaki23_toy_sector_energy_ge_predicted_structural (N := N) A c horient hc_strict
+      exact tasaki23_toy_sector_energy_ge_predicted (N := N) A c horient hc_strict
         hA_ne hB_ne hN hφ_ne hφ
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralCasimirEigenvec.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralCasimirEigenvec.lean
@@ -4,7 +4,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralReach
 /-!
 # Structural Theorem 2.3 eigenvector proportionality (no `h_intermediate`)
 
-Extension of #3887 fix to `tasaki23_shiftedDressed_sector_eigenvec_proportional` /
+Extension of #3887 fix to `tasaki23_shiftedDressed_sector_eigenvec_proportional_legacy` /
 `tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy` via
 `isIrreducible_shiftedDressedSReMatrixOnMagSector`.
 
@@ -19,7 +19,7 @@ open LatticeSystem.Math.PerronFrobenius
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural shifted-dressed sector eigenvector proportionality (no `h_intermediate`)**. -/
-theorem tasaki23_shiftedDressed_sector_eigenvec_proportional_structural
+theorem tasaki23_shiftedDressed_sector_eigenvec_proportional
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -62,7 +62,7 @@ theorem tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive
     shiftedDressedSReMatrixOnMagSector_mulVec_of_dressed_eigenvec A J N c
       (dressedHeisenbergSReMatrixOnMagSector_mulVec_of_heis_eigenvec A N hJ_real hw)
   obtain ⟨s, hs⟩ :=
-    tasaki23_shiftedDressed_sector_eigenvec_proportional_structural A c hJ_real hJ_pos
+    tasaki23_shiftedDressed_sector_eigenvec_proportional A c hJ_real hJ_pos
       hJ_nn hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN hφs hφ_pos hws
   refine ⟨s, ?_⟩
   funext σ

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonEnergyStep.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralCommonEnergyStep.lean
@@ -6,7 +6,7 @@ import LatticeSystem.Quantum.SpinS.Theorem23PFConstancyCasimir
 # Structural adjacent-sector common-energy step (no `h_intermediate`)
 
 (PR #3893): structural variant of `tasaki23_common_energy_step_legacy` (TIER 4 step) using
-- `tasaki23_sector_lift_and_casimir_structural` (Step 1)
+- `tasaki23_sector_lift_and_casimir` (Step 1)
 - `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`
   (Thm23-#3887.9)
 - `tasaki23_pf_sector_energy_eq_of_casimir` (already h_intermediate-free)
@@ -52,7 +52,7 @@ theorem tasaki23_common_energy_step
         μ • (fun σ => (marshallSignS A σ.1).re * vM1 σ) := by
   have hM1_mem : M + 1 ∈ tasaki23GroundStateSectors (V := V) A N :=
     tasaki23GroundStateSectors_succ_mem_of_mem_of_lt_right A N hM_mem hM_lt
-  obtain ⟨hH_M, hCas_M⟩ := tasaki23_sector_lift_and_casimir_structural
+  obtain ⟨hH_M, hCas_M⟩ := tasaki23_sector_lift_and_casimir
     (N := N) (M := M) A c c_toy horient hsB hM_mem
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy
     hA_ne hB_ne hN hvM_pos hReEig_M
@@ -60,7 +60,7 @@ theorem tasaki23_common_energy_step
     exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector
       (N := N) (M := M + 1) A c hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict
       hA_ne hB_ne hN
-  obtain ⟨hH_M1, hCas_M1⟩ := tasaki23_sector_lift_and_casimir_structural
+  obtain ⟨hH_M1, hCas_M1⟩ := tasaki23_sector_lift_and_casimir
     (N := N) (M := M + 1) A c c_toy horient hsB hM1_mem
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy
     hA_ne hB_ne hN hvM1_pos hReEig_M1

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFJointCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFJointCasimir.lean
@@ -6,8 +6,8 @@ import LatticeSystem.Quantum.SpinS.SublatticeCasimirSpectralBound
 # Structural Theorem 2.3 PF ground state commuting + joint Casimir eigenvector (no `h_intermediate`)
 
 Extension of #3887 fix to:
-- `tasaki23_pf_groundState_commuting_eigenvector`
-- `tasaki23_toy_groundState_joint_casimir_eigenvector`
+- `tasaki23_pf_groundState_commuting_eigenvector_legacy`
+- `tasaki23_toy_groundState_joint_casimir_eigenvector_legacy`
 
 Both use `tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive`
 (Thm23-#3887.3) instead of the original h_intermediate-bearing variant.
@@ -21,7 +21,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural PF ground state commuting eigenvector (no `h_intermediate`)**. -/
-theorem tasaki23_pf_groundState_commuting_eigenvector_structural
+theorem tasaki23_pf_groundState_commuting_eigenvector
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
@@ -136,7 +136,7 @@ theorem tasaki23_pf_groundState_commuting_eigenvector_structural
     rw [hΦ_supp ρ hρ, mul_zero]
 
 /-- **Structural toy ground state joint Casimir eigenvector (no `h_intermediate`)**. -/
-theorem tasaki23_toy_groundState_joint_casimir_eigenvector_structural
+theorem tasaki23_toy_groundState_joint_casimir_eigenvector
     (A : V → Bool) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hc_strict : ∀ σ,
@@ -170,22 +170,22 @@ theorem tasaki23_toy_groundState_joint_casimir_eigenvector_structural
   have hJ_bipartite : ∀ x y, A x = A y → bipartiteCoupling A x y = 0 :=
     fun _ _ h => bipartiteCoupling_eq_zero_of_same_sublattice A h
   refine ⟨?_, ?_, ?_⟩
-  · exact tasaki23_pf_groundState_commuting_eigenvector_structural A c hJ_real hJ_pos hJ_nn
+  · exact tasaki23_pf_groundState_commuting_eigenvector A c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN (totalSpinSSquared V N)
       (heisenbergToyHamiltonianS_commute_totalSpinSSquared (N := N) (A := A))
       (totalSpinSSquared_commute_totalSpinSOp3 (Λ := V) (N := N)).symm hv_pos hH
-  · exact tasaki23_pf_groundState_commuting_eigenvector_structural A c hJ_real hJ_pos hJ_nn
+  · exact tasaki23_pf_groundState_commuting_eigenvector A c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN (sublatticeSpinSquaredS N A)
       (heisenbergToyHamiltonianS_commute_sublatticeSpinSquaredS (N := N) (A := A))
       (sublatticeSpinSquaredS_commute_totalSpinSOp3 (Λ := V) (N := N) A).symm hv_pos hH
-  · exact tasaki23_pf_groundState_commuting_eigenvector_structural A c hJ_real hJ_pos hJ_nn
+  · exact tasaki23_pf_groundState_commuting_eigenvector A c hJ_real hJ_pos hJ_nn
       hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN (sublatticeSpinSquaredS N (fun x => ! A x))
       (heisenbergToyHamiltonianS_commute_sublatticeSpinSquaredS_complement (N := N) (A := A))
       (sublatticeSpinSquaredS_commute_totalSpinSOp3 (Λ := V) (N := N) (fun x => ! A x)).symm
       hv_pos hH
 
 /-- **Structural toy ground state sublattice Casimir bounds (no `h_intermediate`)**. -/
-theorem tasaki23_toy_groundState_sublattice_casimir_re_le_structural
+theorem tasaki23_toy_groundState_sublattice_casimir_re_le
     (A : V → Bool) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hc_strict : ∀ σ,
@@ -214,14 +214,14 @@ theorem tasaki23_toy_groundState_sublattice_casimir_re_le_structural
           ((Finset.univ.filter (fun x : V => (! A x) = true)).card : ℝ) * (N : ℝ) / 2 *
             (((Finset.univ.filter (fun x : V => (! A x) = true)).card : ℝ) * (N : ℝ) / 2 + 1)) := by
   obtain ⟨_, ⟨γ_A, hγ_A⟩, ⟨γ_B, hγ_B⟩⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector_structural A c hc_strict
+    tasaki23_toy_groundState_joint_casimir_eigenvector A c hc_strict
       hA_ne hB_ne hN hv_pos hH
   have hne := tasaki23_marshallPositive_magSectorEmbedding_ne_zero A hv_pos
   exact ⟨⟨γ_A, hγ_A, sublatticeSpinSquaredS_eigenvalue_re_le_sA A hne hγ_A⟩,
     ⟨γ_B, hγ_B, sublatticeSpinSquaredS_eigenvalue_re_le_sA (fun x => ! A x) hne hγ_B⟩⟩
 
 /-- **Structural PF GS Casimir eigenvector (no `h_intermediate`)**: specialisation of
-`tasaki23_pf_groundState_commuting_eigenvector_structural` to `B = (Ŝ_tot)²`. -/
+`tasaki23_pf_groundState_commuting_eigenvector` to `B = (Ŝ_tot)²`. -/
 theorem tasaki23_pf_groundState_casimir_eigenvector
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -246,7 +246,7 @@ theorem tasaki23_pf_groundState_casimir_eigenvector
             (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ))) =
         γ • magSectorEmbedding
           (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) :=
-  tasaki23_pf_groundState_commuting_eigenvector_structural A c hJ_real hJ_pos hJ_nn
+  tasaki23_pf_groundState_commuting_eigenvector A c hJ_real hJ_pos hJ_nn
     hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN (totalSpinSSquared V N)
     (heisenbergHamiltonianS_commute_totalSpinSSquared J N)
     (totalSpinSSquared_commute_totalSpinSOp3 (Λ := V) (N := N)).symm hv_pos hH

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFSectorCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFSectorCasimir.lean
@@ -5,8 +5,8 @@ import LatticeSystem.Quantum.SpinS.Theorem23StructuralPFCasimirPredicted
 /-!
 # Structural PF GS Casimir = predicted at admissible sector (no `h_intermediate`)
 
-(Thm23-#3887.11): structural variant of `tasaki23_pf_groundState_casimir_eq_predicted_sector`
-using `tasaki23_toy_groundState_casimir_eq_predicted_at_structural` (Thm23-#3887.10) +
+(Thm23-#3887.11): structural variant of `tasaki23_pf_groundState_casimir_eq_predicted_sector_legacy`
+using `tasaki23_toy_groundState_casimir_eq_predicted_at` (Thm23-#3887.10) +
 `tasaki23_pf_groundState_casimir_eq_predicted_of_witness` (Thm23-#3887.8).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -18,7 +18,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural PF GS Casimir = predicted at admissible sector (no `h_intermediate`)**. -/
-theorem tasaki23_pf_groundState_casimir_eq_predicted_sector_structural
+theorem tasaki23_pf_groundState_casimir_eq_predicted_sector
     (A : V → Bool) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -47,7 +47,7 @@ theorem tasaki23_pf_groundState_casimir_eq_predicted_sector_structural
       ((tasaki23PredictedCasimirValue (V := V) A N : ℝ) : ℂ) •
         magSectorEmbedding (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) := by
   obtain ⟨w, hw_pos, hw_cas⟩ :=
-    tasaki23_toy_groundState_casimir_eq_predicted_at_structural
+    tasaki23_toy_groundState_casimir_eq_predicted_at
       (N := N) (M := M) A c_toy horient hsB hM hc_strict_toy hA_ne hB_ne hN
   exact tasaki23_pf_groundState_casimir_eq_predicted_of_witness
     (N := N) (M := M) A c hJ_real hJ_pos

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorLiftCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorLiftCasimir.lean
@@ -4,9 +4,9 @@ import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSectorMarshall
 /-!
 # Structural per-sector lift + predicted Casimir (no `h_intermediate`)
 
-(PR #3893): structural variant of `tasaki23_sector_lift_and_casimir`
+(PR #3893): structural variant of `tasaki23_sector_lift_and_casimir_legacy`
 (in `Theorem23IntervalCommonEnergy.lean`) using
-`tasaki23_pf_groundState_casimir_eq_predicted_sector_structural` (Thm23-#3887.11).
+`tasaki23_pf_groundState_casimir_eq_predicted_sector` (Thm23-#3887.11).
 
 Lifts a Marshall-positive real sector eigenvector to the full Hilbert space
 (`heisenbergHamiltonianSMatrixOnMagSector_mulVec_ofReal` +
@@ -23,7 +23,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural per-sector lift + predicted Casimir (no `h_intermediate`)**. -/
-theorem tasaki23_sector_lift_and_casimir_structural
+theorem tasaki23_sector_lift_and_casimir
     (A : V → Bool) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -58,7 +58,7 @@ theorem tasaki23_sector_lift_and_casimir_structural
   have hH := heisenbergHamiltonianS_mulVec_magSectorEmbedding J
     (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) hComplex
   refine ⟨hH, ?_⟩
-  exact tasaki23_pf_groundState_casimir_eq_predicted_sector_structural
+  exact tasaki23_pf_groundState_casimir_eq_predicted_sector
     (N := N) (M := M) A c c_toy horient hsB hM
     hJ_real hJ_pos hJ_nn hJ_sym hJ_bipartite hc_strict hc_strict_toy
     hA_ne hB_ne hN hv_pos hH

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralToyGSPredictedCasimirAt.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralToyGSPredictedCasimirAt.lean
@@ -10,9 +10,9 @@ set_option linter.unusedVariables false
 # Structural toy ground state has predicted total Casimir (no `h_intermediate`)
 
 (Thm23-#3887.10): structural variant of
-`tasaki23_toy_groundState_casimir_eq_predicted_at` using
+`tasaki23_toy_groundState_casimir_eq_predicted_at_legacy` using
 - `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector` (Thm23-#3887.9)
-- `tasaki23_toy_groundState_joint_casimir_eigenvector_structural` (Thm23-#3887.5)
+- `tasaki23_toy_groundState_joint_casimir_eigenvector` (Thm23-#3887.5)
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
 Springer 2020, §2.5 Theorem 2.3, p. 42.
@@ -23,7 +23,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural toy GS has predicted total Casimir at admissible sector (no `h_intermediate`)**. -/
-theorem tasaki23_toy_groundState_casimir_eq_predicted_at_structural
+theorem tasaki23_toy_groundState_casimir_eq_predicted_at
     (A : V → Bool) (c : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -69,7 +69,7 @@ theorem tasaki23_toy_groundState_casimir_eq_predicted_at_structural
   have hH := heisenbergHamiltonianS_mulVec_magSectorEmbedding (bipartiteCoupling A)
     (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) hComplex
   obtain ⟨⟨γ_tot, htot⟩, ⟨γ_A, hA⟩, ⟨γ_B, hB⟩⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector_structural A c hc_strict
+    tasaki23_toy_groundState_joint_casimir_eigenvector A c hc_strict
       hA_ne hB_ne hN hv_pos hH
   set w : (V → Fin (N + 1)) → ℂ :=
     magSectorEmbedding (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) with hw

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralToySectorGroundState.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralToySectorGroundState.lean
@@ -11,7 +11,7 @@ import LatticeSystem.Quantum.SpinS.BipartiteToyMinEnergy
 at predicted-energy package (the original `toy_sector_groundState_at_predicted`
 witness was removed together with `Theorem23ToyFinal.lean` in PR #3917). Uses
 - `tasaki_2_5_theorem_2_3_sector_existence` (Thm23-#3887.16)
-- `tasaki23_toy_sector_energy_ge_predicted_structural` (Thm23-#3887.17)
+- `tasaki23_toy_sector_energy_ge_predicted` (Thm23-#3887.17)
 - `tasaki23_toy_sector_groundEnergy_le_of_witness` (already h_intermediate-free)
 - `exists_predictedEnergy_sector_eigenvector_of_mem` (already h_intermediate-free)
 
@@ -78,7 +78,7 @@ theorem toy_sector_groundState_at_predicted
     rw [← mul_assoc, marshallSignS_re_sq, one_mul]
     exact hvM_pos σ
   have hge : E ≤ μM :=
-    tasaki23_toy_sector_energy_ge_predicted_structural (N := N) A c horient hc_strict
+    tasaki23_toy_sector_energy_ge_predicted (N := N) A c horient hc_strict
       hA_ne hB_ne hN
       (φ := fun σ => (marshallSignS A σ.1).re * vM σ)
       (by

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralToySectorLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralToySectorLowerBound.lean
@@ -8,9 +8,9 @@ import LatticeSystem.Quantum.SpinS.BipartiteToyMinEnergy
 /-!
 # Structural toy sector energy lower bound (no `h_intermediate`)
 
-(Thm23-#3887.17): structural variant of `tasaki23_toy_sector_energy_ge_predicted`
+(Thm23-#3887.17): structural variant of `tasaki23_toy_sector_energy_ge_predicted_legacy`
 using `exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector`
-(Thm23-#3887.9) and `tasaki23_toy_groundState_joint_casimir_eigenvector_structural`
+(Thm23-#3887.9) and `tasaki23_toy_groundState_joint_casimir_eigenvector`
 (Thm23-#3887.5).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
@@ -22,7 +22,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-- **Structural toy sector energy lower bound (every sector, no `h_intermediate`)**. -/
-theorem tasaki23_toy_sector_energy_ge_predicted_structural
+theorem tasaki23_toy_sector_energy_ge_predicted
     (A : V → Bool) (c : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -58,7 +58,7 @@ theorem tasaki23_toy_sector_energy_ge_predicted_structural
   have hH := heisenbergHamiltonianS_mulVec_magSectorEmbedding (bipartiteCoupling A)
     (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) hComplex
   obtain ⟨⟨γ_tot, htot⟩, ⟨γ_A, hA⟩, ⟨γ_B, hB⟩⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector_structural A c hc_strict
+    tasaki23_toy_groundState_joint_casimir_eigenvector A c hc_strict
       hA_ne hB_ne hN hv_pos hH
   have hEnergy := heisenbergToyHamiltonianS_mulVec_of_joint_casimir_eigenvector A htot hA hB
   have hμGS_eq : γ_tot - γ_A - γ_B = (μGS : ℂ) :=

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyGSPredictedCasimirAt.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyGSPredictedCasimirAt.lean
@@ -30,7 +30,7 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 `M ∈ tasaki23GroundStateSectors A N` there is a Marshall-positive `v > 0` whose embedding
 `magSectorEmbedding (sign · v)` is a `(Ŝ_tot)²`-eigenvector at
 `tasaki23PredictedCasimirValue A N`. -/
-theorem tasaki23_toy_groundState_casimir_eq_predicted_at
+theorem tasaki23_toy_groundState_casimir_eq_predicted_at_legacy
     (A : V → Bool) (N : ℕ) (c : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -81,7 +81,7 @@ theorem tasaki23_toy_groundState_casimir_eq_predicted_at
     (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) hComplex
   -- The toy ground state is a joint Casimir eigenvector (#3657).
   obtain ⟨⟨γ_tot, htot⟩, ⟨γ_A, hA⟩, ⟨γ_B, hB⟩⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos hH
   set w : (V → Fin (N + 1)) → ℂ :=
     magSectorEmbedding (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) with hw
   -- Energy: μ = γ_tot − γ_A − γ_B, so (γ_tot − γ_A − γ_B).re ≤ E.

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToySectorEnergyLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToySectorEnergyLowerBound.lean
@@ -32,7 +32,7 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 `J = bipartiteCoupling A` (with `|¬A| ≤ |A|`), in *any* magnetisation sector `M` the
 predicted minimum energy `(bipartiteToyMinEnergyPredicted A N).re` is below every
 eigenvalue `μM` of the dressed sector matrix. -/
-theorem tasaki23_toy_sector_energy_ge_predicted
+theorem tasaki23_toy_sector_energy_ge_predicted_legacy
     (A : V → Bool) (N : ℕ) (c : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
       (Finset.univ.filter (fun x : V => A x = true)).card)
@@ -72,7 +72,7 @@ theorem tasaki23_toy_sector_energy_ge_predicted
   have hH := heisenbergHamiltonianS_mulVec_magSectorEmbedding (bipartiteCoupling A)
     (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) hComplex
   obtain ⟨⟨γ_tot, htot⟩, ⟨γ_A, hA⟩, ⟨γ_B, hB⟩⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos hH
   -- The ground-state energy equals the Casimir combination `(γ_tot − γ_A − γ_B).re`.
   have hEnergy := heisenbergToyHamiltonianS_mulVec_of_joint_casimir_eigenvector A htot hA hB
   have hμGS_eq : γ_tot - γ_A - γ_B = (μGS : ℂ) :=

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToySublatticeBounds.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToySublatticeBounds.lean
@@ -27,7 +27,7 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 Marshall-positive ground state of `Ĥ_toy` is a joint Casimir eigenvector whose
 `(Ŝ_A)²` and `(Ŝ_¬A)²` eigenvalues `γ_A, γ_B` obey `γ_A.re ≤ s_A(s_A+1)` and
 `γ_B.re ≤ s_B(s_B+1)` (`s_A = |A|·N/2`, `s_B = |¬A|·N/2`). -/
-theorem tasaki23_toy_groundState_sublattice_casimir_re_le
+theorem tasaki23_toy_groundState_sublattice_casimir_re_le_legacy
     (A : V → Bool) (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
     (hc_strict : ∀ σ,
@@ -57,7 +57,7 @@ theorem tasaki23_toy_groundState_sublattice_casimir_re_le
           ((Finset.univ.filter (fun x : V => (! A x) = true)).card : ℝ) * (N : ℝ) / 2 *
             (((Finset.univ.filter (fun x : V => (! A x) = true)).card : ℝ) * (N : ℝ) / 2 + 1)) := by
   obtain ⟨_, ⟨γ_A, hγ_A⟩, ⟨γ_B, hγ_B⟩⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos hH
   have hne := tasaki23_marshallPositive_magSectorEmbedding_ne_zero A hv_pos
   exact ⟨⟨γ_A, hγ_A, sublatticeSpinSquaredS_eigenvalue_re_le_sA A hne hγ_A⟩,
     ⟨γ_B, hγ_B, sublatticeSpinSquaredS_eigenvalue_re_le_sA (fun x => ! A x) hne hγ_B⟩⟩

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyWitness.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyWitness.lean
@@ -74,10 +74,10 @@ theorem tasaki23_toy_groundState_casimir_eq_predicted_of_energy_le
   have hΨ_ne : Ψ ≠ 0 := tasaki23_marshallPositive_magSectorEmbedding_ne_zero A hv_pos
   -- Joint Casimir eigenvector (#3657): total and sublattice eigen-equations.
   obtain ⟨⟨γ_tot, htot⟩, _, _⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos hH
   -- Sublattice Casimir bounds (#3677).
   obtain ⟨⟨γ_A, hA_eq, hA_bd⟩, ⟨γ_B, hB_eq, hB_bd⟩⟩ :=
-    tasaki23_toy_groundState_sublattice_casimir_re_le A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_sublattice_casimir_re_le_legacy A N c hc_strict h_intermediate hv_pos hH
   -- Toy energy formula (#3673): Ĥ_toy Ψ = (γ_tot − γ_A − γ_B) • Ψ.
   have hEnergy := heisenbergToyHamiltonianS_mulVec_of_joint_casimir_eigenvector A htot hA_eq hB_eq
   -- Ĥ_toy = heisenbergHamiltonianS (bipartiteCoupling A); so μ = γ_tot − γ_A − γ_B.


### PR DESCRIPTION
Tracked in #3921. Final non-Prop batch. 17 files / 58 lines. Build green. After merge: only  Prop def remains; that requires separate handling (statement vs proof witness).