### PR TITLE
Theorem 2.4 obligation (2) brick 18: Hermitian instance for Ĥ_M(λ, D) at real (λ, D) — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorIsHermitianReal.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorIsHermitianReal.lean
@@ -1,0 +1,36 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergContinuity
+
+/-!
+# Hermitian instance of `Ĥ_M(λ, D)` for real `(λ, D)` (ℝ-parametrised wrapper)
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+Provides the per-sector Hermitian instance for the anisotropic Hamiltonian
+`Ĥ_M(λ, D)` viewed as a function of `(λ, D) ∈ ℝ × ℝ` (via the real coercion to
+`ℂ`). This is the small "wrapper" needed before applying
+`Continuous.hermitianMinEigenvalue_comp` (PR #3953) to obtain parametric
+continuity of the min eigenvalue.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- For real `r : ℝ`, `star ((r : ℂ)) = (r : ℂ)`. -/
+theorem star_ofReal_eq (r : ℝ) : star ((r : ℂ)) = (r : ℂ) :=
+  Complex.conj_ofReal r
+
+/-- Per-sector restriction is Hermitian at each real `(λ, D)`. -/
+theorem anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M : ℕ) (lam D : ℝ) :
+    (anisotropicHeisenbergS_magSector_submatrix (Λ := Λ) J ((lam : ℂ)) ((D : ℂ)) N M).IsHermitian :=
+  anisotropicHeisenbergS_magSector_submatrix_isHermitian_of_real (Λ := Λ) (N := N) (M := M)
+    hJ (star_ofReal_eq lam) (star_ofReal_eq D)
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739. Foundation brick for Theorem 2.4 obligation (2).

## Summary

Adds the per-sector Hermitian instance of `Ĥ_M(λ, D)` for real `(λ, D) : ℝ × ℝ` (via the real-to-complex coercion). This is the small wrapper needed to bridge between PR #3939's matrix-level Hermitian instance and the parametric continuity application via PR #3953.

## File

`LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorIsHermitianReal.lean` (new, 36 lines, sorry-free):

| Theorem | Statement |
|---|---|
| `star_ofReal_eq r` | `star ((r : ℂ)) = (r : ℂ)` for `r : ℝ` (via `Complex.conj_ofReal`) |
| `anisotropicHeisenbergS_magSector_submatrix_isHermitian_real hJ N M lam D` | `Ĥ_M(λ, D)` Hermitian at real `(λ, D)` |

## Test plan

- [x] `lake build` green (2141 jobs).
- [x] No `sorry`; both theorems compile cleanly.

## Next brick

The parametric continuity application (`Continuous (fun p : ℝ × ℝ => hermitianMinEigenvalue (Ĥ_M(λ, D) Hermitian))`) hit a `whnf` typeclass-synthesis heartbeat timeout in this session even at 1.6M heartbeats. Workaround pending — likely needs an alternative formulation that avoids the dependent-type `Continuous (fun p => hermitianMinEigenvalue (hHerm p))` pattern, or a custom `set_option` chain.
