### PR TITLE
Spin-1/2 embedded two-sector contradiction at hermitianMinEigenvalue Ĥ — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergCrossingDualSectorGroundGeneric.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergCrossingDualSectorGroundGeneric.lean
@@ -1,0 +1,84 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorGroundEigenvector
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricGapCrossingGeneric
+
+/-!
+# Generic-`M_0` dual sector ground full-eigenvectors at parametric IVT crossing
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+Generic-`M_0` variant of PR #3964
+(`anisotropicHeisenbergS_crossing_dual_sector_ground_eigenvectors`) using PR
+#3971's generic-`M_0` IVT crossing. Needed by the Tasaki §2.5 Theorem 2.4
+application with `M_0 = balanced` for `|A| = |B|`.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Set
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Generic-`M_0` dual sector ground full-eigenvectors at parametric crossing**: under
+the IVT-crossing hypotheses (strict gap at `(1, 0)` and inequality at `(λ', D')`),
+produces a crossing `t*` and a common eigenvalue `μ` such that both sectors
+`M_0` and `M` carry nonzero ground full-eigenvectors of `Ĥ(γ(t*))` at `μ`,
+with corresponding `Ŝ³_tot` eigenspace membership. -/
+theorem anisotropicHeisenbergS_crossing_dual_sector_ground_eigenvectors_generic
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_0 M : ℕ)
+    [Nonempty (magConfigS Λ N M)] [Nonempty (magConfigS Λ N M_0)]
+    (lam' D' : ℝ)
+    (h0 : hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M_0) hJ 1 0) <
+          hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M) hJ 1 0))
+    (h1 : hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M) hJ lam' D') ≤
+          hermitianMinEigenvalue
+            (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+              (Λ := Λ) (N := N) (M := M_0) hJ lam' D')) :
+    ∃ t : ℝ, t ∈ Icc (0 : ℝ) 1 ∧
+      ∃ μ : ℝ,
+        (∃ Φ_M0 : magConfigS Λ N M_0 → ℂ, Φ_M0 ≠ 0 ∧
+          (anisotropicHeisenbergS J
+              ((anisotropicHeisenbergParametricPath lam' D' t).1 : ℂ)
+              ((anisotropicHeisenbergParametricPath lam' D' t).2 : ℂ) N).mulVec
+            (magSectorEmbedding Φ_M0) =
+            (μ : ℂ) • magSectorEmbedding Φ_M0 ∧
+          magSectorEmbedding Φ_M0 ∈ magSubspaceS Λ N
+            (((Fintype.card Λ : ℂ) * (N : ℂ) / 2) - (M_0 : ℂ))) ∧
+        (∃ Φ_M : magConfigS Λ N M → ℂ, Φ_M ≠ 0 ∧
+          (anisotropicHeisenbergS J
+              ((anisotropicHeisenbergParametricPath lam' D' t).1 : ℂ)
+              ((anisotropicHeisenbergParametricPath lam' D' t).2 : ℂ) N).mulVec
+            (magSectorEmbedding Φ_M) =
+            (μ : ℂ) • magSectorEmbedding Φ_M ∧
+          magSectorEmbedding Φ_M ∈ magSubspaceS Λ N
+            (((Fintype.card Λ : ℂ) * (N : ℂ) / 2) - (M : ℂ))) := by
+  obtain ⟨t, htmem, hteq⟩ :=
+    anisotropicHeisenbergS_parametric_gap_crossing_generic (Λ := Λ) hJ N M_0 M lam' D' h0 h1
+  refine ⟨t, htmem, hermitianMinEigenvalue
+    (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+      (Λ := Λ) (N := N) (M := M_0) hJ
+      (anisotropicHeisenbergParametricPath lam' D' t).1
+      (anisotropicHeisenbergParametricPath lam' D' t).2), ?_, ?_⟩
+  · obtain ⟨Φ_M0, hΦ_M0_ne, hΦ_M0_eig, hΦ_M0_mem⟩ :=
+      exists_sectorGround_full_eigenvector_anisotropicHeisenbergS (Λ := Λ) hJ
+        (anisotropicHeisenbergParametricPath lam' D' t).1
+        (anisotropicHeisenbergParametricPath lam' D' t).2 N M_0
+    exact ⟨Φ_M0, hΦ_M0_ne, hΦ_M0_eig, hΦ_M0_mem⟩
+  · obtain ⟨Φ_M, hΦ_M_ne, hΦ_M_eig, hΦ_M_mem⟩ :=
+      exists_sectorGround_full_eigenvector_anisotropicHeisenbergS (Λ := Λ) hJ
+        (anisotropicHeisenbergParametricPath lam' D' t).1
+        (anisotropicHeisenbergParametricPath lam' D' t).2 N M
+    refine ⟨Φ_M, hΦ_M_ne, ?_, hΦ_M_mem⟩
+    rw [← hteq] at hΦ_M_eig
+    exact hΦ_M_eig
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfTwoSectorContradiction.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfTwoSectorContradiction.lean
@@ -1,0 +1,80 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergCrossingContradictionConditional
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergGlobalMinFinrankLeTwo
+
+/-!
+# Spin-1/2 embedded two-sector contradiction at the global min energy
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+Combines:
+- PR #3966 `anisotropicHeisenbergS_embedded_two_sector_contradiction_finrank_le_two`
+  (embedded two-sector contradiction at any μ with `finrank ≤ 2`).
+- PR #3970 `spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min`
+  (`finrank ≤ 2` at `μ = hermitianMinEigenvalue Ĥ` for spin-1/2).
+
+Conclusion: for spin-1/2 obligation-(1) hypotheses, if two nonzero sector
+vectors `Φ_admis` (centered-zero) and `Φ_nonadmis` (non-centered-zero) have
+embeddings that are eigenvectors of `Ĥ` at the SPECIFIC energy
+`hermitianMinEigenvalue Ĥ`, we get `False`.
+
+This is the spin-1/2 unconditional packaging of #3966 at the global min energy.
+Combined with the IVT crossing chain + first-crossing identification, this is
+the final algebraic step of obligation (2).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Spin-1/2 embedded two-sector contradiction at the global min**: under the
+spin-1/2 obligation (1) hypotheses, two nonzero sector eigenvectors at
+`hermitianMinEigenvalue Ĥ` with one centered-zero and one non-centered-zero
+produce `False`. -/
+theorem spinHalf_anisotropicHeisenbergS_embedded_two_sector_contradiction_at_global_min
+    (A : Λ → Bool) {J : Λ → Λ → ℂ}
+    (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
+    (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
+    (hJself : ∀ x, J x x = 0) (hJbip : ∀ x y, J x y ≠ 0 → A x ≠ A y)
+    {lam : ℂ} (hlam : lam.im = 0) (hlb : -1 < lam.re) (hub : lam.re < 1)
+    {D : ℂ} (hDim : D.im = 0) (hDpos : 0 < D.re)
+    {c : ℝ}
+    (hc_strict : ∀ σ : Λ → Fin (1 + 1),
+      dressedAxisSwappedAnisotropicHeisenbergSReMatrix A J lam D 1 σ σ < c)
+    (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false)
+    [Nonempty (parityConfigS Λ 1 0)] [Nonempty (parityConfigS Λ 1 1)]
+    (hJ_star : ∀ x y, star (J x y) = J x y)
+    (hlam_star : star lam = lam) (hD_star : star D = D)
+    {M_admis : ℕ} {Φ_admis : magConfigS Λ 1 M_admis → ℂ}
+    (hΦ_admis_ne : Φ_admis ≠ 0)
+    (h_admis_zero : ((Fintype.card Λ : ℂ) * ((1 : ℕ) : ℂ) / 2) - (M_admis : ℂ) = 0)
+    (hΦ_admis_eig : (anisotropicHeisenbergS J lam D 1).mulVec
+        (magSectorEmbedding Φ_admis) =
+        ((hermitianMinEigenvalue
+          (anisotropicHeisenbergS_isHermitian_of_real (Λ := Λ) (N := 1)
+            hJ_star hlam_star hD_star) : ℝ) : ℂ) •
+        magSectorEmbedding Φ_admis)
+    {M_nonadmis : ℕ} {Φ_nonadmis : magConfigS Λ 1 M_nonadmis → ℂ}
+    (hΦ_nonadmis_ne : Φ_nonadmis ≠ 0)
+    (h_nonadmis_ne_zero :
+      (((Fintype.card Λ : ℂ) * ((1 : ℕ) : ℂ) / 2) - (M_nonadmis : ℂ)) ≠ 0)
+    (hΦ_nonadmis_eig : (anisotropicHeisenbergS J lam D 1).mulVec
+        (magSectorEmbedding Φ_nonadmis) =
+        ((hermitianMinEigenvalue
+          (anisotropicHeisenbergS_isHermitian_of_real (Λ := Λ) (N := 1)
+            hJ_star hlam_star hD_star) : ℝ) : ℂ) •
+        magSectorEmbedding Φ_nonadmis) :
+    False :=
+  anisotropicHeisenbergS_embedded_two_sector_contradiction_finrank_le_two
+    J lam D _
+    (spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min
+      A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos
+      hc_strict hA_ne hB_ne hJ_star hlam_star hD_star)
+    hΦ_admis_ne h_admis_zero hΦ_admis_eig
+    hΦ_nonadmis_ne h_nonadmis_ne_zero hΦ_nonadmis_eig
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

Spin-1/2 embedded two-sector contradiction at `hermitianMinEigenvalue Ĥ`.

`spinHalf_anisotropicHeisenbergS_embedded_two_sector_contradiction_at_global_min`: combines
- PR #3966 `anisotropicHeisenbergS_embedded_two_sector_contradiction_finrank_le_two` (embedded two-sector contradiction at any μ with `finrank ≤ 2`),
- PR #3970 `spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min` (spin-1/2 `finrank ≤ 2` at `μ = hermitianMinEigenvalue Ĥ`),

into a single spin-1/2 unconditional packaging at the global min energy: two nonzero sector eigenvectors at the SPECIFIC energy `hermitianMinEigenvalue Ĥ` with one centered-zero and one non-centered-zero produce `False`.

This is the spin-1/2 obligation (2) final algebraic step. Combined with the IVT crossing chain (PRs #3959, #3960, #3961, #3962, #3963, #3964, #3971, #3972) + first-crossing identification of the crossing energy with `hermitianMinEigenvalue Ĥ`, this gives the obligation (2) capstone modulo:
- (i) strict gap at `(1, 0)` (the SU(2) Casimir-based bound).
- (ii) first-crossing argument (sup analysis showing crossing energy = global min).

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSpinHalfTwoSectorContradiction` succeeds
- [x] CI green
