### PR TITLE
Refactor (Phase F): mark 34 _legacy h_intermediate symbols as @[deprecated] -- #3921

### DIFF
--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -252,6 +252,8 @@ For an over site `x` and under site `y` with `x ≠ y`, the intermediate-
 existence hypothesis `h_intermediate` guarantees a transport when
 `A x = A y` (only used in the hard case). The conclusion combines
 both cases as a `RaiseLowerReachableS` (which subsumes a single step). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem exists_raiseLowerReachableS_bipartite_of_over_under_legacy
     {A : V → Bool} {σ σ' : V → Fin (N + 1)}
     {x y : V} (hxy : x ≠ y)
@@ -292,6 +294,8 @@ extreme).
 Proof: strong induction on `configDistS`, using
 `exists_raiseLowerReachableS_bipartite_of_over_under_legacy` (PR #821) at
 each step (which combines the easy and hard cases). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy
     (A : V → Bool)
     (h_intermediate : ∀ τ : V → Fin (N + 1), ∀ x : V,

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapBlockIrreducibleUnconditional.lean
@@ -27,6 +27,8 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **Parity-block shifted PF matrix is irreducible** (unconditional under case (i.2) strict).
 Discharges the totality hypothesis of #3797 via #3823 `parityReachableS_total_legacy`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPF.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPF.lean
@@ -35,6 +35,8 @@ Combining (j.1) positive PF eigenvector existence + (j.13.h.1) generic shift
 identification + matrix-identity bridge between real-lifted and complex submatrix,
 the dressed submatrix's `hermitianMinEigenvalue` equals the un-shifted PF value
 `ν = c - μ_PF`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf_legacy
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
@@ -130,6 +132,8 @@ theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalu
 /-- **(j.13.h.2-bare) Bare submatrix hermitianMinEigenvalue identification**.
 
 Transfer (j.13.h.2-dressed) via Marshall similarity (j.8) #3865. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf_legacy
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSector.lean
@@ -109,6 +109,8 @@ input on the subtype). Composition of:
 - Sector matrix-pow lift from reachability (#843).
 - Sector matrix non-negativity (#834).
 - Sector matrix step positivity (#842). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem exists_matrixPow_pos_of_magConfigS_bipartite_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
@@ -135,6 +137,8 @@ theorem exists_matrixPow_pos_of_magConfigS_bipartite_legacy
 /-- **Strict positive-length matrix-power positivity** on the sector
 for distinct configurations: for σ ≠ σ' in the same sector, the
 matrix-power is positive at some k ≥ 1 (excluding the trivial k = 0). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem exists_matrixPow_pos_length_of_magConfigS_bipartite_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
@@ -170,6 +174,8 @@ Proof: combines the matrix-power positivity for distinct σ ≠ σ'
 (#845) with the diagonal positivity (`M σ σ = c - dressed σ σ > 0`
 when `c > dressed σ σ`) via the
 `Matrix.isIrreducible_iff_exists_pow_pos` characterization. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem isIrreducible_shiftedDressedSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
@@ -211,6 +217,8 @@ and a strictly positive eigenvector `v > 0` (componentwise) with
 Direct corollary of `Matrix.IsIrreducible` (#846) +
 `exists_positive_eigenvector_of_irreducible` from the project's
 Perron–Frobenius infrastructure. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem exists_positive_eigenvector_shiftedDressedSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
@@ -240,6 +248,8 @@ Direct corollary of `Matrix.IsIrreducible` (#846) and
 non-degeneracy half of Tasaki §2.5 Theorem 2.2 for general spin (the
 ground-state in each magnetization sector is unique up to a positive
 scalar, equivalently 1-dimensional). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
@@ -344,6 +354,8 @@ eigenvalue `c - r < c` (where `r > 0` is the Perron eigenvalue of
 the shifted matrix).
 
 Combines #847 (existence) with #849 (eigenvalue conversion). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem exists_positive_eigenvector_dressedHeisenbergSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorEigenvalueUnique.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorEigenvalueUnique.lean
@@ -311,6 +311,8 @@ Composition of:
   (PR #853, real-form existence).
 - `heisenbergHamiltonianSMatrixOnMagSector_mulVec_ofReal`
   (PR #858, real → complex eigenvector lift). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem exists_marshallSign_complexEigenvector_heisenbergHamiltonianSMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
@@ -421,6 +423,8 @@ and their real parts are positive scalar multiples of each other.
 
 Proof: extract real parts via PR #861 to reduce to the real-form
 Marshall-positive uniqueness theorems (PRs #854, #856). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem marshallPositive_complexEigenvec_re_unique_heisenbergHamiltonianSMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}

--- a/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedMatrixOnMagSectorMarshall.lean
@@ -261,6 +261,8 @@ The eigenvector `w τ := sign A τ.1 .re * v τ` has `|w τ| = v τ > 0`,
 so `w` is everywhere non-zero. The sign of `w` matches the Marshall sign
 structure. This is the ground-state half of Tasaki §2.5 Theorem 2.2 in
 the magnetization sector. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem exists_marshallSign_eigenvector_heisenbergHamiltonianSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
@@ -376,6 +378,8 @@ Reduction to `pos_eigenvec_unique_shiftedDressedSReMatrixOnMagSector_legacy`
 (#848): convert both `dressed_sec`-eigenvectors to `shifted_sec`-
 eigenvectors at the shifted eigenvalue `c - μ`, then apply PF
 uniqueness on the shifted matrix. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem pos_eigenvec_unique_dressedHeisenbergSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
@@ -414,6 +418,8 @@ Reduction: by inverse Marshall conjugation, the conjugates `vᵢ := sign · wᵢ
 are positive eigenvectors of the dressed sector matrix at `μ`. By dressed
 sector uniqueness (this PR) `v₂ = r • v₁` for some `r > 0`. Multiplying
 both sides by `sign` (which squares to 1) gives `w₂ = r • w₁`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem marshallPositive_eigenvec_unique_heisenbergHamiltonianSReMatrixOnMagSector_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}

--- a/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedSubmatrixPFEigenvector.lean
@@ -33,6 +33,8 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **Existence of a strictly positive eigenvector for the unshifted dressed-`Ĥ'` parity-block
 submatrix**, derived from PF on the shifted matrix. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_legacy
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/MagConfig.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfig.lean
@@ -169,6 +169,8 @@ chain in the bipartite complete graph.
 
 Proof: combine the full-type bipartite reachability theorem (#823)
 with the subtype lifting (#840). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph_legacy
     (A : V → Bool) {M : ℕ}
     (h_intermediate : ∀ τ : V → Fin (N + 1), ∀ x : V,

--- a/LatticeSystem/Quantum/SpinS/MagSectorEmbedding.lean
+++ b/LatticeSystem/Quantum/SpinS/MagSectorEmbedding.lean
@@ -598,6 +598,8 @@ Composition of:
 This is the COMPLEX-Hilbert-space form of Tasaki §2.5 Theorem 2.2 on
 the actual quantum Heisenberg Hamiltonian, lifted from the sector
 form (PRs #847–#865). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem exists_marshallSign_eigenvector_heisenbergHamiltonianS_full_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
@@ -733,6 +735,8 @@ the §2.5 ground state on the actual quantum Heisenberg Hamiltonian.
 This is the COMPLEX-Hilbert-space form of Tasaki §2.5 Theorem 2.2 on
 the actual quantum Heisenberg Hamiltonian, lifted from the magnetization
 sector form (PRs #847–#865). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full_legacy
     (A : V → Bool)
     {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}

--- a/LatticeSystem/Quantum/SpinS/ParityReachTotal.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachTotal.lean
@@ -37,6 +37,8 @@ set_option linter.unusedDecidableInType false in
 /-- **`ParityReachableS` totality on the bipartite complete graph**: any two configurations of
 the same total-magnetization parity are `ParityReachableS`-connected.  Discharges the
 `hreach_total` hypothesis of the parity-block matrix irreducibility theorem #3797. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem parityReachableS_total_legacy
     (A : V → Bool)
     (hA_ne : ∃ a, A a = true)

--- a/LatticeSystem/Quantum/SpinS/Theorem23IntervalCommonEnergy.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23IntervalCommonEnergy.lean
@@ -33,6 +33,8 @@ Given the Marshall-positive real sector eigen-equation `hReEig` of a connected b
 antiferromagnetic coupling `J` in an admissible sector `M`, the embedded vector is a
 full-space `H`-eigenvector at the same energy and a `(Ŝ_tot)²`-eigenvector at
 `tasaki23PredictedCasimirValue A N`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_sector_lift_and_casimir_legacy
     (A : V → Bool) (N : ℕ) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
@@ -76,6 +78,8 @@ theorem tasaki23_sector_lift_and_casimir_legacy
 Perron–Frobenius ground state in admissible sector `M` has energy `μ`, and `M` is not the
 right endpoint of the admissible interval, then the Marshall-positive ground state in the
 next sector `M + 1` also has energy `μ`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_common_energy_step_legacy
     (A : V → Bool) (N : ℕ) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤
@@ -137,6 +141,8 @@ theorem tasaki23_common_energy_step_legacy
 There is a single energy `μ` such that in *every* admissible sector
 `M ∈ tasaki23GroundStateSectors A N` the connected bipartite antiferromagnetic coupling `J`
 has a Marshall-positive Perron–Frobenius ground state of energy `μ`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_common_groundEnergy_legacy
     (A : V → Bool) (N : ℕ) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
@@ -39,6 +39,8 @@ eigenvalue `r` (with strictly positive Perron eigenvector `v`) is a scalar
 multiple of `v`.  Specialisation of
 `PerronFrobenius.eigenvec_proportional_of_pos_eigenvec` to the irreducible
 shifted dressed sector matrix. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_shiftedDressed_sector_eigenvec_proportional_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -69,6 +71,8 @@ Marshall-conjugates `φ` and `w` to eigenvectors of the shifted dressed sector
 matrix (where `marshallSignS · φ > 0` is the strictly positive Perron
 eigenvector), applies the geometric simplicity
 `tasaki23_shiftedDressed_sector_eigenvec_proportional_legacy`, and conjugates back. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -120,6 +124,8 @@ Marshall-positive ground state by the one-dimensionality
 `tasaki23_heis_sector_eigenvec_proportional_of_marshallPositive_legacy`.  Recombining,
 `(Ŝtot)² Φ = γ Φ`.  This pins the total spin of the ground state (total-spin
 determination, Tasaki §2.5 p.42). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_pf_groundState_casimir_eigenvector_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirPredicted.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirPredicted.lean
@@ -81,6 +81,8 @@ Tasaki's overlap argument: `Φ` is a total-Casimir eigenvector at some real `γ`
 (`tasaki23_pf_groundState_casimir_eigenvector_legacy` + `isHermitian_eigenvalue_star_eq`);
 the Marshall-positive overlap with `w` is non-zero, so
 `tasaki23_marshallPositive_casimir_eigenvalue_eq` forces `γ = predicted`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_pf_groundState_casimir_eq_predicted_of_witness_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFSectorCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFSectorCasimir.lean
@@ -28,6 +28,8 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 `M ∈ tasaki23GroundStateSectors A N`, the Marshall-positive Perron–Frobenius ground state
 of an arbitrary connected bipartite antiferromagnetic coupling `J` is a `(Ŝ_tot)²`-
 eigenvector at `tasaki23PredictedCasimirValue A N`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_pf_groundState_casimir_eq_predicted_sector_legacy
     (A : V → Bool) (N : ℕ) (c c_toy : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFToyJointCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFToyJointCasimir.lean
@@ -38,6 +38,8 @@ The proof is the same one-dimensionality argument: `B Φ` is a Heisenberg
 eigenvector at the same `μ` (commutation with `Ĥ`) supported in the same
 magnetization sector (commutation with `Ŝ_tot^(3)`), so its real/imaginary parts
 are scalar multiples of the Marshall-positive ground state, giving `B Φ = γ Φ`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_pf_groundState_commuting_eigenvector_legacy
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]
@@ -160,6 +162,8 @@ eigenvector.  All three Casimirs commute with `Ĥ_toy` (it is their linear
 combination) and with `Ŝ_tot^(3)`, so the one-dimensionality of the ground
 eigenspace makes the ground state an eigenvector of each.  Pinning the three
 eigenvalues to the predicted values is the remaining variational obligation. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_toy_groundState_joint_casimir_eigenvector_legacy
     (A : V → Bool) (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyGSPredictedCasimirAt.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyGSPredictedCasimirAt.lean
@@ -30,6 +30,8 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 `M ∈ tasaki23GroundStateSectors A N` there is a Marshall-positive `v > 0` whose embedding
 `magSectorEmbedding (sign · v)` is a `(Ŝ_tot)²`-eigenvector at
 `tasaki23PredictedCasimirValue A N`. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_toy_groundState_casimir_eq_predicted_at_legacy
     (A : V → Bool) (N : ℕ) (c : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToySectorEnergyLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToySectorEnergyLowerBound.lean
@@ -32,6 +32,8 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 `J = bipartiteCoupling A` (with `|¬A| ≤ |A|`), in *any* magnetisation sector `M` the
 predicted minimum energy `(bipartiteToyMinEnergyPredicted A N).re` is below every
 eigenvalue `μM` of the dressed sector matrix. -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_toy_sector_energy_ge_predicted_legacy
     (A : V → Bool) (N : ℕ) (c : ℝ)
     (horient : (Finset.univ.filter (fun x : V => (! A x) = true)).card ≤

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToySublatticeBounds.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToySublatticeBounds.lean
@@ -27,6 +27,8 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 Marshall-positive ground state of `Ĥ_toy` is a joint Casimir eigenvector whose
 `(Ŝ_A)²` and `(Ŝ_¬A)²` eigenvalues `γ_A, γ_B` obey `γ_A.re ≤ s_A(s_A+1)` and
 `γ_B.re ≤ s_B(s_B+1)` (`s_A = |A|·N/2`, `s_B = |¬A|·N/2`). -/
+@[deprecated (since := "2026-05-30")]
+
 theorem tasaki23_toy_groundState_sublattice_casimir_re_le_legacy
     (A : V → Bool) (N : ℕ) (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]


### PR DESCRIPTION
Tracked in #3921. **Concludes Phase F** for now.

## Summary

Add `@[deprecated (since := "2026-05-30")]` attribute to all 34 `_legacy`-suffixed h_intermediate twin symbols across 18 files.

## Rationale

The `_legacy` symbols were created by Phase E batch 3-10 (PRs #3928-#3935) by renaming the original h_intermediate twins out of the canonical name space. Source deletion is blocked by intra-file elaboration coupling (see Phase E batch 2 step 2 retrospective in `.self-local/docs/structural-consolidation-2026-05-30.md`), so we keep the source but mark it as deprecated. Downstream consumers — if any reappear later — will get a deprecation warning pointing to the canonical structural variant.

## Stats

- 18 files modified, 68 lines added (2 lines per legacy symbol: `@[deprecated ...]` + blank line).
- Build: 3505 jobs, green.

## Future work

Eventual deletion of `_legacy` symbols depends on either: (a) removing the private helpers in the same file that they share elaboration state with, or (b) the entire file becoming deletable.

## Test plan

- [x] `lake build` succeeds.
- [ ] CI green.
