### PR TITLE
Refactor (build-speed eval, 20-PR cadence): linter line-length cleanup — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMCrossingEqualityAtSInf.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMCrossingEqualityAtSInf.lean
@@ -75,7 +75,8 @@ theorem anisotropicHeisenbergS_per_M_crossing_equality_at_sInf
     -- show t_first ∈ closure { t | strict gap at t }.
     -- Even simpler: use that the strict-gap-below holds on [0, t_first), and take limit.
     -- Use IsClosed.mem_of_tendsto or the direct: filter argument with sub-sequence.
-    -- Cleanest: { t | f(t) ≤ g(t) } is closed; show t_first is a limit point of this set from below.
+    -- Cleanest: { t | f(t) ≤ g(t) } is closed; show t_first is a limit point of this set
+    -- from below.
     -- From PR #3995, [0, t_first) ⊆ { t | f(t) < g(t) } ⊆ { t | f(t) ≤ g(t) }.
     -- Hence closure ([0, t_first)) ⊆ closure { f ≤ g } = { f ≤ g }.
     -- t_first ∈ closure ([0, t_first)) IF t_first > 0; else t_first = 0 and we handle directly.


### PR DESCRIPTION
## Summary

20-PR cadence refactor PR after PR #3999.

## Build-speed evaluation

Measured incremental rebuild of the final first-crossing scaffolding leaf `AnisotropicHeisenbergBalancedMinEqFullAtSInf`: **2.7 s**.

The chain since the last refactor (#3979) added 20 PRs:
- #3980 ★★★ axiomatic capstone (MILESTONE)
- #3982-#3986 first-crossing scaffolding (continuity, `balancedGSSet`, sup ∈ set)
- #3988-#3990 inverse lift + block-min hard direction + balanced is GS from strict gap
- #3992 axiomatic capstone v2 (single path-wide strict-gap axiom)
- #3993-#3995 per-`M` crossing set + sInf ∈ + strict gap below
- #3997-#3999 closure-based balanced IS GS at sInf + composition

Build times stay at 2-3 s per leaf. **Decision: no consolidation** — the chain naturally decomposes into focused bricks each ~50-150 lines, and the sup-analysis brick dependencies are clean.

## Cleanup

Wrapped a 100+ char comment line in `PerMCrossingEqualityAtSInf.lean` (`linter.style.longLine` warning).

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergPerMCrossingEqualityAtSInf` succeeds (no longLine warning)
- [x] CI green
