### PR TITLE
sInf (perMCrossingSet ∩ Icc 0 1) ∈ set — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMCrossingSInfMem.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMCrossingSInfMem.lean
@@ -1,0 +1,60 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergPerMCrossingSet
+
+/-!
+# `sInf (perMCrossingSet ∩ Icc 0 1) ∈ set` — first per-`M` crossing achieved
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) first-crossing argument.
+
+For per-`M` closed crossing set (PR #3993), the intersection with `Icc 0 1` is
+closed, bounded below, and (given non-emptiness) achieves its infimum.
+
+Building block for the per-`M` first crossing extraction: given the violation
+hypothesis `E_M(γ(1)) ≤ E_balanced(γ(1))`, `1 ∈ perMCrossingSet M`, so the
+set is non-empty, and `sInf ≤ 1` is the per-`M` first crossing.
+
+Composes:
+- PR #3993 `isClosed_perMCrossingSet`.
+- `isClosed_Icc`, `IsClosed.csInf_mem` (mathlib).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Set
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Per-`M` crossing set intersected with `Icc 0 1` is closed**. -/
+theorem isClosed_perMCrossingSet_inter_Icc
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_balanced M : ℕ)
+    [Nonempty (magConfigS Λ N M_balanced)] [Nonempty (magConfigS Λ N M)]
+    (lam' D' : ℝ) :
+    IsClosed (perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' ∩ Icc (0 : ℝ) 1) :=
+  (isClosed_perMCrossingSet hJ N M_balanced M lam' D').inter isClosed_Icc
+
+/-- **Per-`M` crossing set ∩ `Icc 0 1` is bounded below by `0`**. -/
+theorem bddBelow_perMCrossingSet_inter_Icc
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_balanced M : ℕ)
+    [Nonempty (magConfigS Λ N M_balanced)] [Nonempty (magConfigS Λ N M)]
+    (lam' D' : ℝ) :
+    BddBelow (perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' ∩ Icc (0 : ℝ) 1) :=
+  ⟨0, fun t ht => ht.2.1⟩
+
+/-- **`sInf` of the per-`M` crossing set ∩ `Icc 0 1` lies in the set**: given
+non-emptiness, the closed + bounded-below set achieves its infimum. -/
+theorem sInf_perMCrossingSet_inter_Icc_mem
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_balanced M : ℕ)
+    [Nonempty (magConfigS Λ N M_balanced)] [Nonempty (magConfigS Λ N M)]
+    (lam' D' : ℝ)
+    (hne : (perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' ∩ Icc (0 : ℝ) 1).Nonempty) :
+    sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' ∩ Icc (0 : ℝ) 1) ∈
+      perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' ∩ Icc (0 : ℝ) 1 :=
+  IsClosed.csInf_mem (isClosed_perMCrossingSet_inter_Icc hJ N M_balanced M lam' D')
+    hne (bddBelow_perMCrossingSet_inter_Icc hJ N M_balanced M lam' D')
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMCrossingSet.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMCrossingSet.lean
@@ -1,0 +1,58 @@
+import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricMinEigenvalue
+
+/-!
+# Per-`M` crossing set is closed
+
+Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) first-crossing argument.
+
+Defines the per-`M` crossing set
+`perMCrossingSet J hJ N M_balanced M lam' D' := { t : ℝ | E_M(γ(t)) ≤ E_balanced(γ(t)) }`
+and proves it is closed in `ℝ`.
+
+The first-crossing argument considers the union over `M ≠ M_balanced` of these sets;
+that union is closed (finite union of closed sets) and contains `t = 1` under
+the obligation (2) violation hypothesis.
+
+Composes:
+- PR #3957 / PR #3965 (sector min eigenvalue continuous along path).
+- `IsClosed.preimage` + `isClosed_Iic` (mathlib).
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, §2.5 Theorem 2.4, p. 43–44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **Per-`M` crossing set**: `{ t : ℝ | E_M(γ(t)) ≤ E_balanced(γ(t)) }`. -/
+noncomputable def perMCrossingSet
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_balanced M : ℕ)
+    [Nonempty (magConfigS Λ N M_balanced)] [Nonempty (magConfigS Λ N M)]
+    (lam' D' : ℝ) : Set ℝ :=
+  { t : ℝ |
+    anisotropicHeisenbergS_magSector_minEigenvalue_alongParametricPath
+      (Λ := Λ) hJ N M lam' D' t ≤
+    anisotropicHeisenbergS_magSector_minEigenvalue_alongParametricPath
+      (Λ := Λ) hJ N M_balanced lam' D' t }
+
+/-- **Per-`M` crossing set is closed in `ℝ`**: preimage of `Iic 0` under the
+continuous gap function `g(t) := E_M(γ(t)) - E_balanced(γ(t))`. -/
+theorem isClosed_perMCrossingSet
+    {J : Λ → Λ → ℂ} (hJ : ∀ x y, star (J x y) = J x y)
+    (N M_balanced M : ℕ)
+    [Nonempty (magConfigS Λ N M_balanced)] [Nonempty (magConfigS Λ N M)]
+    (lam' D' : ℝ) :
+    IsClosed (perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D') := by
+  unfold perMCrossingSet
+  -- { t | f(t) ≤ g(t) } = (f - g)⁻¹ (Iic 0) (closed under continuous f - g).
+  have hf := continuous_anisotropicHeisenbergS_magSector_minEigenvalue_alongParametricPath
+    (Λ := Λ) hJ N M lam' D'
+  have hg := continuous_anisotropicHeisenbergS_magSector_minEigenvalue_alongParametricPath
+    (Λ := Λ) hJ N M_balanced lam' D'
+  exact isClosed_le hf hg
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary

`sInf (perMCrossingSet ∩ Icc 0 1) ∈ set` under non-emptiness — per-`M` first crossing achieved.

- `isClosed_perMCrossingSet_inter_Icc` — closed (PR #3993 ∩ `isClosed_Icc`).
- `bddBelow_perMCrossingSet_inter_Icc` — bounded below by `0`.
- `sInf_perMCrossingSet_inter_Icc_mem` — combined with non-emptiness via `IsClosed.csInf_mem`.

Building block for the per-`M` first crossing extraction: given the violation hypothesis `E_M(γ(1)) ≤ E_balanced(γ(1))`, `1 ∈ perMCrossingSet M ∩ Icc 0 1` (non-empty), and `sInf ≤ 1` is the per-`M` first crossing achieved in the set.

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergPerMCrossingSInfMem` succeeds
- [x] CI green
