### PR TITLE
Theorem 2.4 obligation (2) brick 19: Ĥ(λ, D) continuity on ℝ × ℝ (entry-wise) — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuousReal.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuousReal.lean
@@ -1,0 +1,45 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergContinuity
+
+/-!
+# Matrix-level continuity of `Ĥ(λ, D)` (full Hamiltonian) for real `(λ, D)`
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+The full anisotropic Hamiltonian `Ĥ(λ, D) ∈ Matrix _ _ ℂ` is continuous as a
+function of the real parameters `(λ, D) ∈ ℝ × ℝ` (via the real-to-complex
+coercion). Specialises PR #3939's `continuous_anisotropicHeisenbergS`.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- The matrix-valued function `(λ, D) ↦ Ĥ(λ, D)` is continuous on `ℝ × ℝ`. -/
+theorem continuous_anisotropicHeisenbergS_real (J : Λ → Λ → ℂ) (N : ℕ) :
+    Continuous (fun p : ℝ × ℝ => anisotropicHeisenbergS (Λ := Λ) J ((p.1 : ℂ)) ((p.2 : ℂ)) N) := by
+  refine continuous_matrix (fun σ τ => ?_)
+  -- entry-wise continuity reduces to continuity of complex polynomials in (λ, D).
+  unfold anisotropicHeisenbergS
+  simp only [Matrix.add_apply, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  refine Continuous.add ?_ ?_
+  · -- ∑ x y, J x y * spinSDotXXZ x y lam N σ τ — polynomial in lam
+    refine continuous_finset_sum _ (fun x _ => continuous_finset_sum _ (fun y _ => ?_))
+    refine Continuous.mul continuous_const ?_
+    -- spinSDotXXZ x y lam N σ τ is polynomial in lam (= a + lam * b for constants a, b)
+    unfold spinSDotXXZ
+    simp only [Matrix.add_apply, Matrix.smul_apply, smul_eq_mul]
+    refine Continuous.add (Continuous.add continuous_const continuous_const) ?_
+    refine Continuous.mul ?_ continuous_const
+    exact Complex.continuous_ofReal.comp continuous_fst
+  · -- singleIonAnisotropyS D N σ τ = D * (∑ x, ...) σ τ
+    unfold singleIonAnisotropyS
+    simp only [Matrix.smul_apply, smul_eq_mul]
+    refine Continuous.mul ?_ continuous_const
+    exact Complex.continuous_ofReal.comp continuous_snd
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #3739. Foundation brick for Theorem 2.4 obligation (2).

## Summary

Proves continuity of the **full anisotropic Hamiltonian** `Ĥ(λ, D)` viewed as a matrix-valued function of real `(λ, D) ∈ ℝ × ℝ`.

Workaround for a `.comp` typeclass-synthesis heartbeat timeout encountered with the standard composition pattern `(continuous_anisotropicHeisenbergS J N).comp hCoerce` — the proof instead uses `continuous_matrix` to reduce to entry-wise continuity, then decomposes each entry as a polynomial in `(λ, D)`.

## File

`LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergContinuousReal.lean` (new, 45 lines, sorry-free):

| Theorem | Statement |
|---|---|
| `continuous_anisotropicHeisenbergS_real J N` | `Continuous (fun p : ℝ × ℝ => anisotropicHeisenbergS J p.1 p.2 N)` |

## Next brick

Now need: (a) lift this to per-sector submatrix (via `Continuous.matrix_submatrix`), (b) attach the Hermitian instance (PR #3954), (c) apply `Continuous.hermitianMinEigenvalue_comp` (PR #3953) to get the parametric min-eigenvalue continuity needed by obligation (2).

## Test plan

- [x] `lake build` green (2141 jobs).
- [x] No `sorry`; theorem compiles cleanly.
