### PR TITLE
Tasaki §2.5 Theorem 2.4 obligation (2) IVT bricks (a)(b)(d): parametric path + IVT crossing wrapper — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricGapCrossing.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricGapCrossing.lean
@@ -1,0 +1,114 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricPath
+import Mathlib.Topology.Order.IntermediateValue
+
+/-!
+# IVT crossing for the parametric gap `E_0(γ(t)) - E_M(γ(t))`
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+If at the SU(2) point `(1, 0)` we have `E_0 < E_M` (strict gap, supplied by
+Theorem 2.3) and at some target `(λ', D')` we have `E_M ≤ E_0`, then by
+intermediate value theorem applied to the continuous gap function
+`g(t) := E_0(γ(t)) - E_M(γ(t))` on `[0, 1]`, there is a crossing point
+`t* ∈ [0, 1]` at which `E_0(γ(t*)) = E_M(γ(t*))`. This is brick (2-IVT-d)
+of the obligation (2) deformation argument.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Set
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **IVT crossing for the parametric gap**: if the gap `E_0 - E_M` is strictly
+negative at `t = 0` (i.e., `E_0(1, 0) < E_M(1, 0)`) and non-negative at `t = 1`
+(i.e., `E_M(λ', D') ≤ E_0(λ', D')`), then there exists a crossing
+`t* ∈ [0, 1]` with `E_0(γ(t*)) = E_M(γ(t*))`.
+
+This packages mathlib `intermediate_value_Icc` for the composed function
+`t ↦ hermitianMinEigenvalue (Ĥ_M(γ(t))) - hermitianMinEigenvalue (Ĥ_0(γ(t)))`
+on `[0, 1]`. -/
+theorem anisotropicHeisenbergS_parametric_gap_crossing
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M : ℕ)
+    [Nonempty (magConfigS Λ N M)] [Nonempty (magConfigS Λ N 0)]
+    (lam' D' : ℝ)
+    (h0 : hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := 0) hJ 1 0) <
+          hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M) hJ 1 0))
+    (h1 : hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M) hJ lam' D') ≤
+          hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := 0) hJ lam' D')) :
+    ∃ t : ℝ, t ∈ Icc (0 : ℝ) 1 ∧
+      hermitianMinEigenvalue
+        (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+          (Λ := Λ) (N := N) (M := 0) hJ
+          (anisotropicHeisenbergParametricPath lam' D' t).1
+          (anisotropicHeisenbergParametricPath lam' D' t).2) =
+      hermitianMinEigenvalue
+        (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+          (Λ := Λ) (N := N) (M := M) hJ
+          (anisotropicHeisenbergParametricPath lam' D' t).1
+          (anisotropicHeisenbergParametricPath lam' D' t).2) := by
+  -- Abbreviate the per-sector min eigenvalue along the path.
+  set E0 : ℝ → ℝ := fun t => hermitianMinEigenvalue
+    (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+      (Λ := Λ) (N := N) (M := 0) hJ
+      (anisotropicHeisenbergParametricPath lam' D' t).1
+      (anisotropicHeisenbergParametricPath lam' D' t).2)
+  set EM : ℝ → ℝ := fun t => hermitianMinEigenvalue
+    (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+      (Λ := Λ) (N := N) (M := M) hJ
+      (anisotropicHeisenbergParametricPath lam' D' t).1
+      (anisotropicHeisenbergParametricPath lam' D' t).2)
+  -- Continuous gap g(t) = E0(t) - EM(t).
+  have hE0 : Continuous E0 :=
+    continuous_anisotropicHeisenbergS_magSector_minEigenvalue_along_parametricPath
+      (Λ := Λ) hJ N 0 lam' D'
+  have hEM : Continuous EM :=
+    continuous_anisotropicHeisenbergS_magSector_minEigenvalue_along_parametricPath
+      (Λ := Λ) hJ N M lam' D'
+  have hg : Continuous (fun t => E0 t - EM t) := hE0.sub hEM
+  -- Endpoint values.
+  have hpath0 := anisotropicHeisenbergParametricPath_zero lam' D'
+  have hpath1 := anisotropicHeisenbergParametricPath_one lam' D'
+  have hE0_0 : E0 0 = hermitianMinEigenvalue
+      (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+        (Λ := Λ) (N := N) (M := 0) hJ 1 0) := by
+    simp only [E0, hpath0]
+  have hEM_0 : EM 0 = hermitianMinEigenvalue
+      (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+        (Λ := Λ) (N := N) (M := M) hJ 1 0) := by
+    simp only [EM, hpath0]
+  have hE0_1 : E0 1 = hermitianMinEigenvalue
+      (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+        (Λ := Λ) (N := N) (M := 0) hJ lam' D') := by
+    simp only [E0, hpath1]
+  have hEM_1 : EM 1 = hermitianMinEigenvalue
+      (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+        (Λ := Λ) (N := N) (M := M) hJ lam' D') := by
+    simp only [EM, hpath1]
+  -- g(0) < 0, g(1) ≥ 0.
+  have hg0 : E0 0 - EM 0 < 0 := by
+    rw [hE0_0, hEM_0]; linarith
+  have hg1 : 0 ≤ E0 1 - EM 1 := by
+    rw [hE0_1, hEM_1]; linarith
+  -- Apply mathlib intermediate_value_Icc on [0, 1] at y = 0.
+  obtain ⟨t, htmem, hteq⟩ :=
+    intermediate_value_Icc (by norm_num : (0 : ℝ) ≤ 1)
+      (hg.continuousOn : ContinuousOn (fun t => E0 t - EM t) (Icc (0 : ℝ) 1))
+      ⟨le_of_lt hg0, hg1⟩
+  refine ⟨t, htmem, ?_⟩
+  -- hteq : E0 t - EM t = 0 ⟹ E0 t = EM t.
+  exact sub_eq_zero.mp hteq
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricPath.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricPath.lean
@@ -1,0 +1,68 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorMinEigenvalueContinuous
+
+/-!
+# Parametric path `[0, 1] → ℝ × ℝ` for the obligation (2) IVT crossing argument
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+Defines the linear path
+`anisotropicHeisenbergParametricPath λ' D' t := ((1 - t) + t * λ', t * D')`
+from the SU(2) point `(1, 0)` to an arbitrary target `(λ', D')` in `ℝ × ℝ`,
+proves continuity, and proves continuity of the composed per-sector min
+eigenvalue `t ↦ hermitianMinEigenvalue (Ĥ_M(γ(t)))` on `[0, 1]`. This is
+the analytic ingredient (2-IVT-a)+(2-IVT-b) of the obligation (2) IVT
+crossing argument.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Linear parametric path** from the SU(2) point `(1, 0)` to `(λ', D')` in `ℝ × ℝ`,
+parameterised by `t ∈ ℝ`. At `t = 0` returns `(1, 0)`; at `t = 1` returns `(λ', D')`. -/
+def anisotropicHeisenbergParametricPath (lam' D' : ℝ) : ℝ → ℝ × ℝ :=
+  fun t => ((1 - t) + t * lam', t * D')
+
+/-- The parametric path is continuous in `t`. -/
+theorem continuous_anisotropicHeisenbergParametricPath (lam' D' : ℝ) :
+    Continuous (anisotropicHeisenbergParametricPath lam' D') := by
+  unfold anisotropicHeisenbergParametricPath
+  refine Continuous.prodMk ?_ ?_
+  · exact ((continuous_const.sub continuous_id).add (continuous_id.mul continuous_const))
+  · exact continuous_id.mul continuous_const
+
+/-- At `t = 0` the path is at the SU(2) point `(1, 0)`. -/
+@[simp]
+theorem anisotropicHeisenbergParametricPath_zero (lam' D' : ℝ) :
+    anisotropicHeisenbergParametricPath lam' D' 0 = (1, 0) := by
+  unfold anisotropicHeisenbergParametricPath
+  simp
+
+/-- At `t = 1` the path is at the target `(λ', D')`. -/
+@[simp]
+theorem anisotropicHeisenbergParametricPath_one (lam' D' : ℝ) :
+    anisotropicHeisenbergParametricPath lam' D' 1 = (lam', D') := by
+  unfold anisotropicHeisenbergParametricPath
+  simp
+
+/-- **Composed continuity (2-IVT-b)**: `t ↦ hermitianMinEigenvalue (Ĥ_M(γ(t)))` is continuous
+on `ℝ`, where `γ` is the parametric path from `(1, 0)` to `(λ', D')`. This composes the
+parametric continuity of the per-sector min eigenvalue (PR #3957) with the continuity of
+the path. -/
+theorem continuous_anisotropicHeisenbergS_magSector_minEigenvalue_along_parametricPath
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M : ℕ) [Nonempty (magConfigS Λ N M)] (lam' D' : ℝ) :
+    Continuous (fun t : ℝ => hermitianMinEigenvalue
+      (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+        (Λ := Λ) (N := N) (M := M) hJ
+        (anisotropicHeisenbergParametricPath lam' D' t).1
+        (anisotropicHeisenbergParametricPath lam' D' t).2)) :=
+  (continuous_anisotropicHeisenbergS_magSector_minEigenvalue_real (Λ := Λ) hJ N M).comp
+    (continuous_anisotropicHeisenbergParametricPath lam' D')
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

