### PR TITLE
Generic-M_0 dual sector ground full-eigenvectors at parametric IVT crossing — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergCrossingDualSectorGroundGeneric.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergCrossingDualSectorGroundGeneric.lean
@@ -1,0 +1,84 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorGroundEigenvector
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricGapCrossingGeneric
+
+/-!
+# Generic-`M_0` dual sector ground full-eigenvectors at parametric IVT crossing
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+Generic-`M_0` variant of PR #3964
+(`anisotropicHeisenbergS_crossing_dual_sector_ground_eigenvectors`) using PR
+#3971's generic-`M_0` IVT crossing. Needed by the Tasaki §2.5 Theorem 2.4
+application with `M_0 = balanced` for `|A| = |B|`.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Set
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Generic-`M_0` dual sector ground full-eigenvectors at parametric crossing**: under
+the IVT-crossing hypotheses (strict gap at `(1, 0)` and inequality at `(λ', D')`),
+produces a crossing `t*` and a common eigenvalue `μ` such that both sectors
+`M_0` and `M` carry nonzero ground full-eigenvectors of `Ĥ(γ(t*))` at `μ`,
+with corresponding `Ŝ³_tot` eigenspace membership. -/
+theorem anisotropicHeisenbergS_crossing_dual_sector_ground_eigenvectors_generic
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_0 M : ℕ)
+    [Nonempty (magConfigS Λ N M)] [Nonempty (magConfigS Λ N M_0)]
+    (lam' D' : ℝ)
+    (h0 : hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M_0) hJ 1 0) <
+          hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M) hJ 1 0))
+    (h1 : hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M) hJ lam' D') ≤
+          hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M_0) hJ lam' D')) :
+    ∃ t : ℝ, t ∈ Icc (0 : ℝ) 1 ∧
+      ∃ μ : ℝ,
+        (∃ Φ_M0 : magConfigS Λ N M_0 → ℂ, Φ_M0 ≠ 0 ∧
+          (anisotropicHeisenbergS J
+              ((anisotropicHeisenbergParametricPath lam' D' t).1 : ℂ)
+              ((anisotropicHeisenbergParametricPath lam' D' t).2 : ℂ) N).mulVec
+            (magSectorEmbedding Φ_M0) =
+            (μ : ℂ) • magSectorEmbedding Φ_M0 ∧
+          magSectorEmbedding Φ_M0 ∈ magSubspaceS Λ N
+            (((Fintype.card Λ : ℂ) * (N : ℂ) / 2) - (M_0 : ℂ))) ∧
+        (∃ Φ_M : magConfigS Λ N M → ℂ, Φ_M ≠ 0 ∧
+          (anisotropicHeisenbergS J
+              ((anisotropicHeisenbergParametricPath lam' D' t).1 : ℂ)
+              ((anisotropicHeisenbergParametricPath lam' D' t).2 : ℂ) N).mulVec
+            (magSectorEmbedding Φ_M) =
+            (μ : ℂ) • magSectorEmbedding Φ_M ∧
+          magSectorEmbedding Φ_M ∈ magSubspaceS Λ N
+            (((Fintype.card Λ : ℂ) * (N : ℂ) / 2) - (M : ℂ))) := by
+  obtain ⟨t, htmem, hteq⟩ :=
+    anisotropicHeisenbergS_parametric_gap_crossing_generic (Λ := Λ) hJ N M_0 M lam' D' h0 h1
+  refine ⟨t, htmem, hermitianMinEigenvalue
+    (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+      (Λ := Λ) (N := N) (M := M_0) hJ
+      (anisotropicHeisenbergParametricPath lam' D' t).1
+      (anisotropicHeisenbergParametricPath lam' D' t).2), ?_, ?_⟩
+  · obtain ⟨Φ_M0, hΦ_M0_ne, hΦ_M0_eig, hΦ_M0_mem⟩ :=
+      exists_sectorGround_full_eigenvector_anisotropicHeisenbergS (Λ := Λ) hJ
+        (anisotropicHeisenbergParametricPath lam' D' t).1
+        (anisotropicHeisenbergParametricPath lam' D' t).2 N M_0
+    exact ⟨Φ_M0, hΦ_M0_ne, hΦ_M0_eig, hΦ_M0_mem⟩
+  · obtain ⟨Φ_M, hΦ_M_ne, hΦ_M_eig, hΦ_M_mem⟩ :=
+      exists_sectorGround_full_eigenvector_anisotropicHeisenbergS (Λ := Λ) hJ
+        (anisotropicHeisenbergParametricPath lam' D' t).1
+        (anisotropicHeisenbergParametricPath lam' D' t).2 N M
+    refine ⟨Φ_M, hΦ_M_ne, ?_, hΦ_M_mem⟩
+    rw [← hteq] at hΦ_M_eig
+    exact hΦ_M_eig
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricGapCrossingGeneric.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricGapCrossingGeneric.lean
@@ -1,0 +1,98 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricPath
+import Mathlib.Topology.Order.IntermediateValue
+
+/-!
+# Generic-`M_0` IVT crossing for the parametric gap `E_{M_0}(γ(t)) - E_M(γ(t))`
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+Generalisation of `anisotropicHeisenbergS_parametric_gap_crossing` (PR #3959,
+specialised to `M_0 = 0`) to an arbitrary ground sector `M_0`. Needed by the
+actual Tasaki §2.5 Theorem 2.4 application with `M_0 = balanced = |Λ|·N/2`
+(the centered-zero sector that contains the symmetric GS).
+
+Proof structure identical to PR #3959; only the sector label is parameterised.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Set
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Generic-`M_0` IVT crossing for the parametric gap**: if the gap `E_{M_0} - E_M`
+is strictly negative at `t = 0` (i.e., `E_{M_0}(1, 0) < E_M(1, 0)`) and non-negative
+at `t = 1` (i.e., `E_M(λ', D') ≤ E_{M_0}(λ', D')`), then there exists a crossing
+`t* ∈ [0, 1]` with `E_{M_0}(γ(t*)) = E_M(γ(t*))`. -/
+theorem anisotropicHeisenbergS_parametric_gap_crossing_generic
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_0 M : ℕ)
+    [Nonempty (magConfigS Λ N M)] [Nonempty (magConfigS Λ N M_0)]
+    (lam' D' : ℝ)
+    (h0 : hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M_0) hJ 1 0) <
+          hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M) hJ 1 0))
+    (h1 : hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M) hJ lam' D') ≤
+          hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M_0) hJ lam' D')) :
+    ∃ t : ℝ, t ∈ Icc (0 : ℝ) 1 ∧
+      hermitianMinEigenvalue
+        (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+          (Λ := Λ) (N := N) (M := M_0) hJ
+          (anisotropicHeisenbergParametricPath lam' D' t).1
+          (anisotropicHeisenbergParametricPath lam' D' t).2) =
+      hermitianMinEigenvalue
+        (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+          (Λ := Λ) (N := N) (M := M) hJ
+          (anisotropicHeisenbergParametricPath lam' D' t).1
+          (anisotropicHeisenbergParametricPath lam' D' t).2) := by
+  set EM0 : ℝ → ℝ := fun t => hermitianMinEigenvalue
+    (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+      (Λ := Λ) (N := N) (M := M_0) hJ
+      (anisotropicHeisenbergParametricPath lam' D' t).1
+      (anisotropicHeisenbergParametricPath lam' D' t).2)
+  set EM : ℝ → ℝ := fun t => hermitianMinEigenvalue
+    (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+      (Λ := Λ) (N := N) (M := M) hJ
+      (anisotropicHeisenbergParametricPath lam' D' t).1
+      (anisotropicHeisenbergParametricPath lam' D' t).2)
+  have hEM0 : Continuous EM0 :=
+    continuous_anisotropicHeisenbergS_magSector_minEigenvalue_along_parametricPath
+      (Λ := Λ) hJ N M_0 lam' D'
+  have hEM : Continuous EM :=
+    continuous_anisotropicHeisenbergS_magSector_minEigenvalue_along_parametricPath
+      (Λ := Λ) hJ N M lam' D'
+  have hg : Continuous (fun t => EM0 t - EM t) := hEM0.sub hEM
+  have hpath0 := anisotropicHeisenbergParametricPath_zero lam' D'
+  have hpath1 := anisotropicHeisenbergParametricPath_one lam' D'
+  have hEM0_0 : EM0 0 = hermitianMinEigenvalue
+      (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+        (Λ := Λ) (N := N) (M := M_0) hJ 1 0) := by simp only [EM0, hpath0]
+  have hEM_0 : EM 0 = hermitianMinEigenvalue
+      (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+        (Λ := Λ) (N := N) (M := M) hJ 1 0) := by simp only [EM, hpath0]
+  have hEM0_1 : EM0 1 = hermitianMinEigenvalue
+      (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+        (Λ := Λ) (N := N) (M := M_0) hJ lam' D') := by simp only [EM0, hpath1]
+  have hEM_1 : EM 1 = hermitianMinEigenvalue
+      (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+        (Λ := Λ) (N := N) (M := M) hJ lam' D') := by simp only [EM, hpath1]
+  have hg0 : EM0 0 - EM 0 < 0 := by rw [hEM0_0, hEM_0]; linarith
+  have hg1 : 0 ≤ EM0 1 - EM 1 := by rw [hEM0_1, hEM_1]; linarith
+  obtain ⟨t, htmem, hteq⟩ :=
+    intermediate_value_Icc (by norm_num : (0 : ℝ) ≤ 1)
+      (hg.continuousOn : ContinuousOn (fun t => EM0 t - EM t) (Icc (0 : ℝ) 1))
+      ⟨le_of_lt hg0, hg1⟩
+  refine ⟨t, htmem, ?_⟩
+  exact sub_eq_zero.mp hteq
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

Generic-`M_0` variant of PR #3964 `anisotropicHeisenbergS_crossing_dual_sector_ground_eigenvectors` using PR #3971's generic-`M_0` IVT crossing.

`anisotropicHeisenbergS_crossing_dual_sector_ground_eigenvectors_generic`: under the IVT-crossing hypotheses (strict gap at `(1, 0)` and inequality at `(λ', D')`), produces a crossing `t*` and a common eigenvalue `μ` such that both sectors `M_0` and `M` carry nonzero ground full-eigenvectors of `Ĥ(γ(t*))` at `μ`, with corresponding `Ŝ³_tot` eigenspace membership.

Needed by the Tasaki §2.5 Theorem 2.4 application with `M_0 = balanced = |Λ|·N/2` for `|A| = |B|`.

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergCrossingDualSectorGroundGeneric` succeeds
- [x] CI green
