### PR TITLE
Refactor (design audit + 20-PR cadence): deprecate 4 orphan obligation-(2) capstones → canonical #4014 — #3739

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2Axiomatic.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2Axiomatic.lean
@@ -43,6 +43,7 @@ hypotheses + the (2-IVT-c) strict gap + the first-crossing energy identification
 for any sector `M` with non-trivial centered magnetization, the per-sector min
 eigenvalue at `(λ', D')` is strictly greater than the `M_balanced`-sector min
 eigenvalue. -/
+@[deprecated "Use the canonical capstone spinHalf_anisotropicHeisenbergS_obligation_2_single_axiom (PR #4014). This v1 capstone is an orphan in the final dependency chain." (since := "2026-05-31")]
 theorem spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2AxiomaticV2.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2AxiomaticV2.lean
@@ -36,6 +36,7 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 /-- **Spin-1/2 obligation (2) capstone v2 (strict-gap path-wide)**: under the
 spin-1/2 obligation (1) hypotheses and a **path-wide strict gap** axiom (replacing
 PR #3980's two separate axioms), the obligation (2) conclusion holds at `(λ', D')`. -/
+@[deprecated "Use the canonical capstone spinHalf_anisotropicHeisenbergS_obligation_2_single_axiom (PR #4014). This v2 capstone is an orphan in the final dependency chain." (since := "2026-05-31")]
 theorem spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic_path_wide
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2AxiomaticV3.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2AxiomaticV3.lean
@@ -45,6 +45,7 @@ the per-`M` first-crossing sup analysis, under:
 - "below-sInf balanced IS GS" hypothesis (argmin choice).
 
 The conclusion is `False` (since we assumed obligation 2 violated). -/
+@[deprecated "Use the canonical capstone spinHalf_anisotropicHeisenbergS_obligation_2_single_axiom (PR #4014); for hne-parameterised use spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic_sup_crossing_hne (PR #4009). This v3 capstone is an orphan in the final dependency chain." (since := "2026-05-31")]
 theorem spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic_sup_crossing
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2AxiomaticV4.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2AxiomaticV4.lean
@@ -34,6 +34,7 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 
 /-- **Spin-1/2 obligation (2) capstone v4 (argmin discharged)**: derives False
 under the contradiction hypothesis + obligation (1) hypotheses + 3 axioms. -/
+@[deprecated "Use the canonical capstone spinHalf_anisotropicHeisenbergS_obligation_2_single_axiom (PR #4014); the argmin extraction is performed automatically there. This v4 capstone is an orphan in the final dependency chain." (since := "2026-05-31")]
 theorem spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic_argmin
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)


### PR DESCRIPTION
## Summary

Design audit + 20-PR cadence refactor (5 PRs early due to user-flagged design quality concern).

## Build-speed evaluation

Measured leaf rebuild: **8.4 s** for `spinHalf_anisotropicHeisenbergS_obligation_2_single_axiom` (canonical capstone). Healthy. No consolidation needed.

## Design audit

The obligation (2) chain accumulated **7 capstone versions** during incremental development:
- #3980 (v1), #3992 (v2), #4001 (v3), #4004 (v4), #4009 (v3' hne), #4010 (v5 final), #4014 (v6 single-axiom)

Of these, only **#4014** is the user-facing canonical capstone, and only **#4010 + #4009** are on the canonical dependency chain (#4014 → #4010 → #4009).

The other **4 capstones are ORPHANS** — not referenced by the canonical chain nor by any external module. They are scaffolding from incremental design exploration.

## Action

Marked the 4 orphan capstones `@[deprecated]` pointing at the canonical `spinHalf_anisotropicHeisenbergS_obligation_2_single_axiom` (#4014):

- v1 #3980 `spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic`
- v2 #3992 `spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic_path_wide`
- v3 #4001 `spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic_sup_crossing`
- v4 #4004 `spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic_argmin`

Files **preserved** (not deleted) for historical reference + downstream stability. Deprecation warning surfaces in code search and CI logs to discourage use.

Tracked in #3739.

## Test plan
- [x] `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSpinHalfObligation2SingleAxiom` succeeds (canonical capstone unaffected)
- [x] CI green