Bricks (a), (b), and (d) of the Tasaki §2.5 Theorem 2.4 obligation (2) IVT crossing argument.

- **(2-IVT-a)** `anisotropicHeisenbergParametricPath λ' D' t := ((1 - t) + t * λ', t * D')` — the linear path from the SU(2) point `(1, 0)` to the target `(λ', D')` in `ℝ × ℝ`, with continuity and endpoint simp lemmas.
- **(2-IVT-b)** Continuity of the composed per-sector min eigenvalue `t ↦ hermitianMinEigenvalue (Ĥ_M(γ(t)))` on `ℝ` (composition of PR #3957 with the parametric path).
- **(2-IVT-d)** **IVT crossing**: given the strict initial gap `E_0(1, 0) < E_M(1, 0)` and the contradiction-hypothesis endpoint `E_M(λ', D') ≤ E_0(λ', D')`, the continuous gap `g(t) = E_0(γ(t)) - E_M(γ(t))` on `[0, 1]` admits a crossing `t* ∈ [0, 1]` with `E_0(γ(t*)) = E_M(γ(t*))`. Wraps mathlib `intermediate_value_Icc`.

The two endpoint hypotheses are left as inputs; brick (2-IVT-c) will supply the strict gap at `(1, 0)` from Theorem 2.3 (#3893) in a follow-up PR.

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricGapCrossing` succeeds
- [x] CI green
