### PR TITLE
Refactor (build-speed eval, 20-PR cadence): obligation (2) chain healthy + linter cleanup — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergCrossingTPos.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergCrossingTPos.lean
@@ -70,8 +70,9 @@ theorem anisotropicHeisenbergS_parametric_gap_crossing_t_pos
     subst h0_eq
     have hγ0 := anisotropicHeisenbergParametricPath_zero lam' D'
     rw [hγ0] at heq
-    simp at heq
+    simp only at heq
     -- heq : E_{M_0}(1, 0) = E_M(1, 0). But h0 : E_{M_0}(1, 0) < E_M(1, 0).
-    exact (lt_irrefl _ (heq ▸ h0))
+    rw [heq] at h0
+    exact lt_irrefl _ h0
 
 end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

20-PR cadence refactor PR after PR #3978 (IVT crossing point t > 0 brick).

## Build-speed evaluation

Measured incremental rebuild of the obligation (2) chain leaves:
- `AnisotropicHeisenbergCrossingDualSectorGroundExplicit` (deepest leaf): **2.5 s**
- `AnisotropicHeisenbergSpinHalfFinrankLeTwoAtPath`: **2.0 s**
- `AnisotropicHeisenbergCrossingTPos` (fresh after cleanup): **2.4 s**

The obligation (2) chain now spans 20+ files in `LatticeSystem/Quantum/SpinS/` covering: parametric path, IVT crossing (specialised + generic + `t > 0`), sector lifts, dual sector ground (3 variants: original / generic / explicit-μ), axis-swap energy bridges, spin-1/2 `finrank ≤ 2` at global min (path-version), `magSectorEmbedding` LI.

**Decision: no consolidation**. Each leaf builds incrementally in 2-3 seconds. The fine granularity:
1. Mirrors the proof dependency DAG (one brick per lemma family).
2. Aligns with the existing §2.5 / §2.4 obligation (1) chain pattern.
3. Keeps build-failure surface small.

## Cleanup

Replaced `exact (lt_irrefl _ (heq ▸ h0))` with explicit rewrite + `lt_irrefl`, clearing the `flexible-tactic uses heq` linter info on `AnisotropicHeisenbergCrossingTPos.lean`.

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergCrossingTPos` succeeds (no warnings)
- [x] CI green
