### PR TITLE
Add Problem 2.5.c unitary axis input — #412

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -94,6 +94,7 @@ import LatticeSystem.Quantum.SpinS.GraphLocalStarBlock
 import LatticeSystem.Quantum.SpinS.GraphLocalStarLowerBound
 import LatticeSystem.Quantum.SpinS.GraphLocalStarSumWrapper
 import LatticeSystem.Quantum.SpinS.Problem25cSingleSiteSquared
+import LatticeSystem.Quantum.SpinS.Problem25cUnitaryAxisInput
 import LatticeSystem.Quantum.SpinS.SingleSiteXYExpectation
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale

--- a/LatticeSystem/Quantum/SpinS/Problem25cUnitaryAxisInput.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25cUnitaryAxisInput.lean
@@ -1,0 +1,77 @@
+import LatticeSystem.Quantum.SpinS.Problem25cSingleSiteSquared
+import LatticeSystem.Quantum.SpinS.RayleighUnitarySimilarity
+
+/-!
+# Tasaki Problem 2.5.c: unitary symmetry input for equal axes
+
+This module packages the next symmetry input for Tasaki Problem 2.5.c after the
+algebraic equal-axis bridge in `Problem25cSingleSiteSquared.lean`.  If a
+many-body unitary conjugates one single-site spin component to another and the
+state is invariant under the inverse unitary, then the corresponding squared
+single-site expectations are equal.
+
+The axis-2/axis-3 specialization is phrased using the conjugation identity as
+an explicit hypothesis.  The existing `AxisSwapUnitaryS.tensor_conj_onSiteS`
+API supplies this hypothesis for the lifted tensor axis-swap; the remaining
+state-invariance input is intentionally left explicit.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, Problem 2.5.c, p. 43, and the SU(2)-symmetry context around
+Theorem 2.4, pp. 43-44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
+
+/-! ## Generic unitary-invariance bridge -/
+
+/-- Moving a many-body unitary from the ket side to the bra side inside the
+matrix inner product. -/
+theorem dotProduct_star_mulVec_eq_dotProduct_star_conjTranspose_mulVec
+    (T : ManyBodyOpS V N) (Φ Ψ : (V → Fin (N + 1)) → ℂ) :
+    dotProduct (star Φ) (T.mulVec Ψ) =
+      dotProduct (star (T.conjTranspose.mulVec Φ)) Ψ := by
+  rw [Matrix.dotProduct_mulVec, star_vecMul]
+
+/-- If `T` conjugates the single-site operator `A` to `B` and `Φ` is fixed by
+`T⁻¹ = T†`, then the squared single-site expectations of `A` and `B` in `Φ`
+are equal. -/
+theorem singleSiteSpinSquareExpectationS_eq_of_conj_invariant
+    (x : V) (A B : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)
+    (T Tinv : ManyBodyOpS V N) (Φ : (V → Fin (N + 1)) → ℂ)
+    (hTadj : T.conjTranspose = Tinv)
+    (hTinvT : Tinv * T = 1)
+    (hΦ : Tinv.mulVec Φ = Φ)
+    (hconj : T * onSiteS x A * Tinv = onSiteS x B) :
+    singleSiteSpinSquareExpectationS x B Φ =
+      singleSiteSpinSquareExpectationS x A Φ := by
+  let OA : ManyBodyOpS V N := onSiteS x A
+  let OB : ManyBodyOpS V N := onSiteS x B
+  have hOB : OB = T * OA * Tinv := by
+    simpa [OA, OB] using hconj.symm
+  have hsq : OB * OB = T * (OA * OA) * Tinv := by
+    calc
+      OB * OB = (T * OA * Tinv) * (T * OA * Tinv) := by rw [hOB]
+      _ = T * (OA * OA) * Tinv := by
+        rw [show (T * OA * Tinv) * (T * OA * Tinv) =
+            T * OA * (Tinv * T) * OA * Tinv by simp only [mul_assoc]]
+        rw [hTinvT]
+        simp only [mul_one, mul_assoc]
+  unfold singleSiteSpinSquareExpectationS
+  calc
+    dotProduct (star Φ) ((OB * OB).mulVec Φ) =
+        dotProduct (star Φ) ((T * (OA * OA) * Tinv).mulVec Φ) := by rw [hsq]
+    _ = dotProduct (star Φ) (T.mulVec ((OA * OA).mulVec Φ)) := by
+      rw [show (T * (OA * OA) * Tinv).mulVec Φ =
+          T.mulVec ((OA * OA).mulVec (Tinv.mulVec Φ)) from by
+            rw [← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]]
+      rw [hΦ]
+    _ = dotProduct (star (T.conjTranspose.mulVec Φ)) ((OA * OA).mulVec Φ) := by
+      rw [dotProduct_star_mulVec_eq_dotProduct_star_conjTranspose_mulVec]
+    _ = dotProduct (star Φ) ((OA * OA).mulVec Φ) := by
+      rw [hTadj, hΦ]
+
+end LatticeSystem.Quantum

