### PR TITLE
Global Ĥ min ≤ each sector min — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedGSSetClosed.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedGSSetClosed.lean
@@ -1,0 +1,61 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergFullMinEigenvalueContinuous
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricMinEigenvalue
+
+/-!
+# The set `{ t | balanced sector is the GS at γ(t) }` is closed
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) first-crossing argument.
+
+Defines the set
+`balancedGSSet J hJ N M_balanced lam' D' := { t : ℝ | hermitianMinEigenvalue (Ĥ_M_balanced(γ(t))) = hermitianMinEigenvalue (Ĥ(γ(t))) }`
+and proves it is closed in `ℝ`.
+
+This is a building block for the first-crossing argument: `t* := sSup balancedGSSet`
+will be reached (closed + bounded + non-empty), and at `t*` the equality holds.
+
+Composes:
+- PR #3957 / PR #3965 (sector min eigenvalue continuous along path).
+- PR #3982 (full Ĥ min eigenvalue continuous along path).
+- `isClosed_eq` (mathlib, preimage of diagonal under continuous map into Hausdorff).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **The set of `t` where the balanced sector is the GS at `γ(t)`** (i.e., the
+sector-`M_balanced` min eigenvalue equals the global Ĥ min eigenvalue). -/
+noncomputable def balancedGSSet
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_balanced : ℕ) [Nonempty (magConfigS Λ N M_balanced)]
+    [Nonempty (Λ → Fin (N + 1))] (lam' D' : ℝ) : Set ℝ :=
+  { t : ℝ |
+    anisotropicHeisenbergS_magSector_minEigenvalue_alongParametricPath
+      (Λ := Λ) hJ N M_balanced lam' D' t =
+    hermitianMinEigenvalue
+      (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N
+        (anisotropicHeisenbergParametricPath lam' D' t).1
+        (anisotropicHeisenbergParametricPath lam' D' t).2) }
+
+/-- **The balanced-GS set is closed in `ℝ`**: as the preimage of the diagonal
+in `ℝ × ℝ` under the continuous map
+`t ↦ (E_M_balanced(γ(t)), global Ĥ(γ(t)) min)`, which is closed in `ℝ × ℝ`
+(Hausdorff). -/
+theorem isClosed_balancedGSSet
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_balanced : ℕ) [Nonempty (magConfigS Λ N M_balanced)]
+    [Nonempty (Λ → Fin (N + 1))] (lam' D' : ℝ) :
+    IsClosed (balancedGSSet (Λ := Λ) hJ N M_balanced lam' D') := by
+  unfold balancedGSSet
+  exact isClosed_eq
+    (continuous_anisotropicHeisenbergS_magSector_minEigenvalue_alongParametricPath
+      (Λ := Λ) hJ N M_balanced lam' D')
+    (continuous_anisotropicHeisenbergS_full_minEigenvalue_alongParametricPath
+      (Λ := Λ) hJ N lam' D')
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinEigenvalueContinuous.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinEigenvalueContinuous.lean
@@ -1,0 +1,63 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergContinuousReal
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorIsHermitianReal
+import LatticeSystem.Quantum.SpinS.HermitianMinEigenvalueContinuous
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricPath
+
+/-!
+# Continuity of `(λ, D) ↦ hermitianMinEigenvalue Ĥ(λ, D)` (full Hamiltonian)
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2).
+
+For real-coupling `J` and real `(λ, D)`, the **global** min eigenvalue
+`hermitianMinEigenvalue Ĥ(λ, D)` of the FULL anisotropic Hamiltonian is
+continuous on `ℝ × ℝ`. Parallel of PR #3957 (`hermitianMinEigenvalue (Ĥ_M(λ, D))`
+continuity, sector version) but applied to the full Hamiltonian — the input
+needed by the first-crossing argument's sup analysis.
+
+Composes:
+- `continuous_anisotropicHeisenbergS_real` (existing, entry-wise Ĥ continuity).
+- `anisotropicHeisenbergS_isHermitian_of_real` (existing, full Ĥ Hermitian).
+- `Continuous.hermitianMinEigenvalue_comp` (PR #3953, Lipschitz-composition).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- Hermitian instance of full Ĥ at real `(λ, D)`. -/
+theorem anisotropicHeisenbergS_full_isHermitian_real
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N : ℕ) (lam D : ℝ) :
+    (anisotropicHeisenbergS (Λ := Λ) J ((lam : ℂ)) ((D : ℂ)) N).IsHermitian :=
+  anisotropicHeisenbergS_isHermitian_of_real (Λ := Λ) (N := N)
+    hJ (star_ofReal_eq lam) (star_ofReal_eq D)
+
+/-- **Full-Hamiltonian global min eigenvalue continuity in real `(λ, D)`**: the
+function `(λ, D) ↦ hermitianMinEigenvalue (Ĥ(λ, D))` is continuous on `ℝ × ℝ`. -/
+theorem continuous_anisotropicHeisenbergS_full_minEigenvalue_real
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y) (N : ℕ)
+    [Nonempty (Λ → Fin (N + 1))] :
+    Continuous (fun p : ℝ × ℝ => hermitianMinEigenvalue
+      (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N p.1 p.2)) :=
+  Continuous.hermitianMinEigenvalue_comp
+    (continuous_anisotropicHeisenbergS_real J N)
+    (fun p => anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N p.1 p.2)
+
+/-- **Composed continuity along the parametric path**: the function
+`t ↦ hermitianMinEigenvalue (Ĥ(γ(t)))` is continuous on `ℝ`. -/
+theorem continuous_anisotropicHeisenbergS_full_minEigenvalue_alongParametricPath
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y) (N : ℕ)
+    [Nonempty (Λ → Fin (N + 1))] (lam' D' : ℝ) :
+    Continuous (fun t : ℝ => hermitianMinEigenvalue
+      (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N
+        (anisotropicHeisenbergParametricPath lam' D' t).1
+        (anisotropicHeisenbergParametricPath lam' D' t).2)) :=
+  (continuous_anisotropicHeisenbergS_full_minEigenvalue_real (Λ := Λ) hJ N).comp
+    (continuous_anisotropicHeisenbergParametricPath lam' D')
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinLeSectorMin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinLeSectorMin.lean
@@ -1,0 +1,83 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorGroundEigenvector
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergFullMinEigenvalueContinuous
+import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
+
+/-!
+# `hermitianMinEigenvalue Ĥ ≤ hermitianMinEigenvalue Ĥ_M` (sector min upper-bounds global min)
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) first-crossing argument.
+
+For real-coupling `J` and real `(λ, D)`, the sector-`M` min eigenvalue
+`hermitianMinEigenvalue Ĥ_M(λ, D)` is `≥` the full `Ĥ` global min eigenvalue
+(equivalently, the global min is `≤` each sector min). This is the easy
+direction of the global-min-over-sector-mins identity, sufficient for the
+first-crossing argument's `0 ∈ balancedGSSet` step under the strict gap axiom.
+
+Proof: PR #3963 produces a sector ground full-eigenvector at energy
+`hermitianMinEigenvalue Ĥ_M`, so this is an eigenvalue of Ĥ;
+`hermitian_min_eigenvalue_le` then gives the bound.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Global Ĥ min ≤ each sector min**: for real-coupling `J` and real `(λ, D)`,
+the sector-`M` min eigenvalue is `≥` the full `Ĥ` global min. -/
+theorem hermitianMinEigenvalue_anisotropicHeisenbergS_full_le_sector
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M : ℕ) (lam D : ℝ) [Nonempty (magConfigS Λ N M)]
+    [Nonempty (Λ → Fin (N + 1))] :
+    hermitianMinEigenvalue
+        (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N lam D) ≤
+      hermitianMinEigenvalue
+        (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+          (Λ := Λ) (N := N) (M := M) hJ lam D) := by
+  classical
+  -- Get a sector ground full-eigenvector at the sector min.
+  obtain ⟨Φ, hΦ_ne, hΦ_eig, _⟩ :=
+    exists_sectorGround_full_eigenvector_anisotropicHeisenbergS (Λ := Λ) hJ lam D N M
+  -- Φ_embed is a full-Ĥ eigenvector at sector min; hence sector min ∈ spectrum.
+  set μ := hermitianMinEigenvalue
+    (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+      (Λ := Λ) (N := N) (M := M) hJ lam D) with hμ_def
+  set Ψ : (Λ → Fin (N + 1)) → ℂ := magSectorEmbedding Φ with hΨ_def
+  have hΨ_ne : Ψ ≠ 0 := by
+    intro h
+    apply hΦ_ne
+    funext τ
+    have := congrFun h τ.1
+    rwa [hΨ_def, magSectorEmbedding_apply_subtype Φ τ] at this
+  -- Eigenspace at (μ : ℂ) is non-trivial.
+  have hΨ_mem : Ψ ∈ Module.End.eigenspace (Matrix.toLin'
+      (anisotropicHeisenbergS J (lam : ℂ) (D : ℂ) N)) ((μ : ℝ) : ℂ) := by
+    rw [Module.End.mem_eigenspace_iff, Matrix.toLin'_apply]
+    exact hΦ_eig
+  have hne_bot : Module.End.eigenspace (Matrix.toLin'
+      (anisotropicHeisenbergS J (lam : ℂ) (D : ℂ) N)) ((μ : ℝ) : ℂ) ≠ ⊥ := by
+    intro hbot
+    rw [hbot] at hΨ_mem
+    exact hΨ_ne hΨ_mem
+  -- HasEigenvalue → mem_spectrum.
+  have hHE : Module.End.HasEigenvalue (Matrix.toLin'
+      (anisotropicHeisenbergS J (lam : ℂ) (D : ℂ) N)) ((μ : ℝ) : ℂ) := hne_bot
+  have hHerm := anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N lam D
+  -- Convert to real-spectrum membership.
+  have h_mem_C : ((μ : ℝ) : ℂ) ∈ spectrum ℂ
+      (anisotropicHeisenbergS (Λ := Λ) J (lam : ℂ) (D : ℂ) N) := by
+    rw [← Matrix.spectrum_toLin']
+    exact hHE.mem_spectrum
+  have h_mem_R : μ ∈ spectrum ℝ
+      (anisotropicHeisenbergS (Λ := Λ) J (lam : ℂ) (D : ℂ) N) := by
+    rw [← spectrum.algebraMap_mem_iff ℂ (R := ℝ)]; exact h_mem_C
+  rw [hHerm.spectrum_real_eq_range_eigenvalues] at h_mem_R
+  obtain ⟨i, hi⟩ := h_mem_R
+  rw [← hi]
+  exact hermitian_min_eigenvalue_le hHerm i
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

For real-coupling `J` and real `(λ, D)`, the sector-`M` min eigenvalue is `≥` the full `Ĥ` global min.

`hermitianMinEigenvalue_anisotropicHeisenbergS_full_le_sector`: `hermitianMinEigenvalue Ĥ(λ, D) ≤ hermitianMinEigenvalue Ĥ_M(λ, D)` for any sector `M` with non-empty `magConfigS`.

Proof: PR #3963 produces a sector ground full-eigenvector at energy `hermitianMinEigenvalue Ĥ_M`, so this is an eigenvalue of `Ĥ` (via `HasEigenvalue → mem_spectrum → range eigenvalues`); `hermitian_min_eigenvalue_le` then gives the bound.

This is the easy direction of the global-min-over-sector-mins identity (the analog of PR #3969's axisSwap block-min identity but for magnetization sectors). Sufficient for the first-crossing argument's `0 ∈ balancedGSSet` step: combined with the strict gap `E_balanced < E_M` for `M ≠ balanced` (axiom 1 of PR #3980), the inequality `global min ≤ E_balanced` becomes equality (since global min ≤ E_balanced and any value strictly above E_balanced cannot be the min).

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergFullMinLeSectorMin` succeeds
- [x] CI green
