### PR TITLE
Theorem 2.4 obligation (2) brick 13: eigenvectorUnitary unitarity bridge — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean
@@ -1,0 +1,54 @@
+import LatticeSystem.Quantum.SpinS.RayleighOnDiagonal
+import LatticeSystem.Quantum.SpinS.RayleighUnitarySimilarity
+import LatticeSystem.Quantum.SpinS.RayleighOnVecBddBelow
+import Mathlib.Analysis.Matrix.Spectrum
+
+/-!
+# Hermitian variational lower bound: `min eigenvalue ≤ rayleighOnVec` on unit vectors
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+For Hermitian `M` and a unit vector `v` (in the matrix-side sense
+`dotProduct (star v) v = 1`), the Rayleigh quotient is bounded below by the
+minimum eigenvalue:
+`hermitianMinEigenvalue hM ≤ rayleighOnVec M v`.
+
+Proof: by `Matrix.IsHermitian.spectral_theorem`, `M = U * D * Uᴴ` where
+`U = eigenvectorUnitary hM` and `D = diagonal eigenvalues`. Apply
+`rayleighOnVec_unitary_conj` to reduce to the diagonal case
+`rayleighOnVec D (Uᴴ v)`, then apply the diagonal variational bound
+(PR #3944) and the unitary unit-norm preservation (PR #3945).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+
+/-- The Hermitian eigenvectorUnitary `U` is unitary: `U * Uᴴ = 1`. -/
+theorem eigenvectorUnitary_mul_conjTranspose_eq_one
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
+    (Matrix.IsHermitian.eigenvectorUnitary hM : Matrix n n ℂ) *
+      (Matrix.IsHermitian.eigenvectorUnitary hM : Matrix n n ℂ).conjTranspose = 1 := by
+  have h := (Matrix.IsHermitian.eigenvectorUnitary hM).property
+  rw [show (Matrix.IsHermitian.eigenvectorUnitary hM :
+        Matrix n n ℂ).conjTranspose = star (Matrix.IsHermitian.eigenvectorUnitary hM :
+        Matrix n n ℂ) from rfl]
+  exact h.2
+
+/-- The Hermitian eigenvectorUnitary `U` is unitary: `Uᴴ * U = 1`. -/
+theorem eigenvectorUnitary_conjTranspose_mul_eq_one
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
+    (Matrix.IsHermitian.eigenvectorUnitary hM : Matrix n n ℂ).conjTranspose *
+      (Matrix.IsHermitian.eigenvectorUnitary hM : Matrix n n ℂ) = 1 := by
+  have h := (Matrix.IsHermitian.eigenvectorUnitary hM).property
+  rw [show (Matrix.IsHermitian.eigenvectorUnitary hM :
+        Matrix n n ℂ).conjTranspose = star (Matrix.IsHermitian.eigenvectorUnitary hM :
+        Matrix n n ℂ) from rfl]
+  exact h.1
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739. Foundation brick for Theorem 2.4 obligation (2) — Hermitian variational lower bound preparation.

## Summary

Two unitarity lemmas for `Matrix.IsHermitian.eigenvectorUnitary`:
- `eigenvectorUnitary_mul_conjTranspose_eq_one`: `U * Uᴴ = 1`.
- `eigenvectorUnitary_conjTranspose_mul_eq_one`: `Uᴴ * U = 1`.

These bridge `Matrix.IsHermitian.eigenvectorUnitary` (which lives in the `unitaryGroup` subtype) to the matrix-side conjTranspose equations needed by:
- `rayleighOnVec_unitary_conj` (PR #3945)
- `dotProduct_star_conjTranspose_mulVec_self` unit-norm preservation (PR #3945)

## Next bricks for the variational lower bound

With these unitarity lemmas + `Matrix.IsHermitian.spectral_theorem` (M = U D Uᴴ, mathlib), we can:
1. Apply `rayleighOnVec_unitary_conj` to reduce `rayleighOnVec M v` to `rayleighOnVec D (Uᴴ v)`.
2. Apply `rayleighOnVec_diagonal_real_ge_min_mul_normSq` (PR #3944) to get the diagonal lower bound `≥ (min eigenvalue) · Σ ‖(Uᴴ v)_i‖²`.
3. Apply unit-norm preservation (PR #3945) to get `Σ ‖(Uᴴ v)_i‖² = dotProduct (star v) v = 1`.
4. Conclude `hermitianMinEigenvalue hM ≤ rayleighOnVec M v` for unit v.

Combined with PR #3948 (unconditional upper bound `rayleighInfMatrix M ≤ hermitianMinEigenvalue hM`), this gives the full Rayleigh-Ritz characterisation `rayleighInfMatrix M = hermitianMinEigenvalue hM`.

## File

`LatticeSystem/Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean` (new, 54 lines, sorry-free).

## Test plan

- [x] `lake build` green (2560 jobs).
- [x] No `sorry`; both theorems compile cleanly.