--- a/docs/index.md
+++ b/docs/index.md
@@ -2263,6 +2263,7 @@ Issue #412; assembled in PRs #875–#879. All theorems live in
 | `basisSpinS V N` / `basisSpinS_apply` | the standard basis packaged as `Module.Basis (V → Fin (N + 1)) ℂ ((V → Fin (N + 1)) → ℂ)` via `Module.Basis.mk` (PR #919, file `Quantum/SpinS/BasisSpinS.lean`) |
 | `spinSDot_self_mulVec` / `_expectation` / `_expectation_normalized` / `_expectation_allAlignedStateS` | **universal single-site Casimir expectation `⟨Φ, Ŝ_x · Ŝ_x · Φ⟩ = S(S+1)`** for normalized `Φ`. Direct from `spinSDot_self`. Foundation for Tasaki Problem 2.5.c (γ-7) (PR #920, file `Quantum/SpinS/SingleSiteCasimirExpectation.lean`) |
 | `singleSiteSpinSquareExpectationS` / `_axis_sum` / `_axis_sum_normalized` / `_axis1_eq_of_axes_equal_normalized` / `_all_axes_eq_of_axes_equal_normalized` | **Problem 2.5.c single-site squared-expectation bridge**: packages `⟨Φ,(Ŝ_x^(α))² Φ⟩`, proves the three-axis sum is the universal single-site Casimir expectation, and under normalized-state plus equal-axis hypotheses returns `N(N+2)/12 = S(S+1)/3` for each Cartesian axis. This isolates the algebraic reduction while leaving the AFM ground-state SU(2)-symmetry input explicit. Tasaki, Springer 2020, Problem 2.5.c, p. 43 (PR #4056, file `Quantum/SpinS/Problem25cSingleSiteSquared.lean`) |
+| `dotProduct_star_mulVec_eq_dotProduct_star_conjTranspose_mulVec` / `singleSiteSpinSquareExpectationS_eq_of_conj_invariant` | **Problem 2.5.c unitary symmetry input**: if a many-body unitary `T` conjugates a single-site spin component `A` to `B`, `T† = T⁻¹`, and the state is fixed by `T⁻¹`, then the squared single-site expectations of `A` and `B` are equal. This turns future SU(2)/axis-swap ground-state invariance into the equal-axis hypothesis required by PR #4056. Tasaki, Springer 2020, Problem 2.5.c, p. 43 and Theorem 2.4 context, pp. 43-44 (PR #4057, file `Quantum/SpinS/Problem25cUnitaryAxisInput.lean`) |
 | `spinSOpPlus_one_eq_spinHalfOpPlus` / `_Minus_` / `_Op1_` / `_Op2_` / `_Op3_` | **spin-`S` ↔ spin-`1/2` bridge at `N = 1`**: `spinSOp{Plus, Minus, 1, 2, 3} 1 = spinHalfOp{Plus, Minus, 1, 2, 3}` (each is the corresponding half-Pauli matrix) (PRs #922 + #923, file `Quantum/SpinS/SpinHalfSpecialization.lean`) |
 | `onSiteS_spinSOp3_mulVec_allAlignedStateS` / `allAlignedStateS_expectation_onSiteS_spinSOp3` / `_sq` / `onSiteS_spinSOp3_sq_mulVec_allAlignedStateS` | **single-site `Ŝ^(3)_x` and `(Ŝ^(3)_x)²` on `|c..c⟩`**: `Ŝ^(3)_x · |c..c⟩ = (N/2 − c.val) · |c..c⟩` and expectation of `(Ŝ^(3)_x)²` is `(N/2 − c.val)²` (PR #925, file `Quantum/SpinS/SingleSiteZExpectation.lean`) |
 | `allAlignedStateS_expectation_onSiteS_spinSOp1_sq_add_spinSOp2_sq` | **xy-plane Casimir expectation**: `⟨((Ŝ^(1)_x)² + (Ŝ^(2)_x)²) · |c..c⟩⟩ = N(N+2)/4 − (N/2 − c.val)²`. From #920 minus #925; for `c=0` gives `S/2` (PR #926, file `Quantum/SpinS/SingleSiteXYExpectation.lean`) |
@@ -2697,7 +2698,9 @@ mathematical work):
 - **Problem 2.5.c** (single-site squared expectation
   `⟨Φ_GS|(Ŝ_x^(α))²|Φ_GS⟩ = S(S+1)/3` in the AFM ground state).  The
   Casimir-to-equal-axes algebraic bridge is live under
-  `Quantum/SpinS/Problem25cSingleSiteSquared.lean`; the remaining input is the
+  `Quantum/SpinS/Problem25cSingleSiteSquared.lean`, and the unitary-conjugation
+  expectation input is live under
+  `Quantum/SpinS/Problem25cUnitaryAxisInput.lean`. The remaining input is the
   AFM ground-state SU(2)-symmetry/equal-axis hypothesis.
 - **Problem 2.5.d** (two-spin correlation under MLM).
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -14220,6 +14220,24 @@ This PR deliberately leaves the equal-axis ground-state symmetry as an
 explicit hypothesis.  Reference: Tasaki, Springer 2020, Problem~2.5.c,
 p.~43.
 
+\textbf{Problem 2.5.c unitary symmetry input (PR~\#4057)}: the
+next module records the generic symmetry mechanism behind the equal-axis
+input.  If a many-body unitary \(T\) has inverse \(T^{-1}=T^\dagger\),
+conjugates a single-site component \(\hat S_x^{(a)}\) to
+\(\hat S_x^{(b)}\), and fixes the state through \(T^{-1}\Phi=\Phi\), then
+\[
+  \langle\Phi,(\hat S_x^{(b)})^2\Phi\rangle
+  =
+  \langle\Phi,(\hat S_x^{(a)})^2\Phi\rangle .
+\]
+The proof expands \((\hat S_x^{(b)})^2=T(\hat S_x^{(a)})^2T^{-1}\),
+uses the state-invariance hypothesis on the ket side, and moves \(T\) to
+the bra side as \(T^\dagger=T^{-1}\).  The existing axis-swap API can
+supply such a conjugation hypothesis for axes \(2\) and \(3\); the remaining
+work is the AFM ground-state invariance or fuller SU(2) rotation input.
+Reference: Tasaki, Springer 2020, Problem~2.5.c, p.~43, and the
+Theorem~2.4 symmetry context, pp.~43--44.
+
 \textbf{Spin-`S` $\leftrightarrow$ spin-`1/2` bridge at $N = 1$
 (PRs~\#922 + \#923)}: the new file
 \texttt{Quantum/SpinS/SpinHalfSpecialization.lean} proves


### PR DESCRIPTION
Tracked in #412.

## Summary

- add `Problem25cUnitaryAxisInput.lean` with a generic unitary-conjugation bridge for squared single-site expectations
- expose the module from `LatticeSystem.lean`
- document the Problem 2.5.c symmetry-input step in `docs/index.md` and `tex/proof-guide.tex`

## Verification

- `git diff --check`
- `git diff --cached --check`
- `lake env lean LatticeSystem/Quantum/SpinS/Problem25cUnitaryAxisInput.lean`
- `lake build LatticeSystem.Quantum.SpinS.Problem25cUnitaryAxisInput`
- `lake env lean LatticeSystem.lean`
- `cd tex && latexmk -g -pdf proof-guide.tex`
- `.self-local/tex/4057-problem25c-unitary-axis-input.tex`: `latexmk -g -pdf 4057-problem25c-unitary-axis-input.tex`
