### PR TITLE
Add Problem 2.5.c single-site squared statement — #412

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -93,6 +93,8 @@ import LatticeSystem.Quantum.SpinS.HeisenbergGraphLocal
 import LatticeSystem.Quantum.SpinS.GraphLocalStarBlock
 import LatticeSystem.Quantum.SpinS.GraphLocalStarLowerBound
 import LatticeSystem.Quantum.SpinS.GraphLocalStarSumWrapper
+import LatticeSystem.Quantum.SpinS.Problem25cSingleSiteSquared
+import LatticeSystem.Quantum.SpinS.SingleSiteXYExpectation
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale
 import LatticeSystem.Quantum.Pauli

--- a/LatticeSystem/Quantum/SpinS/Problem25cSingleSiteSquared.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25cSingleSiteSquared.lean
@@ -1,0 +1,107 @@
+import LatticeSystem.Quantum.SpinS.SingleSiteCasimirExpectation
+
+/-!
+# Tasaki Problem 2.5.c: single-site squared expectation bridge
+
+This module records the algebraic bridge for Tasaki Problem 2.5.c.  The
+universal single-site Casimir identity already gives
+
+`⟨Φ, Ŝ_x · Ŝ_x Φ⟩ = N(N+2)/4`
+
+for normalized `Φ`, where `N = 2S`.  If a later SU(2)-symmetry input supplies
+equality of the three squared Cartesian single-site expectations at `x`, then
+each common value is one third of the Casimir value:
+
+`⟨Φ, (Ŝ_x^(α))² Φ⟩ = N(N+2)/12 = S(S+1)/3`.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, Problem 2.5.c, p. 43.
+-/
+
+namespace LatticeSystem.Quantum
+
+variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
+
+/-- The expectation value of the squared single-site spin operator
+`(onSiteS x A)^2` in the state `Φ`. -/
+noncomputable def singleSiteSpinSquareExpectationS (x : V)
+    (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)
+    (Φ : (V → Fin (N + 1)) → ℂ) : ℂ :=
+  dotProduct (star Φ) (((onSiteS x A : ManyBodyOpS V N) * onSiteS x A).mulVec Φ)
+
+/-- The sum of the three squared-axis single-site expectations is the
+single-site Casimir expectation. -/
+theorem singleSiteSpinSquareExpectationS_axis_sum (x : V)
+    (Φ : (V → Fin (N + 1)) → ℂ) :
+    singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ +
+        singleSiteSpinSquareExpectationS x (spinSOp2 N) Φ +
+        singleSiteSpinSquareExpectationS x (spinSOp3 N) Φ =
+      dotProduct (star Φ) ((spinSDot x x N).mulVec Φ) := by
+  unfold singleSiteSpinSquareExpectationS spinSDot
+  rw [Matrix.add_mulVec, Matrix.add_mulVec, dotProduct_add, dotProduct_add]
+
+/-- For a normalized state, the sum of the three squared-axis single-site
+expectations is `N(N+2)/4 = S(S+1)`. -/
+theorem singleSiteSpinSquareExpectationS_axis_sum_normalized (x : V)
+    {Φ : (V → Fin (N + 1)) → ℂ}
+    (hΦ : dotProduct (star Φ) Φ = 1) :
+    singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ +
+        singleSiteSpinSquareExpectationS x (spinSOp2 N) Φ +
+        singleSiteSpinSquareExpectationS x (spinSOp3 N) Φ =
+      (N : ℂ) * (N + 2) / 4 := by
+  rw [singleSiteSpinSquareExpectationS_axis_sum, spinSDot_self_expectation_normalized x hΦ]
+
+/-- Problem 2.5.c algebraic reduction: if the three squared-axis expectations
+are equal in a normalized state, then the axis-1 value is
+`N(N+2)/12 = S(S+1)/3`. -/
+theorem singleSiteSpinSquareExpectationS_axis1_eq_of_axes_equal_normalized
+    (x : V) {Φ : (V → Fin (N + 1)) → ℂ}
+    (hΦ : dotProduct (star Φ) Φ = 1)
+    (h12 : singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ =
+      singleSiteSpinSquareExpectationS x (spinSOp2 N) Φ)
+    (h13 : singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ =
+      singleSiteSpinSquareExpectationS x (spinSOp3 N) Φ) :
+    singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ =
+      (N : ℂ) * (N + 2) / 12 := by
+  let e1 := singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ
+  let e2 := singleSiteSpinSquareExpectationS x (spinSOp2 N) Φ
+  let e3 := singleSiteSpinSquareExpectationS x (spinSOp3 N) Φ
+  have hsum : e1 + e2 + e3 = (N : ℂ) * (N + 2) / 4 :=
+    singleSiteSpinSquareExpectationS_axis_sum_normalized x hΦ
+  have h12e : e1 = e2 := by simpa [e1, e2] using h12
+  have h13e : e1 = e3 := by simpa [e1, e3] using h13
+  have hsum_eq : e1 + e1 + e1 = (N : ℂ) * (N + 2) / 4 := by
+    calc
+      e1 + e1 + e1 = e1 + e2 + e3 := by
+        rw [← h12e, ← h13e]
+      _ = (N : ℂ) * (N + 2) / 4 := hsum
+  have hthree : (3 : ℂ) * e1 = (N : ℂ) * (N + 2) / 4 := by
+    calc
+      (3 : ℂ) * e1 = e1 + e1 + e1 := by ring
+      _ = (N : ℂ) * (N + 2) / 4 := hsum_eq
+  calc
+    singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ = e1 := rfl
+    _ = (1 / 3 : ℂ) * ((3 : ℂ) * e1) := by ring
+    _ = (1 / 3 : ℂ) * ((N : ℂ) * (N + 2) / 4) := by rw [hthree]
+    _ = (N : ℂ) * (N + 2) / 12 := by ring
+
+/-- Problem 2.5.c algebraic reduction for all three axes, packaged as a
+conjunction under the equal-axis hypotheses. -/
+theorem singleSiteSpinSquareExpectationS_all_axes_eq_of_axes_equal_normalized
+    (x : V) {Φ : (V → Fin (N + 1)) → ℂ}
+    (hΦ : dotProduct (star Φ) Φ = 1)
+    (h12 : singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ =
+      singleSiteSpinSquareExpectationS x (spinSOp2 N) Φ)
+    (h13 : singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ =
+      singleSiteSpinSquareExpectationS x (spinSOp3 N) Φ) :
+    singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ =
+        (N : ℂ) * (N + 2) / 12 ∧
+      singleSiteSpinSquareExpectationS x (spinSOp2 N) Φ =
+        (N : ℂ) * (N + 2) / 12 ∧
+      singleSiteSpinSquareExpectationS x (spinSOp3 N) Φ =
+        (N : ℂ) * (N + 2) / 12 := by
+  have h1 := singleSiteSpinSquareExpectationS_axis1_eq_of_axes_equal_normalized
+    (x := x) hΦ h12 h13
+  exact ⟨h1, ⟨h12.symm.trans h1, h13.symm.trans h1⟩⟩
+
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/SingleSiteXYExpectation.lean
+++ b/LatticeSystem/Quantum/SpinS/SingleSiteXYExpectation.lean
@@ -1,0 +1,60 @@
+import LatticeSystem.Quantum.SpinS.Problem25cSingleSiteSquared
+import LatticeSystem.Quantum.SpinS.SingleSiteZExpectation
+
+/-!
+# Single-site xy-plane squared expectation on all-aligned states
+
+This module records the xy-plane part of the single-site Casimir on the
+all-aligned state `|c..c⟩`.  It is a direct subtraction of the explicit
+z-axis square expectation from the universal single-site Casimir value.
+
+This is background for Tasaki Problem 2.5.c: non-SU(2)-symmetric saturated
+states split the single-site Casimir unevenly across axes, whereas the AFM
+ground-state symmetry input will force equal axis values.
+-/
+
+namespace LatticeSystem.Quantum
+
+variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
+
+/-- On an all-aligned state, the xy-plane squared single-site expectation is
+the universal single-site Casimir value minus the z-axis square expectation:
+`N(N+2)/4 - (N/2 - c)^2`. -/
+theorem allAlignedStateS_expectation_onSiteS_spinSOp1_sq_add_spinSOp2_sq
+    (x : V) (c : Fin (N + 1)) :
+    dotProduct (star (allAlignedStateS V N c))
+      ((((onSiteS x (spinSOp1 N) : ManyBodyOpS V N) * onSiteS x (spinSOp1 N)) +
+        ((onSiteS x (spinSOp2 N) : ManyBodyOpS V N) * onSiteS x (spinSOp2 N))).mulVec
+          (allAlignedStateS V N c)) =
+      (N : ℂ) * (N + 2) / 4 -
+        (((N : ℂ) / 2 - (c.val : ℂ)) * ((N : ℂ) / 2 - (c.val : ℂ))) := by
+  let Φ : (V → Fin (N + 1)) → ℂ := allAlignedStateS V N c
+  let e1 := singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ
+  let e2 := singleSiteSpinSquareExpectationS x (spinSOp2 N) Φ
+  let e3 := singleSiteSpinSquareExpectationS x (spinSOp3 N) Φ
+  have hleft :
+      dotProduct (star Φ)
+        ((((onSiteS x (spinSOp1 N) : ManyBodyOpS V N) * onSiteS x (spinSOp1 N)) +
+          ((onSiteS x (spinSOp2 N) : ManyBodyOpS V N) * onSiteS x (spinSOp2 N))).mulVec Φ) =
+        e1 + e2 := by
+    unfold e1 e2 singleSiteSpinSquareExpectationS
+    rw [Matrix.add_mulVec, dotProduct_add]
+  have hsum : e1 + e2 + e3 = (N : ℂ) * (N + 2) / 4 := by
+    exact singleSiteSpinSquareExpectationS_axis_sum_normalized x
+      (allAlignedStateS_inner_self c)
+  have hz :
+      e3 = ((N : ℂ) / 2 - (c.val : ℂ)) * ((N : ℂ) / 2 - (c.val : ℂ)) := by
+    simpa [e3, singleSiteSpinSquareExpectationS, Φ]
+      using allAlignedStateS_expectation_onSiteS_spinSOp3_sq (x := x) (c := c)
+  calc
+    dotProduct (star (allAlignedStateS V N c))
+        ((((onSiteS x (spinSOp1 N) : ManyBodyOpS V N) * onSiteS x (spinSOp1 N)) +
+          ((onSiteS x (spinSOp2 N) : ManyBodyOpS V N) * onSiteS x (spinSOp2 N))).mulVec
+            (allAlignedStateS V N c)) =
+        e1 + e2 := by simpa [Φ] using hleft
+    _ = (e1 + e2 + e3) - e3 := by ring
+    _ = (N : ℂ) * (N + 2) / 4 -
+        (((N : ℂ) / 2 - (c.val : ℂ)) * ((N : ℂ) / 2 - (c.val : ℂ))) := by
+      rw [hsum, hz]
+
+end LatticeSystem.Quantum

