### PR TITLE
Theorem 2.4 obligation (2) brick 4: rayleighOnVec + continuity — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/RayleighInfMatrix.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighInfMatrix.lean
@@ -21,7 +21,7 @@ namespace LatticeSystem.Quantum
 
 open Matrix
 
-variable {n : Type*} [Fintype n] [Nonempty n]
+variable {n : Type*} [Fintype n]
 
 /-- The Rayleigh quotient of `M` at a vector `ψ : n → ℂ` (no normalisation),
 defined as `re (∑ i j, conj (ψ i) * M i j * ψ j) = re ⟨ψ, M ψ⟩`. -/
@@ -39,5 +39,20 @@ theorem continuous_rayleighOnVec_matrix (ψ : n → ℂ) :
   refine continuous_const.mul ?_
   refine continuous_finset_sum _ (fun j _ => ?_)
   exact (continuous_apply_apply i j).mul continuous_const
+
+/-- The Rayleigh-on-vec quotient is jointly continuous in `(M, ψ)` (as a function
+of `Matrix n n ℂ × (n → ℂ)`). -/
+theorem continuous_rayleighOnVec :
+    Continuous (fun p : Matrix n n ℂ × (n → ℂ) => rayleighOnVec p.1 p.2) := by
+  unfold rayleighOnVec
+  refine Complex.continuous_re.comp ?_
+  refine continuous_finset_sum _ (fun i _ => ?_)
+  refine Continuous.mul ?_ ?_
+  · refine continuous_star.comp ?_
+    exact (continuous_apply i).comp continuous_snd
+  · refine continuous_finset_sum _ (fun j _ => ?_)
+    refine Continuous.mul ?_ ?_
+    · exact (continuous_apply_apply i j).comp continuous_fst
+    · exact (continuous_apply j).comp continuous_snd
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/RayleighInfMatrix.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighInfMatrix.lean
@@ -1,0 +1,43 @@
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Topology.Instances.Matrix
+
+/-!
+# Rayleigh infimum of a complex matrix (foundation for min-eigenvalue continuity)
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) deformation foundation.
+
+For a complex matrix `M : Matrix n n ℂ` (with `n` a nonempty finite type), the
+Rayleigh infimum is
+`rayleighInf M := ⨅ ψ : { x : n → ℂ // ‖x‖ = 1 }, (dotProduct (star ψ) (M.mulVec ψ)).re`
+using the standard L² norm on `n → ℂ`. For Hermitian `M` this equals
+`hermitianMinEigenvalue M`. The definition is continuous in `M` (foundation for
+the min-eigenvalue continuity needed by the obligation (2) deformation argument).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {n : Type*} [Fintype n] [Nonempty n]
+
+/-- The Rayleigh quotient of `M` at a vector `ψ : n → ℂ` (no normalisation),
+defined as `re (∑ i j, conj (ψ i) * M i j * ψ j) = re ⟨ψ, M ψ⟩`. -/
+noncomputable def rayleighOnVec (M : Matrix n n ℂ) (ψ : n → ℂ) : ℝ :=
+  (dotProduct (star ψ) (M.mulVec ψ)).re
+
+/-- The Rayleigh-on-vec quotient is continuous in `M` for any fixed `ψ`.
+This is the entry point for `rayleighInf` continuity via the parametrised iInf. -/
+theorem continuous_rayleighOnVec_matrix (ψ : n → ℂ) :
+    Continuous (fun M : Matrix n n ℂ => rayleighOnVec M ψ) := by
+  unfold rayleighOnVec
+  refine Complex.continuous_re.comp ?_
+  -- dotProduct (star ψ) (M.mulVec ψ) = ∑ i, conj (ψ i) * (∑ j, M i j * ψ j)
+  refine continuous_finset_sum _ (fun i _ => ?_)
+  refine continuous_const.mul ?_
+  refine continuous_finset_sum _ (fun j _ => ?_)
+  exact (continuous_apply_apply i j).mul continuous_const
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/RayleighInfMatrix.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighInfMatrix.lean
@@ -55,4 +55,12 @@ theorem continuous_rayleighOnVec :
     · exact (continuous_apply_apply i j).comp continuous_fst
     · exact (continuous_apply j).comp continuous_snd
 
+/-- The Rayleigh quotient is `ℝ`-additive in `M` (since `dotProduct` and `mulVec` are linear in
+the matrix and `Complex.re` is linear). -/
+theorem rayleighOnVec_add_matrix (M N : Matrix n n ℂ) (ψ : n → ℂ) :
+    rayleighOnVec (M + N) ψ = rayleighOnVec M ψ + rayleighOnVec N ψ := by
+  unfold rayleighOnVec
+  rw [Matrix.add_mulVec, dotProduct_add, Complex.add_re]
+
+
 end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739. Second foundation file for Theorem 2.4 obligation (2) (deformation argument).

## Context

Continuing the obligation (2) foundation series (PR #3938 closed obligation (1) general spin-S; PR #3939 added Ĥ(λ, D) continuity). This PR adds the **Rayleigh quotient** infrastructure as the foundation for proving min-eigenvalue continuity in (λ, D).

The eventual chain is:
1. Define `rayleighInf M = ⨅_{|ψ|=1} re ⟨ψ, M ψ⟩` (later PR).
2. Prove `rayleighInf M` is continuous in M (via this PR's joint continuity of the Rayleigh quotient + iInf over compact unit sphere).
3. Prove `rayleighInf M = hermitianMinEigenvalue hM` for Hermitian M (Rayleigh-Ritz).
4. Conclude min-eigenvalue continuity in (λ, D).
5. IVT crossing argument.

## This PR — Rayleigh quotient + continuity

`LatticeSystem/Quantum/SpinS/RayleighInfMatrix.lean` (new, ~60 lines, sorry-free):

| Theorem / def | Statement |
|---|---|
| `rayleighOnVec M ψ` | `(dotProduct (star ψ) (M.mulVec ψ)).re` — Rayleigh quotient (no normalisation) |
| `continuous_rayleighOnVec_matrix ψ` | `Continuous (fun M => rayleighOnVec M ψ)` for fixed ψ |
| `continuous_rayleighOnVec` | `Continuous (fun (M, ψ) => rayleighOnVec M ψ)` — joint continuity |

The joint continuity is the technically important version: combined with the compactness of the unit sphere in `n → ℂ` (finite-dim), it gives the iInf-continuity needed for the next brick.

## Remaining bricks (follow-up PRs)

- Define `rayleighInf M = ⨅_{|ψ|=1} rayleighOnVec M ψ` and prove its continuity in M.
- Bridge `rayleighInf M = hermitianMinEigenvalue hM` for Hermitian M (via Rayleigh-Ritz).
- Apply to `Ĥ_M(λ, D)` and combine with PR #3939 continuity for full min-eigenvalue continuity in (λ, D).
- IVT crossing argument + final uniqueness.

## Test plan

- [x] `lake build LatticeSystem.Quantum.SpinS.RayleighInfMatrix` green locally (2318 jobs).
- [x] No `sorry`; all 3 declarations compile cleanly.
- [x] No new linter warnings introduced.
