### PR TITLE
Global Ĥ min ≥ some sector min (block-min identity hard direction) — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinGeSectorMin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinGeSectorMin.lean
@@ -1,0 +1,109 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorInverseLift
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergFullMinLeSectorMin
+import LatticeSystem.Quantum.SpinS.HermitianMinEigenvalueEigenvector
+
+/-!
+# Global Ĥ min ≥ some sector min (block-min identity, hard direction)
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) first-crossing argument.
+
+For real-coupling `J` and real `(λ, D)`, there exists a non-empty sector `M`
+such that `hermitianMinEigenvalue Ĥ_M(λ, D) ≤ hermitianMinEigenvalue Ĥ(λ, D)`.
+
+Combined with PR #3984 (easy direction `hermitianMinEigenvalue Ĥ ≤ each sector min`),
+this gives: there exists `M` (non-empty) with
+`hermitianMinEigenvalue Ĥ_M = hermitianMinEigenvalue Ĥ`.
+
+Proof: get a full-Ĥ eigvec `v` at the global min (PR #3962). Project to some
+sector `M` where the projection is non-zero (`exists_magSectorRestriction_ne_zero`).
+The restriction is a sector eigvec at the same energy (PR #3988 inverse lift).
+Hence sector-`M` min ≤ global min.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Existence of a non-zero sector projection** for any non-zero full vector:
+if `v ≠ 0`, then `∃ M`, `magSectorRestriction (M := M) v ≠ 0`. -/
+theorem exists_magSectorRestriction_ne_zero
+    {N : ℕ} {v : (Λ → Fin (N + 1)) → ℂ} (hv : v ≠ 0) :
+    ∃ M ∈ Finset.range (Fintype.card Λ * N + 1),
+      magSectorRestriction (V := Λ) (N := N) (M := M) v ≠ 0 := by
+  classical
+  by_contra h
+  push Not at h
+  apply hv
+  have hsum := eq_sum_magSectorEmbedding_magSectorRestriction (V := Λ) (N := N) v
+  rw [hsum]
+  refine Finset.sum_eq_zero (fun M hM => ?_)
+  rw [h M hM, magSectorEmbedding_zero]
+
+/-- **Existence of a sector achieving the global min**: there is a non-empty
+sector `M` with `hermitianMinEigenvalue Ĥ_M ≤ hermitianMinEigenvalue Ĥ`. -/
+theorem exists_sector_hermitianMinEigenvalue_le_full
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N : ℕ) (lam D : ℝ) [Nonempty (Λ → Fin (N + 1))] :
+    ∃ M : ℕ, ∃ _ : Nonempty (magConfigS Λ N M),
+      hermitianMinEigenvalue
+        (anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+          (Λ := Λ) (N := N) (M := M) hJ lam D) ≤
+      hermitianMinEigenvalue
+        (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N lam D) := by
+  classical
+  -- Get a non-zero Ĥ eigvec at the full min.
+  obtain ⟨v, hv_ne, hv_eig⟩ :=
+    exists_nonzero_eigenvector_hermitianMinEigenvalue
+      (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N lam D)
+  -- v has a non-zero sector restriction at some M.
+  obtain ⟨M, _hM_range, hvM_ne⟩ := exists_magSectorRestriction_ne_zero hv_ne
+  -- The sector M is non-empty (restriction non-zero on subtype).
+  haveI hNE : Nonempty (magConfigS Λ N M) := by
+    by_contra hempty
+    rw [not_nonempty_iff] at hempty
+    apply hvM_ne
+    funext τ
+    exact (hempty.false τ).elim
+  refine ⟨M, hNE, ?_⟩
+  -- Sector restriction is a sector eigvec at the full min (PR #3988).
+  set μ : ℝ := hermitianMinEigenvalue
+    (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N lam D) with hμ_def
+  have hsec_eig := anisotropicHeisenbergS_magSector_submatrix_mulVec_magSectorRestriction_of_full_eigen
+    J ((lam : ℂ)) ((D : ℂ)) (μ := ((μ : ℝ) : ℂ)) (M := M) hv_eig
+  -- Sector restriction is non-zero.
+  -- Hence μ IS an eigenvalue of the sector submatrix; sector min ≤ μ.
+  have hsec_Herm := anisotropicHeisenbergS_magSector_submatrix_isHermitian_real
+    (Λ := Λ) (N := N) (M := M) hJ lam D
+  have hne_bot : End.eigenspace (Matrix.toLin'
+      (anisotropicHeisenbergS_magSector_submatrix J ((lam : ℂ)) ((D : ℂ)) N M))
+      ((μ : ℝ) : ℂ) ≠ ⊥ := by
+    intro hbot
+    apply hvM_ne
+    have hmem : magSectorRestriction (M := M) v ∈
+        End.eigenspace (Matrix.toLin'
+          (anisotropicHeisenbergS_magSector_submatrix J ((lam : ℂ)) ((D : ℂ)) N M))
+          ((μ : ℝ) : ℂ) := by
+      rw [End.mem_eigenspace_iff, Matrix.toLin'_apply]; exact hsec_eig
+    rw [hbot] at hmem
+    exact hmem
+  have hHE : End.HasEigenvalue (Matrix.toLin'
+      (anisotropicHeisenbergS_magSector_submatrix J ((lam : ℂ)) ((D : ℂ)) N M))
+      ((μ : ℝ) : ℂ) := hne_bot
+  have h_mem_C : ((μ : ℝ) : ℂ) ∈ spectrum ℂ
+      (anisotropicHeisenbergS_magSector_submatrix J ((lam : ℂ)) ((D : ℂ)) N M) := by
+    rw [← Matrix.spectrum_toLin']
+    exact hHE.mem_spectrum
+  have h_mem_R : μ ∈ spectrum ℝ
+      (anisotropicHeisenbergS_magSector_submatrix J ((lam : ℂ)) ((D : ℂ)) N M) := by
+    rw [← spectrum.algebraMap_mem_iff ℂ (R := ℝ)]; exact h_mem_C
+  rw [hsec_Herm.spectrum_real_eq_range_eigenvalues] at h_mem_R
+  obtain ⟨i, hi⟩ := h_mem_R
+  rw [← hi]
+  exact hermitian_min_eigenvalue_le hsec_Herm i
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorInverseLift.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorInverseLift.lean
@@ -1,0 +1,87 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSectorZero
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergContinuity
+import LatticeSystem.Quantum.SpinS.MagSectorEmbedding
+
+/-!
+# Anisotropic sector inverse lift: full → sector eigenvector restriction
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) first-crossing argument.
+
+The anisotropic analog of `heisenbergHamiltonianSMatrixOnMagSector_mulVec_magSectorRestriction_of_full_eigen`
+(in `MagSectorEmbedding.lean`): a full-Hilbert-space eigenvector `Ψ` of
+`Ĥ(λ, D)` at energy `μ` restricts to a sector-`M` eigenvector of the sector
+submatrix `Ĥ_M(λ, D)` at the same `μ`.
+
+Proof: the U(1) invariance (`anisotropicHeisenbergS_apply_eq_zero_of_magSumS_ne`,
+PR #3898) lets us drop off-sector terms in the `mulVec` expansion.
+
+Used by the first-crossing argument's hard direction (global min Ĥ ≥ min over
+sector mins): a non-zero sector projection of a full GS eigenvector gives a
+sector eigenvector at the same energy.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
+
+/-- **Anisotropic sector inverse lift**: a full-Ĥ eigenvector `Ψ` at energy `μ`
+restricts to a sector-`M` eigenvector of `Ĥ_M(λ, D)` at the same `μ`.
+
+Note: when the sector is empty (i.e., `magConfigS Λ N M` is empty), the
+conclusion holds vacuously since both sides are zero functions on an empty domain. -/
+theorem anisotropicHeisenbergS_magSector_submatrix_mulVec_magSectorRestriction_of_full_eigen
+    (J : Λ → Λ → ℂ) (lam D : ℂ) {M : ℕ}
+    {μ : ℂ} {Ψ : (Λ → Fin (N + 1)) → ℂ}
+    (hΨ : (anisotropicHeisenbergS J lam D N).mulVec Ψ = μ • Ψ) :
+    (anisotropicHeisenbergS_magSector_submatrix (Λ := Λ) J lam D N M).mulVec
+      (magSectorRestriction (M := M) Ψ) =
+      μ • magSectorRestriction (M := M) Ψ := by
+  classical
+  funext τ
+  -- Goal: (Ĥ_M).mulVec (restrict Ψ) τ = (μ • restrict Ψ) τ.
+  -- (μ • restrict Ψ) τ = μ * Ψ τ.1.
+  have hrhs : (μ • magSectorRestriction (M := M) Ψ) τ = μ * Ψ τ.1 := rfl
+  rw [hrhs]
+  -- LHS: (Ĥ_M).mulVec (restrict Ψ) τ = ∑ τ' : magConfigS, Ĥ_M τ τ' * (restrict Ψ) τ'.
+  --     = ∑ τ' : magConfigS, Ĥ τ.1 τ'.1 * Ψ τ'.1.
+  -- Convert subtype sum to filter sum.
+  show ∑ τ' : magConfigS Λ N M,
+      anisotropicHeisenbergS_magSector_submatrix J lam D N M τ τ' *
+        magSectorRestriction (M := M) Ψ τ' = μ * Ψ τ.1
+  have hsec : (∑ τ' : magConfigS Λ N M,
+      anisotropicHeisenbergS_magSector_submatrix J lam D N M τ τ' *
+        magSectorRestriction (M := M) Ψ τ') =
+    ∑ ρ ∈ Finset.univ.filter (fun ρ : Λ → Fin (N + 1) => magSumS ρ = M),
+      (anisotropicHeisenbergS J lam D N) τ.1 ρ * Ψ ρ := by
+    rw [Finset.sum_subtype
+      (Finset.univ.filter (fun ρ : Λ → Fin (N + 1) => magSumS ρ = M))
+      (p := fun ρ => magSumS ρ = M)
+      (fun ρ => by simp [Finset.mem_filter])
+      (fun ρ => (anisotropicHeisenbergS J lam D N) τ.1 ρ * Ψ ρ)]
+    refine Finset.sum_congr rfl (fun ρ' _ => ?_)
+    unfold anisotropicHeisenbergS_magSector_submatrix
+    rw [Matrix.submatrix_apply]; rfl
+  rw [hsec]
+  -- Extend filter sum to full sum (added terms are zero by U(1) sector-crossing vanishing).
+  have hfull : ∑ ρ ∈ Finset.univ.filter (fun ρ : Λ → Fin (N + 1) => magSumS ρ = M),
+      (anisotropicHeisenbergS J lam D N) τ.1 ρ * Ψ ρ =
+    ∑ ρ : Λ → Fin (N + 1), (anisotropicHeisenbergS J lam D N) τ.1 ρ * Ψ ρ := by
+    refine Finset.sum_filter_of_ne (p := fun ρ => magSumS ρ = M) ?_
+    intro ρ _ hne
+    by_contra hρM
+    apply hne
+    have hmag_ne : magSumS τ.1 ≠ magSumS ρ :=
+      fun heq => hρM (heq.symm.trans τ.2)
+    rw [anisotropicHeisenbergS_apply_eq_zero_of_magSumS_ne J lam D hmag_ne, zero_mul]
+  rw [hfull]
+  -- This is (Ĥ).mulVec Ψ τ.1 = (μ • Ψ) τ.1.
+  change (anisotropicHeisenbergS J lam D N).mulVec Ψ τ.1 = _
+  rw [hΨ]
+  rfl
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

The hard direction of the block-min identity for the magnetization decomposition.

`exists_sector_hermitianMinEigenvalue_le_full`: for real-coupling `J` and real `(λ, D)`, there is a non-empty sector `M` with `hermitianMinEigenvalue Ĥ_M ≤ hermitianMinEigenvalue Ĥ`.

Proof:
1. Full-Ĥ eigvec `v` at global min (PR #3962 `exists_nonzero_eigenvector_hermitianMinEigenvalue`).
2. Non-zero sector projection at some `M` (`exists_magSectorRestriction_ne_zero` from disjoint-sector decomposition).
3. Sector restriction is a sector eigvec at the same μ (PR #3988 anisotropic inverse lift).
4. `HasEigenvalue → mem_spectrum → ≤ hermitian_min_eigenvalue`.

Combined with PR #3984 (easy direction `hermitianMinEigenvalue Ĥ ≤ each sector min`), gives existence of `M` with `hermitianMinEigenvalue Ĥ_M = hermitianMinEigenvalue Ĥ`.

Used by the first-crossing argument: under the strict gap `E_balanced < E_M` for `M ≠ balanced`, the `M` achieving the global min IS `M_balanced` (since other `M`'s are strictly higher), hence `E_M_balanced = global min`. This discharges the strict-GS axiom at `(1, 0)` from PR #3986 to the strict-gap axiom.

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergFullMinGeSectorMin` succeeds
- [x] CI green
