### PR TITLE
Sector ground full-eigenvector bridge for the anisotropic Hamiltonian — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorGroundEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorGroundEigenvector.lean
@@ -1,0 +1,69 @@
+import LatticeSystem.Quantum.SpinS.HermitianMinEigenvalueEigenvector
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorEmbeddingLift
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorIsHermitianReal
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergU1
+
+/-!
+# Sector ground eigenvector existence for the anisotropic Hamiltonian
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+Given the anisotropic sector submatrix `Ĥ_M(λ, D)` (Hermitian under real `(λ, D)`
+and Hermitian `J`) on a non-empty `magConfigS Λ N M`, there exists a nonzero
+sector vector `Φ` such that:
+- The sector submatrix satisfies `Ĥ_M . Φ = (E_M : ℂ) . Φ` where
+  `E_M = hermitianMinEigenvalue` of the sector submatrix.
+- The lifted full vector `magSectorEmbedding Φ` is an eigenvector of the FULL
+  anisotropic Hamiltonian `Ĥ(λ, D)` at the same `E_M`.
+- `magSectorEmbedding Φ` lies in the magnetisation subspace `magSubspaceS Λ N (|V|·N/2 − M)`.
+
+This packages the obligation (2) IVT crossing argument's sector→full bridge:
+the per-sector min eigenvalue is realised by a full-Hilbert-space eigenvector
+in the corresponding `Ŝ³_tot` eigenspace.
+
+Combines:
+- `exists_nonzero_eigenvector_hermitianMinEigenvalue` (PR #3962, sector-level).
+- `anisotropicHeisenbergS_mulVec_magSectorEmbedding` (PR #3961, sector → full lift).
+- `magSectorEmbedding_mem_magSubspaceS` (existing, magSubspaceS membership).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Sector ground full-eigenvector existence**: for the anisotropic Hamiltonian
+with real-coupling `J` and real `(λ, D)`, restricted to a non-empty magnetisation
+sector `M`, there exists a nonzero sector vector `Φ` whose embedding is a
+full-Hilbert-space eigenvector of `Ĥ(λ, D)` at the per-sector minimum eigenvalue
+`E_M`. Additionally, the embedding lies in the `Ŝ³_tot` eigenspace
+`magSubspaceS Λ N (|V|·N/2 − M)`. -/
+theorem exists_sectorGround_full_eigenvector_anisotropicHeisenbergS
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y) (lam D : ℝ)
+    (N M : ℕ) [Nonempty (magConfigS Λ N M)] :
+    ∃ Φ : magConfigS Λ N M → ℂ, Φ ≠ 0 ∧
+      (anisotropicHeisenbergS J (lam : ℂ) (D : ℂ) N).mulVec (magSectorEmbedding Φ) =
+        ((hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M) hJ lam D) : ℝ) : ℂ) •
+          magSectorEmbedding Φ ∧
+      magSectorEmbedding Φ ∈ magSubspaceS Λ N
+        (((Fintype.card Λ : ℂ) * (N : ℂ) / 2) - (M : ℂ)) := by
+  classical
+  -- Hermitian sector submatrix.
+  have hHerm := anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+    (Λ := Λ) (N := N) (M := M) hJ lam D
+  -- Sector eigenvector existence at min eigenvalue.
+  obtain ⟨Φ, hΦ_ne, hΦ_eig⟩ :=
+    exists_nonzero_eigenvector_hermitianMinEigenvalue hHerm
+  refine ⟨Φ, hΦ_ne, ?_, ?_⟩
+  · -- Lift via PR #3961.
+    exact anisotropicHeisenbergS_mulVec_magSectorEmbedding J (lam : ℂ) (D : ℂ) Φ hΦ_eig
+  · -- magSubspaceS membership from existing lemma.
+    exact magSectorEmbedding_mem_magSubspaceS Φ
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

Sector ground full-eigenvector existence for the anisotropic Hamiltonian: the obligation (2) IVT crossing bridge.

`exists_sectorGround_full_eigenvector_anisotropicHeisenbergS`: for real-coupling `J` and real `(λ, D)`, restricted to a non-empty magnetisation sector `M`, there exists a nonzero sector vector `Φ` such that:
- `Ĥ(λ, D) . magSectorEmbedding Φ = (E_M : ℂ) . magSectorEmbedding Φ` at the per-sector minimum eigenvalue `E_M = hermitianMinEigenvalue` of the sector submatrix.
- `magSectorEmbedding Φ ∈ magSubspaceS Λ N (|V|·N/2 − M)`.

Composes three existing bricks:
- `exists_nonzero_eigenvector_hermitianMinEigenvalue` (PR #3962, sector-level eigenvector existence).
- `anisotropicHeisenbergS_mulVec_magSectorEmbedding` (PR #3961, sector → full lift).
- `magSectorEmbedding_mem_magSubspaceS` (existing, `Ŝ³_tot` eigenspace membership).

This is the bridge brick that connects the parametric continuity / IVT crossing chain (PRs #3959, #3960) to the existing reflection + obligation (1) `≤ 2` contradiction (PR #3903). At the hypothetical crossing point, sector ground eigenvectors at the common min energy lift to full eigenvectors in distinct `Ŝ³_tot` eigenspaces, supplying the 3-LI family that contradicts `≤ 2`.

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorGroundEigenvector` succeeds
- [x] CI green
