### PR TITLE
Theorem 2.4 obligation (2) brick 10: rayleighInfMatrix BddBelow-conditional upper bound — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/RayleighInfMatrixLeConditional.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighInfMatrixLeConditional.lean
@@ -1,0 +1,52 @@
+import LatticeSystem.Quantum.SpinS.RayleighInfMatrixUpper
+
+/-!
+# Conditional upper bound for `rayleighInfMatrix`
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) foundation.
+
+The infimum `rayleighInfMatrix M` is bounded above by `rayleighOnVec M v` at any
+unit vector `v`, provided the range of the Rayleigh function on the matrix-side
+unit sphere is bounded below (`BddBelow`). This is the immediate consequence of
+`ciInf_le_of_le` made explicit at the matrix-Rayleigh level.
+
+`BddBelow` itself follows from the variational principle (deferred to a
+follow-up brick) or from a direct Cauchy-Schwarz bound. Once `BddBelow` is
+established, combined with `hermitianMinEigenvalue_mem_rayleighOnVec_range`
+(PR #3943) we obtain `rayleighInfMatrix M ≤ hermitianMinEigenvalue hM`.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+
+/-- Conditional upper bound: `rayleighInfMatrix M ≤ rayleighOnVec M v` for any unit `v`,
+provided the function is bounded below over the matrix-side unit sphere. -/
+theorem rayleighInfMatrix_le_rayleighOnVec_of_bddBelow
+    (M : Matrix n n ℂ)
+    (hBdd : BddBelow (Set.range
+      (fun p : {v : n → ℂ // dotProduct (star v) v = 1} => rayleighOnVec M p.val)))
+    {v : n → ℂ} (hunit : dotProduct (star v) v = 1) :
+    rayleighInfMatrix M ≤ rayleighOnVec M v := by
+  unfold rayleighInfMatrix
+  exact ciInf_le_of_le hBdd ⟨v, hunit⟩ le_rfl
+
+/-- If the Rayleigh range over the matrix-side unit sphere is `BddBelow`, then for any
+Hermitian `M`, `rayleighInfMatrix M ≤ hermitianMinEigenvalue hM` (the upper-bound direction
+of Rayleigh-Ritz). The matching `≥` direction (variational lower bound) is deferred. -/
+theorem rayleighInfMatrix_le_hermitianMinEigenvalue_of_bddBelow
+    {M : Matrix n n ℂ} (hM : M.IsHermitian)
+    (hBdd : BddBelow (Set.range
+      (fun p : {v : n → ℂ // dotProduct (star v) v = 1} => rayleighOnVec M p.val))) :
+    rayleighInfMatrix M ≤ hermitianMinEigenvalue hM := by
+  obtain ⟨p, hp⟩ := hermitianMinEigenvalue_mem_rayleighOnVec_range hM
+  have := rayleighInfMatrix_le_rayleighOnVec_of_bddBelow M hBdd p.property
+  rw [hp] at this
+  exact this
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739. Foundation brick for Theorem 2.4 obligation (2).

## Summary

Adds the **BddBelow-conditional upper bound** for `rayleighInfMatrix`:
- `rayleighInfMatrix_le_rayleighOnVec_of_bddBelow M hBdd hunit`: for any unit `v`, `rayleighInfMatrix M ≤ rayleighOnVec M v` when the range is bounded below.
- `rayleighInfMatrix_le_hermitianMinEigenvalue_of_bddBelow hM hBdd`: combining with PR #3943's `hermitianMinEigenvalue_mem_rayleighOnVec_range`, gives `rayleighInfMatrix M ≤ hermitianMinEigenvalue hM`.

These are immediate `ciInf_le_of_le` applications. The `BddBelow` hypothesis is the remaining gap — to be discharged via a follow-up brick (either via Cauchy-Schwarz `|rayleighOnVec M v| ≤ ‖M‖_op` or via the variational principle proper).

## File

`LatticeSystem/Quantum/SpinS/RayleighInfMatrixLeConditional.lean` (new, 52 lines, sorry-free).

## Test plan

- [x] `lake build` green (2739 jobs).
- [x] No `sorry`; both theorems compile cleanly.
