### PR TITLE
Define balancedGSSet and prove it is closed in ℝ — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedGSSetClosed.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedGSSetClosed.lean
@@ -1,0 +1,61 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergFullMinEigenvalueContinuous
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricMinEigenvalue
+
+/-!
+# The set `{ t | balanced sector is the GS at γ(t) }` is closed
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) first-crossing argument.
+
+Defines the set
+`balancedGSSet J hJ N M_balanced lam' D' := { t : ℝ | hermitianMinEigenvalue (Ĥ_M_balanced(γ(t))) = hermitianMinEigenvalue (Ĥ(γ(t))) }`
+and proves it is closed in `ℝ`.
+
+This is a building block for the first-crossing argument: `t* := sSup balancedGSSet`
+will be reached (closed + bounded + non-empty), and at `t*` the equality holds.
+
+Composes:
+- PR #3957 / PR #3965 (sector min eigenvalue continuous along path).
+- PR #3982 (full Ĥ min eigenvalue continuous along path).
+- `isClosed_eq` (mathlib, preimage of diagonal under continuous map into Hausdorff).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **The set of `t` where the balanced sector is the GS at `γ(t)`** (i.e., the
+sector-`M_balanced` min eigenvalue equals the global Ĥ min eigenvalue). -/
+noncomputable def balancedGSSet
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_balanced : ℕ) [Nonempty (magConfigS Λ N M_balanced)]
+    [Nonempty (Λ → Fin (N + 1))] (lam' D' : ℝ) : Set ℝ :=
+  { t : ℝ |
+    anisotropicHeisenbergS_magSector_minEigenvalue_alongParametricPath
+      (Λ := Λ) hJ N M_balanced lam' D' t =
+    hermitianMinEigenvalue
+      (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N
+        (anisotropicHeisenbergParametricPath lam' D' t).1
+        (anisotropicHeisenbergParametricPath lam' D' t).2) }
+
+/-- **The balanced-GS set is closed in `ℝ`**: as the preimage of the diagonal
+in `ℝ × ℝ` under the continuous map
+`t ↦ (E_M_balanced(γ(t)), global Ĥ(γ(t)) min)`, which is closed in `ℝ × ℝ`
+(Hausdorff). -/
+theorem isClosed_balancedGSSet
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_balanced : ℕ) [Nonempty (magConfigS Λ N M_balanced)]
+    [Nonempty (Λ → Fin (N + 1))] (lam' D' : ℝ) :
+    IsClosed (balancedGSSet (Λ := Λ) hJ N M_balanced lam' D') := by
+  unfold balancedGSSet
+  exact isClosed_eq
+    (continuous_anisotropicHeisenbergS_magSector_minEigenvalue_alongParametricPath
+      (Λ := Λ) hJ N M_balanced lam' D')
+    (continuous_anisotropicHeisenbergS_full_minEigenvalue_alongParametricPath
+      (Λ := Λ) hJ N lam' D')
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinEigenvalueContinuous.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinEigenvalueContinuous.lean
@@ -1,0 +1,63 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergContinuousReal
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorIsHermitianReal
+import LatticeSystem.Quantum.SpinS.HermitianMinEigenvalueContinuous
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricPath
+
+/-!
+# Continuity of `(λ, D) ↦ hermitianMinEigenvalue Ĥ(λ, D)` (full Hamiltonian)
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+For real-coupling `J` and real `(λ, D)`, the **global** min eigenvalue
+`hermitianMinEigenvalue Ĥ(λ, D)` of the FULL anisotropic Hamiltonian is
+continuous on `ℝ × ℝ`. Parallel of PR #3957 (`hermitianMinEigenvalue (Ĥ_M(λ, D))`
+continuity, sector version) but applied to the full Hamiltonian — the input
+needed by the first-crossing argument's sup analysis.
+
+Composes:
+- `continuous_anisotropicHeisenbergS_real` (existing, entry-wise Ĥ continuity).
+- `anisotropicHeisenbergS_isHermitian_of_real` (existing, full Ĥ Hermitian).
+- `Continuous.hermitianMinEigenvalue_comp` (PR #3953, Lipschitz-composition).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- Hermitian instance of full Ĥ at real `(λ, D)`. -/
+theorem anisotropicHeisenbergS_full_isHermitian_real
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N : ℕ) (lam D : ℝ) :
+    (anisotropicHeisenbergS (Λ := Λ) J ((lam : ℂ)) ((D : ℂ)) N).IsHermitian :=
+  anisotropicHeisenbergS_isHermitian_of_real (Λ := Λ) (N := N)
+    hJ (star_ofReal_eq lam) (star_ofReal_eq D)
+
+/-- **Full-Hamiltonian global min eigenvalue continuity in real `(λ, D)`**: the
+function `(λ, D) ↦ hermitianMinEigenvalue (Ĥ(λ, D))` is continuous on `ℝ × ℝ`. -/
+theorem continuous_anisotropicHeisenbergS_full_minEigenvalue_real
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y) (N : ℕ)
+    [Nonempty (Λ → Fin (N + 1))] :
+    Continuous (fun p : ℝ × ℝ => hermitianMinEigenvalue
+      (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N p.1 p.2)) :=
+  Continuous.hermitianMinEigenvalue_comp
+    (continuous_anisotropicHeisenbergS_real J N)
+    (fun p => anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N p.1 p.2)
+
+/-- **Composed continuity along the parametric path**: the function
+`t ↦ hermitianMinEigenvalue (Ĥ(γ(t)))` is continuous on `ℝ`. -/
+theorem continuous_anisotropicHeisenbergS_full_minEigenvalue_alongParametricPath
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y) (N : ℕ)
+    [Nonempty (Λ → Fin (N + 1))] (lam' D' : ℝ) :
+    Continuous (fun t : ℝ => hermitianMinEigenvalue
+      (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N
+        (anisotropicHeisenbergParametricPath lam' D' t).1
+        (anisotropicHeisenbergParametricPath lam' D' t).2)) :=
+  (continuous_anisotropicHeisenbergS_full_minEigenvalue_real (Λ := Λ) hJ N).comp
+    (continuous_anisotropicHeisenbergParametricPath lam' D')
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

Defines the set where the balanced sector is the ground state along the parametric path, and proves it is closed in `ℝ`.

- `balancedGSSet J hJ N M_balanced lam' D' : Set ℝ` — the set of `t` where the sector-`M_balanced` min eigenvalue equals the global `Ĥ` min eigenvalue (the balanced sector IS the GS at `γ(t)`).
- `isClosed_balancedGSSet` — the set is closed, as the preimage of the diagonal in `ℝ × ℝ` under the continuous map `t ↦ (E_M_balanced(γ(t)), global Ĥ(γ(t)) min)`.

This is a building block for the **first-crossing argument** (one of the two remaining axioms in PR #3980's axiomatic capstone): `t* := sSup balancedGSSet` will be reached (closed + bounded + non-empty), and at `t*` the energy identification required by the obligation (2) capstone holds.

Composes:
- PR #3957 / #3965 (sector min eigenvalue continuous along path).
- PR #3982 (full Ĥ min eigenvalue continuous along path).
- `isClosed_eq` (mathlib, preimage of diagonal under continuous map into Hausdorff).

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergBalancedGSSetClosed` succeeds
- [x] CI green
