### PR TITLE
Theorem 2.4 obligation (2) brick 5: rayleighOnVec on eigenvector → eigenvalue — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/RayleighOnEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighOnEigenvector.lean
@@ -1,0 +1,34 @@
+import LatticeSystem.Quantum.SpinS.RayleighInfMatrix
+import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
+
+/-!
+# Rayleigh quotient on an eigenvector
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) foundation.
+
+For an eigenvector `v` of `M` with eigenvalue `μ` (i.e. `M.mulVec v = μ • v`)
+that is *unit-normalised* (`dotProduct (star v) v = 1`), the Rayleigh quotient
+`rayleighOnVec M v` equals `μ.re`. This is the canonical bridge identifying
+the Rayleigh inf with the minimum eigenvalue of a Hermitian matrix.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {n : Type*} [Fintype n]
+
+/-- **Rayleigh quotient on an eigenvector**: if `M.mulVec v = μ • v` and `v` is
+unit-normalised, then `rayleighOnVec M v = μ.re`. -/
+theorem rayleighOnVec_eq_re_of_eigenvector
+    (M : Matrix n n ℂ) (v : n → ℂ) (μ : ℂ)
+    (heig : M.mulVec v = μ • v)
+    (hunit : dotProduct (star v) v = 1) :
+    rayleighOnVec M v = μ.re := by
+  unfold rayleighOnVec
+  rw [heig, dotProduct_smul, hunit, smul_eq_mul, mul_one]
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/RayleighOnEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighOnEigenvector.lean
@@ -31,4 +31,11 @@ theorem rayleighOnVec_eq_re_of_eigenvector
   unfold rayleighOnVec
   rw [heig, dotProduct_smul, hunit, smul_eq_mul, mul_one]
 
+/-- The Rayleigh quotient vanishes at the zero vector. -/
+theorem rayleighOnVec_zero_vec (M : Matrix n n ℂ) :
+    rayleighOnVec M 0 = 0 := by
+  unfold rayleighOnVec
+  rw [Matrix.mulVec_zero, dotProduct_zero, Complex.zero_re]
+
+
 end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739. Foundation brick for Theorem 2.4 obligation (2) (deformation argument).

## Summary

Adds the **eigenvector → Rayleigh value** bridge: for an eigenvector `v` of `M` with eigenvalue `μ` (i.e., `M.mulVec v = μ • v`) that is unit-normalised (`dotProduct (star v) v = 1`), the Rayleigh quotient `rayleighOnVec M v` equals `μ.re`.

This is the canonical identification used in the Rayleigh-Ritz characterisation of the minimum eigenvalue:
`hermitianMinEigenvalue M = rayleighInf M = ⨅_{|ψ|=1} rayleighOnVec M ψ`
(the inf is achieved at the bottom-eigenvalue eigenvector).

## File

`LatticeSystem/Quantum/SpinS/RayleighOnEigenvector.lean` (new, ~30 lines, sorry-free).

| Theorem | Statement |
|---|---|
| `rayleighOnVec_eq_re_of_eigenvector` | `(heig : M.mulVec v = μ • v) (hunit : star v ⬝ᵥ v = 1) ⊢ rayleighOnVec M v = μ.re` |

Proof: trivial 4-line rewrite using `dotProduct_smul` and the unit-normalisation hypothesis.

## Test plan

- [x] `lake build` green (2736 jobs).
- [x] No `sorry`; sole theorem compiles cleanly.
- [x] No new linter warnings introduced.
