### PR TITLE
Theorem 2.4 obligation (2) bricks 1–3: Ĥ(λ, D) continuity + sector restriction — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuity.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuity.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Quantum.SpinS.AnisotropicHeisenberg
+import LatticeSystem.Quantum.SpinS.MagConfig
 import Mathlib.Topology.Instances.Matrix
 
 /-!
@@ -54,5 +55,23 @@ theorem continuous_anisotropicHeisenbergS (J : Λ → Λ → ℂ) (N : ℕ) :
     exact Continuous.smul continuous_const
       ((continuous_spinSDotXXZ x y N).comp continuous_fst)
   · exact (continuous_singleIonAnisotropyS N).comp continuous_snd
+
+/-- **Sector restriction** of the anisotropic Hamiltonian to the
+magnetisation-`M` configuration subspace, obtained as a Matrix submatrix
+indexed by `magConfigS Λ N M` (the subtype of magnetisation-`M` configurations). -/
+noncomputable def anisotropicHeisenbergS_magSector_submatrix
+    (J : Λ → Λ → ℂ) (lam D : ℂ) (N M : ℕ) :
+    Matrix (magConfigS Λ N M) (magConfigS Λ N M) ℂ :=
+  (anisotropicHeisenbergS (Λ := Λ) J lam D N).submatrix Subtype.val Subtype.val
+
+/-- **The magnetisation-sector restriction of Ĥ is jointly continuous in
+`(lam, D)`**. Immediate from `continuous_anisotropicHeisenbergS` + the matrix
+submatrix functoriality. -/
+theorem continuous_anisotropicHeisenbergS_magSector_submatrix
+    (J : Λ → Λ → ℂ) (N M : ℕ) :
+    Continuous (fun p : ℂ × ℂ =>
+      anisotropicHeisenbergS_magSector_submatrix (Λ := Λ) J p.1 p.2 N M) := by
+  unfold anisotropicHeisenbergS_magSector_submatrix
+  exact (continuous_anisotropicHeisenbergS J N).matrix_submatrix _ _
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuity.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuity.lean
@@ -1,0 +1,58 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenberg
+import Mathlib.Topology.Instances.Matrix
+
+/-!
+# Continuity of the anisotropic Heisenberg Hamiltonian in `(λ, D)`
+
+Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori) — obligation (2)
+foundation.
+
+The anisotropic Hamiltonian `anisotropicHeisenbergS J lam D N` is a polynomial
+of degree 1 in `lam` and `D` (with fixed `J` and `N`). Hence its matrix-valued
+function `(lam, D) ↦ anisotropicHeisenbergS J lam D N` is continuous on
+`ℂ × ℂ`, and similarly each restriction to a fixed magnetisation sector is
+continuous in `(lam, D)`.
+
+This is the minimal prerequisite for the per-sector min-eigenvalue continuity
+needed by the deformation argument of obligation (2): a 3-fold sector
+degeneracy at some `(λ', D') ≠ (1, 0)` would contradict the obligation (1)
+`≤ 2` bound established in PR #3938.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- The two-site XXZ term `spinSDotXXZ x y · N` is continuous in the anisotropy
+parameter `lam`. -/
+theorem continuous_spinSDotXXZ (x y : Λ) (N : ℕ) :
+    Continuous (fun lam : ℂ => spinSDotXXZ (Λ := Λ) x y lam N) := by
+  unfold spinSDotXXZ
+  exact continuous_const.add (Continuous.smul continuous_id continuous_const)
+
+/-- The single-ion anisotropy term `singleIonAnisotropyS · N` is continuous in
+the crystal-field parameter `D`. -/
+theorem continuous_singleIonAnisotropyS (N : ℕ) :
+    Continuous (fun D : ℂ => singleIonAnisotropyS (Λ := Λ) D N) := by
+  unfold singleIonAnisotropyS
+  exact Continuous.smul continuous_id continuous_const
+
+/-- **The anisotropic Heisenberg Hamiltonian is jointly continuous in
+`(lam, D)`**. The matrix-valued function `(lam, D) ↦ anisotropicHeisenbergS J lam D N`
+is continuous on `ℂ × ℂ`, viewed in the elementwise topology on
+`Matrix (Λ → Fin (N+1)) (Λ → Fin (N+1)) ℂ`. -/
+theorem continuous_anisotropicHeisenbergS (J : Λ → Λ → ℂ) (N : ℕ) :
+    Continuous (fun p : ℂ × ℂ => anisotropicHeisenbergS (Λ := Λ) J p.1 p.2 N) := by
+  unfold anisotropicHeisenbergS
+  refine Continuous.add ?_ ?_
+  · refine continuous_finset_sum _ (fun x _ => continuous_finset_sum _ (fun y _ => ?_))
+    exact Continuous.smul continuous_const
+      ((continuous_spinSDotXXZ x y N).comp continuous_fst)
+  · exact (continuous_singleIonAnisotropyS N).comp continuous_snd
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuity.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuity.lean
@@ -74,4 +74,12 @@ theorem continuous_anisotropicHeisenbergS_magSector_submatrix
   unfold anisotropicHeisenbergS_magSector_submatrix
   exact (continuous_anisotropicHeisenbergS J N).matrix_submatrix _ _
 
