### PR TITLE
Add Problem 2.5.c axis-swap adjoint input — #412

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -93,6 +93,7 @@ import LatticeSystem.Quantum.SpinS.HeisenbergGraphLocal
 import LatticeSystem.Quantum.SpinS.GraphLocalStarBlock
 import LatticeSystem.Quantum.SpinS.GraphLocalStarLowerBound
 import LatticeSystem.Quantum.SpinS.GraphLocalStarSumWrapper
+import LatticeSystem.Quantum.SpinS.Problem25cAxisSwapAdjointInput
 import LatticeSystem.Quantum.SpinS.Problem25cSingleSiteSquared
 import LatticeSystem.Quantum.SpinS.Problem25cUnitaryAxisInput
 import LatticeSystem.Quantum.SpinS.SingleSiteXYExpectation

--- a/LatticeSystem/Quantum/SpinS/Problem25cAxisSwapAdjointInput.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25cAxisSwapAdjointInput.lean
@@ -1,0 +1,87 @@
+import LatticeSystem.Quantum.SpinS.Problem25cUnitaryAxisInput
+import LatticeSystem.Quantum.SpinS.AxisSwapUnitarySSpinS
+
+/-!
+# Tasaki Problem 2.5.c: lifted axis-swap adjoint input
+
+This module instantiates the unitary-invariance bridge from
+`Problem25cUnitaryAxisInput.lean` for the lifted axis-swap unitary already built
+for Tasaki §2.5 Theorem 2.4.  The main auxiliary input is that the adjoint of a
+many-body tensor is the tensor of the single-site adjoints.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, Problem 2.5.c, p. 43, and the SU(2)-symmetry context around
+Theorem 2.4, pp. 43-44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
+
+/-! ## Tensor adjoints -/
+
+omit [DecidableEq V] in
+/-- The adjoint of a many-body tensor is the many-body tensor of the single-site
+adjoints. -/
+theorem manyBodyTensorS_conjTranspose
+    (W : V → Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
+    (manyBodyTensorS W).conjTranspose =
+      manyBodyTensorS (fun x => (W x).conjTranspose) := by
+  ext σ' σ
+  simp [manyBodyTensorS_apply, Matrix.conjTranspose_apply]
+
+namespace AxisSwapUnitaryS
+
+variable (G : AxisSwapUnitaryS N)
+
+/-- A single-site adjoint identity `U† = U⁻¹` lifts to the many-body tensor
+axis-swap unitary. -/
+theorem tensor_conjTranspose {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+    (hUadj : G.U.conjTranspose = G.Uinv) :
+    (G.tensor Λ).conjTranspose = G.tensorInv Λ := by
+  simpa [tensor, tensorInv, hUadj] using
+    (manyBodyTensorS_conjTranspose (V := Λ) (N := N) (fun _ : Λ => G.U))
+
+end AxisSwapUnitaryS
+
+/-! ## The concrete spin-S axis swap -/
+
+/-- The single-site adjoint identity for the concrete spin-S axis swap. -/
+theorem axisSwapUnitarySSpinS_U_conjTranspose (N : ℕ) :
+    (axisSwapUnitarySSpinS N).U.conjTranspose =
+      (axisSwapUnitarySSpinS N).Uinv := by
+  simpa [axisSwapUnitarySSpinS] using spinSRot1_adjoint N (Real.pi / 2)
+
+/-- The lifted adjoint identity for the concrete spin-S axis swap. -/
+theorem axisSwapUnitarySSpinS_tensor_conjTranspose
+    (V : Type*) [Fintype V] [DecidableEq V] (N : ℕ) :
+    ((axisSwapUnitarySSpinS N).tensor V).conjTranspose =
+      (axisSwapUnitarySSpinS N).tensorInv V :=
+  (axisSwapUnitarySSpinS N).tensor_conjTranspose
+    (Λ := V) (axisSwapUnitarySSpinS_U_conjTranspose N)
+
+/-! ## Axis-2 / axis-3 squared expectations -/
+
+/-- If the state is fixed by the inverse lifted spin-S axis swap, then the
+single-site squared expectations for axes 3 and 2 are equal. -/
+theorem singleSiteSpinSquareExpectationS_axis3_eq_axis2_of_axisSwapInvariant
+    (x : V) (Φ : (V → Fin (N + 1)) → ℂ)
+    (hΦ : ((axisSwapUnitarySSpinS N).tensorInv V).mulVec Φ = Φ) :
+    singleSiteSpinSquareExpectationS x (spinSOp3 N) Φ =
+      singleSiteSpinSquareExpectationS x (spinSOp2 N) Φ := by
+  refine singleSiteSpinSquareExpectationS_eq_of_conj_invariant
+    (x := x) (A := spinSOp2 N) (B := spinSOp3 N)
+    (T := (axisSwapUnitarySSpinS N).tensor V)
+    (Tinv := (axisSwapUnitarySSpinS N).tensorInv V) (Φ := Φ)
+    ?hTadj ?hTinvT hΦ ?hconj
+  · exact axisSwapUnitarySSpinS_tensor_conjTranspose V N
+  · exact (axisSwapUnitarySSpinS N).tensorInv_mul_tensor (Λ := V)
+  · have hconj :=
+      (axisSwapUnitarySSpinS N).tensor_conj_onSiteS
+        (Λ := V) x (spinSOp2 N)
+    rw [(axisSwapUnitarySSpinS N).conj_spinSOp2] at hconj
+    exact hconj
+
+end LatticeSystem.Quantum

--- a/docs/index.md
+++ b/docs/index.md
@@ -2264,6 +2264,7 @@ Issue #412; assembled in PRs #875–#879. All theorems live in
 | `spinSDot_self_mulVec` / `_expectation` / `_expectation_normalized` / `_expectation_allAlignedStateS` | **universal single-site Casimir expectation `⟨Φ, Ŝ_x · Ŝ_x · Φ⟩ = S(S+1)`** for normalized `Φ`. Direct from `spinSDot_self`. Foundation for Tasaki Problem 2.5.c (γ-7) (PR #920, file `Quantum/SpinS/SingleSiteCasimirExpectation.lean`) |
 | `singleSiteSpinSquareExpectationS` / `_axis_sum` / `_axis_sum_normalized` / `_axis1_eq_of_axes_equal_normalized` / `_all_axes_eq_of_axes_equal_normalized` | **Problem 2.5.c single-site squared-expectation bridge**: packages `⟨Φ,(Ŝ_x^(α))² Φ⟩`, proves the three-axis sum is the universal single-site Casimir expectation, and under normalized-state plus equal-axis hypotheses returns `N(N+2)/12 = S(S+1)/3` for each Cartesian axis. This isolates the algebraic reduction while leaving the AFM ground-state SU(2)-symmetry input explicit. Tasaki, Springer 2020, Problem 2.5.c, p. 43 (PR #4056, file `Quantum/SpinS/Problem25cSingleSiteSquared.lean`) |
 | `dotProduct_star_mulVec_eq_dotProduct_star_conjTranspose_mulVec` / `singleSiteSpinSquareExpectationS_eq_of_conj_invariant` | **Problem 2.5.c unitary symmetry input**: if a many-body unitary `T` conjugates a single-site spin component `A` to `B`, `T† = T⁻¹`, and the state is fixed by `T⁻¹`, then the squared single-site expectations of `A` and `B` are equal. This turns future SU(2)/axis-swap ground-state invariance into the equal-axis hypothesis required by PR #4056. Tasaki, Springer 2020, Problem 2.5.c, p. 43 and Theorem 2.4 context, pp. 43-44 (PR #4057, file `Quantum/SpinS/Problem25cUnitaryAxisInput.lean`) |
+| `manyBodyTensorS_conjTranspose` / `AxisSwapUnitaryS.tensor_conjTranspose` / `axisSwapUnitarySSpinS_tensor_conjTranspose` / `singleSiteSpinSquareExpectationS_axis3_eq_axis2_of_axisSwapInvariant` | **Problem 2.5.c lifted axis-swap adjoint input**: proves `(⊗_x W_x)† = ⊗_x W_x†`, specializes `U† = U⁻¹` to the many-body spin-`S` axis-swap tensor, and uses the PR #4057 bridge plus `AxisSwapUnitaryS.tensor_conj_onSiteS` to equate the axis-3 and axis-2 squared single-site expectations under an explicit lifted-axis-swap invariance hypothesis. Tasaki, Springer 2020, Problem 2.5.c, p. 43 and Theorem 2.4 context, pp. 43-44 (PR #4058, file `Quantum/SpinS/Problem25cAxisSwapAdjointInput.lean`) |
 | `spinSOpPlus_one_eq_spinHalfOpPlus` / `_Minus_` / `_Op1_` / `_Op2_` / `_Op3_` | **spin-`S` ↔ spin-`1/2` bridge at `N = 1`**: `spinSOp{Plus, Minus, 1, 2, 3} 1 = spinHalfOp{Plus, Minus, 1, 2, 3}` (each is the corresponding half-Pauli matrix) (PRs #922 + #923, file `Quantum/SpinS/SpinHalfSpecialization.lean`) |
 | `onSiteS_spinSOp3_mulVec_allAlignedStateS` / `allAlignedStateS_expectation_onSiteS_spinSOp3` / `_sq` / `onSiteS_spinSOp3_sq_mulVec_allAlignedStateS` | **single-site `Ŝ^(3)_x` and `(Ŝ^(3)_x)²` on `|c..c⟩`**: `Ŝ^(3)_x · |c..c⟩ = (N/2 − c.val) · |c..c⟩` and expectation of `(Ŝ^(3)_x)²` is `(N/2 − c.val)²` (PR #925, file `Quantum/SpinS/SingleSiteZExpectation.lean`) |
 | `allAlignedStateS_expectation_onSiteS_spinSOp1_sq_add_spinSOp2_sq` | **xy-plane Casimir expectation**: `⟨((Ŝ^(1)_x)² + (Ŝ^(2)_x)²) · |c..c⟩⟩ = N(N+2)/4 − (N/2 − c.val)²`. From #920 minus #925; for `c=0` gives `S/2` (PR #926, file `Quantum/SpinS/SingleSiteXYExpectation.lean`) |
@@ -2700,8 +2701,10 @@ mathematical work):
   Casimir-to-equal-axes algebraic bridge is live under
   `Quantum/SpinS/Problem25cSingleSiteSquared.lean`, and the unitary-conjugation
   expectation input is live under
-  `Quantum/SpinS/Problem25cUnitaryAxisInput.lean`. The remaining input is the
-  AFM ground-state SU(2)-symmetry/equal-axis hypothesis.
+  `Quantum/SpinS/Problem25cUnitaryAxisInput.lean`. The lifted axis-swap adjoint
+  and axis-2/axis-3 expectation equality input is live under
+  `Quantum/SpinS/Problem25cAxisSwapAdjointInput.lean`. The remaining input is
+  the AFM ground-state SU(2)-symmetry/equal-axis hypothesis.
 - **Problem 2.5.d** (two-spin correlation under MLM).
 
 The generic graph-centric `neelStateOf` (Phase 3 PR #331) is the

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -14238,6 +14238,35 @@ work is the AFM ground-state invariance or fuller SU(2) rotation input.
 Reference: Tasaki, Springer 2020, Problem~2.5.c, p.~43, and the
 Theorem~2.4 symmetry context, pp.~43--44.
 
+\textbf{Problem 2.5.c lifted axis-swap adjoint input (PR~\#4058)}:
+the next module supplies the concrete adjoint data needed to instantiate the
+unitary bridge with the spin-\(S\) axis swap from the Theorem~2.4
+infrastructure.  Entrywise,
+\[
+  (\Theta_W^\dagger)_{\sigma',\sigma}
+  =
+  \overline{\prod_x W_x(\sigma_x,\sigma'_x)}
+  =
+  \prod_x W_x^\dagger(\sigma'_x,\sigma_x),
+\]
+so \((\otimes_x W_x)^\dagger=\otimes_x W_x^\dagger\).  Applying this to
+the rotation \(U=\exp(-i\pi\hat S^{(1)}/2)\), together with the existing
+single-site theorem \(U^\dagger=U^{-1}\), gives
+\((\otimes_x U)^\dagger=\otimes_x U^{-1}\).  The module then combines this
+with the existing conjugation identity
+\((\otimes_x U)\hat S_x^{(2)}(\otimes_x U^{-1})=\hat S_x^{(3)}\) and the
+PR~\#4057 bridge to prove
+\[
+  \langle\Phi,(\hat S_x^{(3)})^2\Phi\rangle
+  =
+  \langle\Phi,(\hat S_x^{(2)})^2\Phi\rangle
+\]
+under the explicit invariance hypothesis \((\otimes_x U^{-1})\Phi=\Phi\).
+The AFM ground-state invariance and the additional rotation data needed to
+equate all three axes remain separate inputs.  Reference: Tasaki, Springer
+2020, Problem~2.5.c, p.~43, and the Theorem~2.4 symmetry context,
+pp.~43--44.
+
 \textbf{Spin-`S` $\leftrightarrow$ spin-`1/2` bridge at $N = 1$
 (PRs~\#922 + \#923)}: the new file
 \texttt{Quantum/SpinS/SpinHalfSpecialization.lean} proves


### PR DESCRIPTION
Tracked in #412.

## Summary

This PR continues Tasaki Problem 2.5.c after PR #4057 by adding the lifted axis-swap adjoint input needed to instantiate the generic unitary-invariance bridge.

- Proves `(manyBodyTensorS W).conjTranspose = manyBodyTensorS (fun x => (W x).conjTranspose)`.
- Lifts a single-site adjoint identity `U† = U⁻¹` to `AxisSwapUnitaryS.tensor`.
- Specializes the lifted adjoint identity to `axisSwapUnitarySSpinS`.
- Combines the PR #4057 bridge with `AxisSwapUnitaryS.tensor_conj_onSiteS` to prove equality of axis-3 and axis-2 squared single-site expectations under an explicit lifted-axis-swap invariance hypothesis.
- Updates `docs/index.md` and `tex/proof-guide.tex`.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `lake env lean LatticeSystem/Quantum/SpinS/Problem25cAxisSwapAdjointInput.lean`
- `lake build LatticeSystem.Quantum.SpinS.Problem25cAxisSwapAdjointInput`
- `lake env lean LatticeSystem.lean`
- `cd tex && latexmk -g -pdf proof-guide.tex`

Notes:
- The module build replayed existing warnings in older files but introduced no warning in `Problem25cAxisSwapAdjointInput.lean`.
- The proof-guide build completed with the repository's existing warning background; the new paragraph only adds underfull boxes in its local line range.