--- a/docs/index.md
+++ b/docs/index.md
@@ -2262,6 +2262,7 @@ Issue #412; assembled in PRs #875–#879. All theorems live in
 | `multiSiteSpinS_finrank` | **`Module.finrank ℂ ((V → Fin (N+1)) → ℂ) = (N + 1)^|V|`** (the standard quantum-mechanical dimension `(2S + 1)^|Λ|`, PR #918, file `Quantum/SpinS/MultiSiteFinrank.lean`) |
 | `basisSpinS V N` / `basisSpinS_apply` | the standard basis packaged as `Module.Basis (V → Fin (N + 1)) ℂ ((V → Fin (N + 1)) → ℂ)` via `Module.Basis.mk` (PR #919, file `Quantum/SpinS/BasisSpinS.lean`) |
 | `spinSDot_self_mulVec` / `_expectation` / `_expectation_normalized` / `_expectation_allAlignedStateS` | **universal single-site Casimir expectation `⟨Φ, Ŝ_x · Ŝ_x · Φ⟩ = S(S+1)`** for normalized `Φ`. Direct from `spinSDot_self`. Foundation for Tasaki Problem 2.5.c (γ-7) (PR #920, file `Quantum/SpinS/SingleSiteCasimirExpectation.lean`) |
+| `singleSiteSpinSquareExpectationS` / `_axis_sum` / `_axis_sum_normalized` / `_axis1_eq_of_axes_equal_normalized` / `_all_axes_eq_of_axes_equal_normalized` | **Problem 2.5.c single-site squared-expectation bridge**: packages `⟨Φ,(Ŝ_x^(α))² Φ⟩`, proves the three-axis sum is the universal single-site Casimir expectation, and under normalized-state plus equal-axis hypotheses returns `N(N+2)/12 = S(S+1)/3` for each Cartesian axis. This isolates the algebraic reduction while leaving the AFM ground-state SU(2)-symmetry input explicit. Tasaki, Springer 2020, Problem 2.5.c, p. 43 (PR #4056, file `Quantum/SpinS/Problem25cSingleSiteSquared.lean`) |
 | `spinSOpPlus_one_eq_spinHalfOpPlus` / `_Minus_` / `_Op1_` / `_Op2_` / `_Op3_` | **spin-`S` ↔ spin-`1/2` bridge at `N = 1`**: `spinSOp{Plus, Minus, 1, 2, 3} 1 = spinHalfOp{Plus, Minus, 1, 2, 3}` (each is the corresponding half-Pauli matrix) (PRs #922 + #923, file `Quantum/SpinS/SpinHalfSpecialization.lean`) |
 | `onSiteS_spinSOp3_mulVec_allAlignedStateS` / `allAlignedStateS_expectation_onSiteS_spinSOp3` / `_sq` / `onSiteS_spinSOp3_sq_mulVec_allAlignedStateS` | **single-site `Ŝ^(3)_x` and `(Ŝ^(3)_x)²` on `|c..c⟩`**: `Ŝ^(3)_x · |c..c⟩ = (N/2 − c.val) · |c..c⟩` and expectation of `(Ŝ^(3)_x)²` is `(N/2 − c.val)²` (PR #925, file `Quantum/SpinS/SingleSiteZExpectation.lean`) |
 | `allAlignedStateS_expectation_onSiteS_spinSOp1_sq_add_spinSOp2_sq` | **xy-plane Casimir expectation**: `⟨((Ŝ^(1)_x)² + (Ŝ^(2)_x)²) · |c..c⟩⟩ = N(N+2)/4 − (N/2 − c.val)²`. From #920 minus #925; for `c=0` gives `S/2` (PR #926, file `Quantum/SpinS/SingleSiteXYExpectation.lean`) |
@@ -2693,8 +2694,11 @@ mathematical work):
   specialization using Problem 2.5.a, the graph-local finite-sum wrapper, and
   the closed-form `G.degree` variants are live under
   `Quantum/SpinS/GraphLocalStarSumWrapper.lean`.
-- **Problem 2.5.c** (single-site expectation `⟨Ŝ_x⟩ = 0` in the
-  AFM ground state).
+- **Problem 2.5.c** (single-site squared expectation
+  `⟨Φ_GS|(Ŝ_x^(α))²|Φ_GS⟩ = S(S+1)/3` in the AFM ground state).  The
+  Casimir-to-equal-axes algebraic bridge is live under
+  `Quantum/SpinS/Problem25cSingleSiteSquared.lean`; the remaining input is the
+  AFM ground-state SU(2)-symmetry/equal-axis hypothesis.
 - **Problem 2.5.d** (two-spin correlation under MLM).
 
 The generic graph-centric `neelStateOf` (Phase 3 PR #331) is the

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5110,8 +5110,9 @@ Marshall sign machinery + time-reversal action; see
   Requires general-spin infrastructure (P1d''' above is now done in
   PR~\#490; this remains for the §2.5-specific cluster argument).
 \item Problem 2.5.b (lower bound on $E_{\mathrm{GS}}$ via 2.5.a).
-\item Problem 2.5.c (single-site expectation
-  $\langle \hat S_x \rangle = 0$ in the AFM ground state).
+\item Problem 2.5.c (single-site squared expectation
+  $\langle\Phi_{\mathrm{GS}},(\hat S_x^{(\alpha)})^2
+  \Phi_{\mathrm{GS}}\rangle = S(S+1)/3$ in the AFM ground state).
 \item Problem 2.5.d (two-spin correlation under MLM).
 \end{itemize}
 
@@ -14192,6 +14193,32 @@ combines \texttt{spinSDot\_self} ($\hat{S}_x \cdot \hat{S}_x =
 \hat{S}_x \cdot \hat{S}_x\,\Phi\rangle = S(S+1)$ for any normalized
 $\Phi$, independent of state — the universal single-site Casimir
 identity. Foundation for Tasaki Problem 2.5.c ($\gamma$-7).
+
+\textbf{Problem 2.5.c single-site squared bridge (PR~\#4056)}: the
+new Problem 2.5.c module packages the squared-axis expectation
+\[
+  E_\alpha(x,\Phi)=
+  \langle \Phi,(\hat{S}^{(\alpha)}_x)^2\Phi\rangle .
+\]
+The theorem
+\texttt{singleSiteSpinSquareExpectationS\_axis\_sum} expands the
+definition of \(\hat{S}_x\cdot \hat{S}_x\) and proves
+\[
+  E_1(x,\Phi)+E_2(x,\Phi)+E_3(x,\Phi)
+  =
+  \langle\Phi,\hat{S}_x\cdot \hat{S}_x\,\Phi\rangle .
+\]
+Combining this with the normalized Casimir identity above gives the
+sum \(N(N+2)/4=S(S+1)\).  The all-axis wrapper then records the
+algebraic reduction needed for Tasaki Problem~2.5.c: if the later
+AFM SU(2)-symmetry input supplies
+\(E_1=E_2=E_3\), each axis has expectation
+\[
+  E_\alpha(x,\Phi)=\frac{N(N+2)}{12}=\frac{S(S+1)}{3}.
+\]
+This PR deliberately leaves the equal-axis ground-state symmetry as an
+explicit hypothesis.  Reference: Tasaki, Springer 2020, Problem~2.5.c,
+p.~43.
 
 \textbf{Spin-`S` $\leftrightarrow$ spin-`1/2` bridge at $N = 1$
 (PRs~\#922 + \#923)}: the new file


### PR DESCRIPTION
Tracked in #412.

## Summary

- start Tasaki Problem 2.5.c as the next textbook-unit step after Problem 2.5.b
- add a single-site squared-expectation statement package for the reduction from the universal single-site Casimir to `S(S+1)/3` per Cartesian axis
- restore the documented xy-plane all-aligned expectation module so the local single-site expectation docs match the Lean tree
- update the public theorem index and proof guide for the new Problem 2.5.c bridge

## Verification

- `git diff --check`
- `git diff --cached --check`
- `lake env lean LatticeSystem/Quantum/SpinS/Problem25cSingleSiteSquared.lean`
- `lake build LatticeSystem.Quantum.SpinS.Problem25cSingleSiteSquared`
- `lake env lean LatticeSystem/Quantum/SpinS/SingleSiteXYExpectation.lean`
- `lake build LatticeSystem.Quantum.SpinS.SingleSiteXYExpectation`
- `lake env lean LatticeSystem.lean`
- `cd tex && latexmk -g -pdf proof-guide.tex`
- local `.self-local/tex/4056-problem25c-single-site-squared-statement.tex`: `latexmk -g -pdf` succeeded