+/-- The magnetisation-sector restriction of `anisotropicHeisenbergS` is Hermitian
+under real coupling `J`, anisotropy `lam`, and crystal field `D`. -/
+theorem anisotropicHeisenbergS_magSector_submatrix_isHermitian_of_real
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    {lam : ℂ} (hlam : star lam = lam) {D : ℂ} (hD : star D = D) (N M : ℕ) :
+    (anisotropicHeisenbergS_magSector_submatrix (Λ := Λ) J lam D N M).IsHermitian :=
+  (anisotropicHeisenbergS_isHermitian_of_real hJ hlam hD N).submatrix _
+
 end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739. Foundation bricks for Theorem 2.4 obligation (2) deformation argument.

## Context

Obligation (1) general spin-S TRULY UNCONDITIONAL is COMPLETE (PR #3938 merged as `929e00a9`). Remaining obligations:
- (2) deformation/continuity uniqueness from the SU(2) point `(λ, D) = (1, 0)` — **this PR series begins it.**
- (3) `M ↔ −M` reflection — DONE earlier.
- (4) GS unique + `Ŝ³_tot |Φ_GS⟩ = 0` — depends on (1)+(2)+(3).

Obligation (2) needs **per-sector min-eigenvalue continuity in `(λ, D)`** to derive the deformation contradiction: a 3-fold sector degeneracy would violate the obligation (1) `≤ 2` bound.

## This PR — foundation bricks 1–3

`LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuity.lean` (new, sorry-free):

| # | Theorem / def | Statement |
|---|---|---|
| 1 | `continuous_spinSDotXXZ x y N` | Two-site XXZ term continuous in λ. |
| 1 | `continuous_singleIonAnisotropyS N` | Single-ion term continuous in D. |
| 1 | `continuous_anisotropicHeisenbergS J N` | Full Hamiltonian jointly continuous in `(λ, D)`. |
| 2 | `anisotropicHeisenbergS_magSector_submatrix J λ D N M` | Sector restriction `def`. |
| 2 | `continuous_anisotropicHeisenbergS_magSector_submatrix J N M` | Sector restriction continuous in `(λ, D)`. |
| 3 | `anisotropicHeisenbergS_magSector_submatrix_isHermitian_of_real` | Sector restriction Hermitian under real `(J, λ, D)`. |

Each brick is a small polynomial-continuity or submatrix-preservation fact; together they form the **functor**
```
(λ, D) ∈ ℂ × ℂ ↦ (Ĥ_M(λ, D) : Hermitian Matrix on magConfigS Λ N M)
```
that the deformation argument needs.

## Remaining bricks (follow-up PRs)

4. Eigenvalues of `Ĥ_M(λ, D)` continuous in `(λ, D)` — substantial (Rayleigh-Ritz or Weyl's inequality; mathlib lacks both for eigenvalue continuity).
5. Min eigenvalue continuity wrap via `hermitianMinEigenvalue`.
6. IVT crossing argument across the punctured region (i)/(ii).
7. Final uniqueness: GS persists in `H_0`, `Ŝ³_tot |Φ_GS⟩ = 0`.

## Test plan

- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergContinuity` green locally (2140 jobs).
- [x] No `sorry`; all 6 declarations compile cleanly.
- [x] No new linter warnings introduced.
