### PR TITLE
★ Theorem 2.4 obligation (2) brick 15: Rayleigh-Ritz equality MILESTONE — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/RayleighRitzEquality.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighRitzEquality.lean
@@ -1,0 +1,58 @@
+import LatticeSystem.Quantum.SpinS.RayleighInfMatrixLe
+import LatticeSystem.Quantum.SpinS.HermitianVariationalLowerBound
+
+/-!
+# Rayleigh-Ritz equality `rayleighInfMatrix M = hermitianMinEigenvalue hM`
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+Combines the unconditional upper bound `rayleighInfMatrix M ≤ hermitianMinEigenvalue hM`
+(PR #3948) with the variational lower bound
+`hermitianMinEigenvalue hM ≤ rayleighOnVec M v` for unit `v` (PR #3950) to give the
+**Rayleigh-Ritz equality**:
+`rayleighInfMatrix M = hermitianMinEigenvalue hM`
+for any Hermitian `M`.
+
+This identifies the minimum eigenvalue with the infimum of the Rayleigh quotient over
+the matrix-side unit sphere — the central characterisation used by the obligation (2)
+deformation argument.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+
+/-- Variational lower bound at unit vectors: for Hermitian `M` and unit `v`,
+`hermitianMinEigenvalue hM ≤ rayleighOnVec M v`. -/
+theorem hermitianMinEigenvalue_le_rayleighOnVec_of_unit
+    {M : Matrix n n ℂ} (hM : M.IsHermitian)
+    {v : n → ℂ} (hunit : dotProduct (star v) v = 1) :
+    hermitianMinEigenvalue hM ≤ rayleighOnVec M v := by
+  have h := hermitianMinEigenvalue_mul_dotProduct_re_le_rayleighOnVec hM v
+  rw [hunit] at h
+  simpa using h
+
+/-- `hermitianMinEigenvalue hM ≤ rayleighInfMatrix M` for Hermitian `M`. -/
+theorem hermitianMinEigenvalue_le_rayleighInfMatrix
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
+    hermitianMinEigenvalue hM ≤ rayleighInfMatrix M := by
+  unfold rayleighInfMatrix
+  haveI : Nonempty {v : n → ℂ // dotProduct (star v) v = 1} :=
+    nonempty_unit_dotProduct_subtype hM
+  refine le_ciInf (fun p => ?_)
+  exact hermitianMinEigenvalue_le_rayleighOnVec_of_unit hM p.property
+
+/-- **Rayleigh-Ritz equality**: for Hermitian `M`,
+`rayleighInfMatrix M = hermitianMinEigenvalue hM`. -/
+theorem rayleighInfMatrix_eq_hermitianMinEigenvalue
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
+    rayleighInfMatrix M = hermitianMinEigenvalue hM :=
+  le_antisymm (rayleighInfMatrix_le_hermitianMinEigenvalue hM)
+    (hermitianMinEigenvalue_le_rayleighInfMatrix hM)
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739. **★ Rayleigh-Ritz equality MILESTONE ★** for Theorem 2.4 obligation (2).

## Summary

The **Rayleigh-Ritz equality**:
```
rayleighInfMatrix M = hermitianMinEigenvalue hM
```
for any Hermitian `M`. Combines:
- PR #3948: `rayleighInfMatrix M ≤ hermitianMinEigenvalue hM` (upper bound).
- PR #3950: `hermitianMinEigenvalue hM · normSq ≤ rayleighOnVec M v` (variational lower bound).

Combined via `le_antisymm` to give the equality.

## File

`LatticeSystem/Quantum/SpinS/RayleighRitzEquality.lean` (new, 57 lines, sorry-free):

| Theorem | Statement |
|---|---|
| `hermitianMinEigenvalue_le_rayleighOnVec_of_unit hM hunit` | `hermitianMinEigenvalue hM ≤ rayleighOnVec M v` for unit `v` |
| `hermitianMinEigenvalue_le_rayleighInfMatrix hM` | `hermitianMinEigenvalue hM ≤ rayleighInfMatrix M` (via le_ciInf) |
| `rayleighInfMatrix_eq_hermitianMinEigenvalue hM` | **the equality** |

## Significance

This identifies the minimum eigenvalue of a Hermitian matrix with the infimum of its Rayleigh quotient — the central characterisation used by the deformation argument of obligation (2).

The remaining bricks for obligation (2):
- Parametric continuity of `rayleighInfMatrix M` in `M` (Berge-type theorem; mathlib API gap).
- Apply to `Ĥ_M(λ, D)` for parametric min-eigenvalue continuity.
- IVT crossing argument.
- Final uniqueness wrap-up.

## Test plan

- [x] `lake build` green (2746 jobs).
- [x] No `sorry`; all 3 theorems compile cleanly.
