### PR TITLE
Spin-1/2 Ĥ eigenspace finrank ≤ 2 at hermitianMinEigenvalue Ĥ(γ(t)) for t ∈ (0, 1] — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricPathStaysInRegion.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricPathStaysInRegion.lean
@@ -1,0 +1,79 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricPath
+import Mathlib.Tactic.Positivity
+
+/-!
+# The parametric path stays in the obligation (1) strict region for `t ∈ (0, 1]`
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+For target `(λ', D')` in the strict region (i) `(-1 < λ' < 1, D' > 0)`, the
+linear parametric path `γ(t) = ((1 - t) + t λ', t D')` from `(1, 0)` to
+`(λ', D')` satisfies the obligation (1) strict hypotheses for every
+`t ∈ (0, 1]`:
+- `-1 < γ(t).1`
+- `γ(t).1 < 1`
+- `0 < γ(t).2`
+
+(At `t = 0` the path is at the SU(2) point `(1, 0)` itself, which violates the
+strict obligation (1) hypotheses — this is expected since obligation (1) is the
+*punctured* region.)
+
+This is the analytic ingredient that lets PR #3970 (spin-1/2 `finrank ≤ 2`
+at `hermitianMinEigenvalue Ĥ` for fixed `(λ, D)`) be applied at the parametric
+crossing point `γ(t*)` in the obligation (2) chain.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+/-- `γ(t).1 < 1` for `t ∈ (0, 1]` and `λ' < 1`. -/
+theorem anisotropicHeisenbergParametricPath_fst_lt_one
+    {lam' D' : ℝ} (hlam' : lam' < 1) {t : ℝ} (ht_pos : 0 < t) (ht_le : t ≤ 1) :
+    (anisotropicHeisenbergParametricPath lam' D' t).1 < 1 := by
+  unfold anisotropicHeisenbergParametricPath
+  change (1 - t) + t * lam' < 1
+  nlinarith
+
+/-- `-1 < γ(t).1` for `t ∈ [0, 1]` and `-1 < λ'`. -/
+theorem anisotropicHeisenbergParametricPath_neg_one_lt_fst
+    {lam' D' : ℝ} (hlam' : -1 < lam') {t : ℝ} (ht_nn : 0 ≤ t) (ht_le : t ≤ 1) :
+    -1 < (anisotropicHeisenbergParametricPath lam' D' t).1 := by
+  unfold anisotropicHeisenbergParametricPath
+  change -1 < (1 - t) + t * lam'
+  -- 1 - t + t * lam' = 1 + t * (lam' - 1). For lam' > -1, t ∈ [0, 1]:
+  -- t * (lam' - 1) ≥ -2 since either lam' ≥ 1 (so ≥ 0) or t * (lam' - 1) ≥ 1 * (lam' - 1) > -2.
+  have h1 : 1 - t + t * lam' = 1 + t * (lam' - 1) := by ring
+  rw [h1]
+  rcases le_or_gt 1 lam' with h | h
+  · -- lam' ≥ 1
+    have : 0 ≤ t * (lam' - 1) := mul_nonneg ht_nn (by linarith)
+    linarith
+  · -- lam' < 1
+    have : t * (lam' - 1) ≥ 1 * (lam' - 1) := by
+      have hneg : lam' - 1 < 0 := by linarith
+      nlinarith
+    linarith
+
+/-- `0 < γ(t).2` for `t ∈ (0, 1]` and `D' > 0`. -/
+theorem anisotropicHeisenbergParametricPath_snd_pos
+    {lam' D' : ℝ} (hD' : 0 < D') {t : ℝ} (ht_pos : 0 < t) :
+    0 < (anisotropicHeisenbergParametricPath lam' D' t).2 := by
+  unfold anisotropicHeisenbergParametricPath
+  change 0 < t * D'
+  positivity
+
+/-- **Combined**: for target `(λ', D')` in strict region (i) and `t ∈ (0, 1]`,
+the path satisfies the strict obligation (1) hypotheses. -/
+theorem anisotropicHeisenbergParametricPath_in_strict_region
+    {lam' D' : ℝ} (hlam'_lb : -1 < lam') (hlam'_ub : lam' < 1) (hD' : 0 < D')
+    {t : ℝ} (ht_pos : 0 < t) (ht_le : t ≤ 1) :
+    -1 < (anisotropicHeisenbergParametricPath lam' D' t).1 ∧
+    (anisotropicHeisenbergParametricPath lam' D' t).1 < 1 ∧
+    0 < (anisotropicHeisenbergParametricPath lam' D' t).2 :=
+  ⟨anisotropicHeisenbergParametricPath_neg_one_lt_fst hlam'_lb (le_of_lt ht_pos) ht_le,
+   anisotropicHeisenbergParametricPath_fst_lt_one hlam'_ub ht_pos ht_le,
+   anisotropicHeisenbergParametricPath_snd_pos hD' ht_pos⟩
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfFinrankLeTwoAtPath.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfFinrankLeTwoAtPath.lean
@@ -1,0 +1,88 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergGlobalMinFinrankLeTwo
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricPathStaysInRegion
+
+/-!
+# Spin-1/2 `Ĥ` eigenspace `finrank ≤ 2` at `hermitianMinEigenvalue Ĥ(γ(t))` for `t ∈ (0, 1]`
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+Combines:
+- PR #3970 `spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min`
+  (fixed `(λ, D)` version).
+- PR #3975 `anisotropicHeisenbergParametricPath_in_strict_region` (path stays in
+  strict region for `t ∈ (0, 1]`).
+
+Conclusion: at any path point `γ(t)` for `t ∈ (0, 1]` with target `(λ', D')` in
+strict region (i), the `Ĥ(γ(t))` eigenspace at its global min eigenvalue has
+`finrank ≤ 2`. This is the parametric version of PR #3970, suitable for use at
+the IVT crossing point.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Spin-1/2 `Ĥ` eigenspace `finrank ≤ 2` at the global min along the path**:
+for target `(λ', D')` in strict region (i) and `t ∈ (0, 1]`, the eigenspace of
+`Ĥ(γ(t))` at its global min `hermitianMinEigenvalue Ĥ(γ(t))` has `finrank ≤ 2`. -/
+theorem spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_path
+    (A : Λ → Bool) {J : Λ → Λ → ℂ}
+    (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
+    (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
+    (hJself : ∀ x, J x x = 0) (hJbip : ∀ x y, J x y ≠ 0 → A x ≠ A y)
+    {c : ℝ}
+    (hc_strict : ∀ (lam D : ℂ) (σ : Λ → Fin (1 + 1)),
+      dressedAxisSwappedAnisotropicHeisenbergSReMatrix A J lam D 1 σ σ < c)
+    (hA_ne : ∃ a, A a = true) (hB_ne : ∃ b, A b = false)
+    [Nonempty (parityConfigS Λ 1 0)] [Nonempty (parityConfigS Λ 1 1)]
+    (hJ_star : ∀ x y, star (J x y) = J x y)
+    {lam' D' : ℝ} (hlam'_lb : -1 < lam') (hlam'_ub : lam' < 1) (hD' : 0 < D')
+    {t : ℝ} (ht_pos : 0 < t) (ht_le : t ≤ 1) :
+    finrank ℂ (End.eigenspace (Matrix.toLin'
+      (anisotropicHeisenbergS (Λ := Λ) J
+        ((anisotropicHeisenbergParametricPath lam' D' t).1 : ℂ)
+        ((anisotropicHeisenbergParametricPath lam' D' t).2 : ℂ) 1))
+      ((hermitianMinEigenvalue
+        (anisotropicHeisenbergS_isHermitian_of_real (Λ := Λ) (N := 1)
+          hJ_star
+          (show star ((anisotropicHeisenbergParametricPath lam' D' t).1 : ℂ) =
+              ((anisotropicHeisenbergParametricPath lam' D' t).1 : ℂ) from by
+            rw [Complex.star_def, Complex.conj_ofReal])
+          (show star ((anisotropicHeisenbergParametricPath lam' D' t).2 : ℂ) =
+              ((anisotropicHeisenbergParametricPath lam' D' t).2 : ℂ) from by
+            rw [Complex.star_def, Complex.conj_ofReal])) : ℝ) : ℂ)) ≤ 2 := by
+  -- Path point lies in strict region (i).
+  obtain ⟨hlb, hub, hDpos⟩ :=
+    anisotropicHeisenbergParametricPath_in_strict_region hlam'_lb hlam'_ub hD' ht_pos ht_le
+  -- The path coordinates as ℂ.
+  set lam_t : ℂ := ((anisotropicHeisenbergParametricPath lam' D' t).1 : ℂ)
+  set D_t : ℂ := ((anisotropicHeisenbergParametricPath lam' D' t).2 : ℂ)
+  -- Imaginary parts vanish for real-cast values.
+  have hlam_t_im : lam_t.im = 0 := by simp [lam_t]
+  have hD_t_im : D_t.im = 0 := by simp [D_t]
+  -- Real parts match the path coordinates.
+  have hlam_t_re : lam_t.re = (anisotropicHeisenbergParametricPath lam' D' t).1 := by
+    simp [lam_t]
+  have hD_t_re : D_t.re = (anisotropicHeisenbergParametricPath lam' D' t).2 := by
+    simp [D_t]
+  -- Star equations.
+  have hlam_t_star : star lam_t = lam_t := by
+    rw [Complex.star_def]; simp [lam_t]
+  have hD_t_star : star D_t = D_t := by
+    rw [Complex.star_def]; simp [D_t]
+  -- Bounds in terms of .re.
+  have hlb_t : -1 < lam_t.re := by rw [hlam_t_re]; exact hlb
+  have hub_t : lam_t.re < 1 := by rw [hlam_t_re]; exact hub
+  have hDpos_t : 0 < D_t.re := by rw [hD_t_re]; exact hDpos
+  -- Apply PR #3970.
+  exact spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min
+    A hJim hJnn hJpos hJself hJbip
+    hlam_t_im hlb_t hub_t hD_t_im hDpos_t
+    (hc_strict lam_t D_t) hA_ne hB_ne hJ_star hlam_t_star hD_t_star
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

Parametric-path version of PR #3970, applying the spin-1/2 obligation (1) bound at each path point `γ(t)` for `t ∈ (0, 1]` with target `(λ', D')` in strict region (i).

`spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_path`: for target `(λ', D')` in strict region (i) and `t ∈ (0, 1]`, the eigenspace of `Ĥ(γ(t))` at its global min `hermitianMinEigenvalue Ĥ(γ(t))` has `finrank ≤ 2`.

Composes:
- PR #3970 (spin-1/2 `finrank ≤ 2` at global min, fixed `(λ, D)` version).
- PR #3975 (path stays in strict region for `t ∈ (0, 1]`).

The `hc_strict` hypothesis is taken parametrically over `(lam, D)` since the path provides varying values; the user supplies a uniform bound applicable at any `(lam, D)`.

This closes the "PR #3970 parametric (γ(t).1, γ(t).2) version" gap (gap 3 of the obligation (2) capstone work). Remaining: (i) strict gap at `(1, 0)`, (ii) first-crossing argument.

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSpinHalfFinrankLeTwoAtPath` succeeds
- [x] CI green
