### PR TITLE
Refactor (build-speed eval, 20-PR cadence): clean up obligation (2) linter warning — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/HermitianMinEigenvalueContinuous.lean
+++ b/LatticeSystem/Quantum/SpinS/HermitianMinEigenvalueContinuous.lean
@@ -30,7 +30,7 @@ variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
 variable {X : Type*} [PseudoMetricSpace X]
 
 /-- Entry-norm sum is continuous in the matrix parameter. -/
-theorem continuous_sum_entryNorms :
+theorem continuous_sum_entryNorms {n : Type*} [Fintype n] :
     Continuous (fun M : Matrix n n ℂ => ∑ i, ∑ j, ‖M i j‖) := by
   refine continuous_finset_sum _ (fun i _ => ?_)
   refine continuous_finset_sum _ (fun j _ => ?_)


### PR DESCRIPTION
## Summary

20-PR cadence refactor PR after PR #3957 (Tasaki §2.5 Theorem 2.4 obligation (2) parametric min eigenvalue continuity capstone).

## Build-speed evaluation

Measured incremental build of the obligation (2) leaf `LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorMinEigenvalueContinuous`:
- Incremental rebuild: **2.3 s**
- The full obligation (2) chain (17 small files, ~1036 lines total) rebuilds well within typical Quantum/SpinS norms.

The obligation (2) foundation comprises:
- 9 `Rayleigh*` files (definition, bounds, similarity, equality)
- 2 `HermitianMinEigenvalue*` files (Lipschitz, continuous-comp)
- 6 `AnisotropicHeisenberg*` files (Hermitian, continuity, sector-min combiner)

**Decision: no consolidation**. The fine granularity:
1. Mirrors the proof dependency DAG (one brick per lemma family).
2. Keeps incremental rebuilds fast (each leaf < 100 lines compiles instantly).
3. Aligns with the existing per-Tasaki-step file structure of §2.5.

## Cleanup

Removed unused `[DecidableEq n]` from `continuous_sum_entryNorms` by overriding the section variable locally — the function doesn't need decidable equality since it only reads entries and takes norms.

`unusedSectionVars`/`unusedDecidableInType` linter warning cleared.

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorMinEigenvalueContinuous` succeeds
- [x] CI green
