### PR TITLE
Add Problem 2.5.c z-axis rotation input — #412

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -98,6 +98,7 @@ import LatticeSystem.Quantum.SpinS.Problem25cAxisSwapEqualAxes
 import LatticeSystem.Quantum.SpinS.Problem25cSingleSiteSquared
 import LatticeSystem.Quantum.SpinS.Problem25cTwoSymmetryAxisInput
 import LatticeSystem.Quantum.SpinS.Problem25cUnitaryAxisInput
+import LatticeSystem.Quantum.SpinS.Problem25cZAxisRotationInput
 import LatticeSystem.Quantum.SpinS.SingleSiteXYExpectation
 import LatticeSystem.Lattice.Graph
 import LatticeSystem.Lattice.Scale

--- a/LatticeSystem/Quantum/SpinS/Problem25cZAxisRotationInput.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25cZAxisRotationInput.lean
@@ -1,0 +1,367 @@
+import LatticeSystem.Quantum.SpinS.Problem25cTwoSymmetryAxisInput
+import LatticeSystem.Quantum.SpinS.PMAsOneTwo
+
+/-!
+# Tasaki Problem 2.5.c: z-axis rotation input
+
+This module instantiates the second abstract unitary input from
+`Problem25cTwoSymmetryAxisInput.lean` by the concrete general spin-`S` rotation
+about axis 3 through angle `-π/2`.  The rotation conjugates `Ŝ²` to `Ŝ¹`, so
+the remaining state-side input is invariance under the inverse lifted rotation.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+Springer 2020, Problem 2.5.c, p. 43, and the SU(2)-symmetry context around
+Theorem 2.4, pp. 43-44.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix NormedSpace Complex
+
+variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
+
+/-! ## Single-site z-axis rotation -/
+
+/-- **Spin-`S` rotation about axis 3**, `exp(-iθ Ŝ³)`. -/
+noncomputable def spinSRot3 (N : ℕ) (θ : ℝ) : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ :=
+  exp (-(((θ : ℂ) * Complex.I)) • spinSOp3 N)
+
+/-- **At `θ = 0`, `exp(0) = 1` for the z-axis spin-`S` rotation. -/
+theorem spinSRot3_zero (N : ℕ) : spinSRot3 N 0 = 1 := by
+  unfold spinSRot3
+  simp
+
+/-- **Addition formula** for z-axis spin-`S` rotations. -/
+theorem spinSRot3_mul (N : ℕ) (θ φ : ℝ) :
+    spinSRot3 N θ * spinSRot3 N φ = spinSRot3 N (θ + φ) := by
+  unfold spinSRot3
+  have hcomm : Commute (-(((θ : ℂ) * Complex.I)) • spinSOp3 N)
+      (-(((φ : ℂ) * Complex.I)) • spinSOp3 N) := by
+    exact (Commute.refl (spinSOp3 N)).smul_left _ |>.smul_right _
+  rw [← Matrix.exp_add_of_commute _ _ hcomm]
+  congr 1
+  push_cast
+  module
+
+/-- **Right inverse** for z-axis spin-`S` rotations. -/
+theorem spinSRot3_mul_neg (N : ℕ) (θ : ℝ) :
+    spinSRot3 N θ * spinSRot3 N (-θ) = 1 := by
+  rw [spinSRot3_mul, add_neg_cancel, spinSRot3_zero]
+
+/-- **Left inverse** for z-axis spin-`S` rotations. -/
+theorem spinSRot3_neg_mul (N : ℕ) (θ : ℝ) :
+    spinSRot3 N (-θ) * spinSRot3 N θ = 1 := by
+  rw [spinSRot3_mul, neg_add_cancel, spinSRot3_zero]
+
+/-- **Adjoint formula** for z-axis spin-`S` rotations. -/
+theorem spinSRot3_adjoint (N : ℕ) (θ : ℝ) :
+    Matrix.conjTranspose (spinSRot3 N θ) = spinSRot3 N (-θ) := by
+  unfold spinSRot3
+  rw [← Matrix.exp_conjTranspose]
+  congr 1
+  rw [Matrix.conjTranspose_smul, (spinSOp3_isHermitian N)]
+  congr 1
+  push_cast
+  simp [Complex.conj_I, mul_comm]
+
+/-! ## Axis-3 ladder conjugation -/
+
+/-- `Ŝ⁺ + Ŝ⁻ = 2 Ŝ¹`. -/
+theorem spinSOpPlus_add_Minus_eq_two_smul_spinSOp1 (N : ℕ) :
+    spinSOpPlus N + spinSOpMinus N = (2 : ℂ) • spinSOp1 N := by
+  rw [spinSOpPlus_eq_one_add_I_smul_two, spinSOpMinus_eq_one_sub_I_smul_two]
+  module
+
+/-- `Ŝ⁺ - Ŝ⁻ = 2i Ŝ²`. -/
+theorem spinSOpPlus_sub_Minus_eq_twoI_smul_spinSOp2 (N : ℕ) :
+    spinSOpPlus N - spinSOpMinus N = (2 * Complex.I) • spinSOp2 N := by
+  rw [spinSOpPlus_eq_one_add_I_smul_two, spinSOpMinus_eq_one_sub_I_smul_two]
+  module
+
+/-- **Eigenvector commutation for `Ŝ⁺`**:
+`Ŝ³ Ŝ⁺ = Ŝ⁺ (Ŝ³ + 1)`. -/
+theorem spinSOp3_mul_spinSOpPlus_shift (N : ℕ) :
+    spinSOp3 N * spinSOpPlus N = spinSOpPlus N * (spinSOp3 N + 1) := by
+  have h := spinSOp3_commutator_spinSOpPlus N
+  calc
+    spinSOp3 N * spinSOpPlus N =
+        (spinSOp3 N * spinSOpPlus N - spinSOpPlus N * spinSOp3 N) +
+          spinSOpPlus N * spinSOp3 N := by
+      abel
+    _ = spinSOpPlus N + spinSOpPlus N * spinSOp3 N := by
+      rw [h]
+    _ = spinSOpPlus N * (spinSOp3 N + 1) := by
+      rw [Matrix.mul_add, Matrix.mul_one]
+      abel
+
+/-- **Eigenvector commutation for `Ŝ⁻`**:
+`Ŝ³ Ŝ⁻ = Ŝ⁻ (Ŝ³ - 1)`. -/
+theorem spinSOp3_mul_spinSOpMinus_shift (N : ℕ) :
+    spinSOp3 N * spinSOpMinus N = spinSOpMinus N * (spinSOp3 N - 1) := by
+  have h := spinSOp3_commutator_spinSOpMinus N
+  calc
+    spinSOp3 N * spinSOpMinus N =
+        (spinSOp3 N * spinSOpMinus N - spinSOpMinus N * spinSOp3 N) +
+          spinSOpMinus N * spinSOp3 N := by
+      abel
+    _ = -spinSOpMinus N + spinSOpMinus N * spinSOp3 N := by
+      rw [h]
+    _ = spinSOpMinus N * (spinSOp3 N - 1) := by
+      rw [Matrix.mul_sub, Matrix.mul_one]
+      abel
+
+/-- **Iterated commutation for `Ŝ⁺`**:
+`(Ŝ³)^n Ŝ⁺ = Ŝ⁺ (Ŝ³ + 1)^n`. -/
+theorem spinSOp3_pow_mul_spinSOpPlus (N n : ℕ) :
+    spinSOp3 N ^ n * spinSOpPlus N =
+      spinSOpPlus N * (spinSOp3 N + 1) ^ n := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+      rw [pow_succ, Matrix.mul_assoc, spinSOp3_mul_spinSOpPlus_shift,
+          ← Matrix.mul_assoc, ih, Matrix.mul_assoc, ← pow_succ]
+
+/-- **Iterated commutation for `Ŝ⁻`**:
+`(Ŝ³)^n Ŝ⁻ = Ŝ⁻ (Ŝ³ - 1)^n`. -/
+theorem spinSOp3_pow_mul_spinSOpMinus (N n : ℕ) :
+    spinSOp3 N ^ n * spinSOpMinus N =
+      spinSOpMinus N * (spinSOp3 N - 1) ^ n := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+      rw [pow_succ, Matrix.mul_assoc, spinSOp3_mul_spinSOpMinus_shift,
+          ← Matrix.mul_assoc, ih, Matrix.mul_assoc, ← pow_succ]
+
+attribute [-instance] Matrix.SpecialLinearGroup.hasCoeToGeneralLinearGroup in
+set_option backward.isDefEq.respectTransparency false in
+/-- Exponential intertwining of `Ŝ⁺` for the z-axis spin-`S` rotation generator. -/
+nonrec theorem exp_smul_spinSOp3_mul_spinSOpPlus (N : ℕ) (α : ℂ) :
+    NormedSpace.exp (α • spinSOp3 N) * spinSOpPlus N =
+      spinSOpPlus N * NormedSpace.exp (α • (spinSOp3 N + 1)) :=
+  matrix_exp_intertwine_of_pow_intertwine
+    (pow_smul_mul_of_pow_mul α (spinSOp3_pow_mul_spinSOpPlus N))
+
+attribute [-instance] Matrix.SpecialLinearGroup.hasCoeToGeneralLinearGroup in
+set_option backward.isDefEq.respectTransparency false in
+/-- Exponential intertwining of `Ŝ⁻` for the z-axis spin-`S` rotation generator. -/
+nonrec theorem exp_smul_spinSOp3_mul_spinSOpMinus (N : ℕ) (α : ℂ) :
+    NormedSpace.exp (α • spinSOp3 N) * spinSOpMinus N =
+      spinSOpMinus N * NormedSpace.exp (α • (spinSOp3 N - 1)) :=
+  matrix_exp_intertwine_of_pow_intertwine
+    (pow_smul_mul_of_pow_mul α (spinSOp3_pow_mul_spinSOpMinus N))
+
+attribute [-instance] Matrix.SpecialLinearGroup.hasCoeToGeneralLinearGroup in
+set_option backward.isDefEq.respectTransparency false in
+/-- `exp(α • (Ŝ³ + 1)) = exp(α) • exp(α • Ŝ³)`. -/
+nonrec theorem exp_smul_spinSOp3_succ (N : ℕ) (α : ℂ) :
+    NormedSpace.exp (α • (spinSOp3 N + 1)) =
+      Complex.exp α • NormedSpace.exp (α • spinSOp3 N) := by
+  have hcomm : Commute (α • spinSOp3 N) (α • (1 : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)) :=
+    (Commute.one_right (spinSOp3 N)).smul_left α |>.smul_right α
+  rw [show α • (spinSOp3 N + 1) = α • spinSOp3 N + α • 1 from smul_add _ _ _]
+  rw [Matrix.exp_add_of_commute _ _ hcomm, exp_smul_one_eq]
+  rw [Matrix.mul_smul, Matrix.mul_one]
+
+attribute [-instance] Matrix.SpecialLinearGroup.hasCoeToGeneralLinearGroup in
+set_option backward.isDefEq.respectTransparency false in
+/-- `exp(α • (Ŝ³ - 1)) = exp(-α) • exp(α • Ŝ³)`. -/
+nonrec theorem exp_smul_spinSOp3_pred (N : ℕ) (α : ℂ) :
+    NormedSpace.exp (α • (spinSOp3 N - 1)) =
+      Complex.exp (-α) • NormedSpace.exp (α • spinSOp3 N) := by
+  have hcomm : Commute (α • spinSOp3 N) ((-α) • (1 : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)) :=
+    (Commute.one_right (spinSOp3 N)).smul_left α |>.smul_right (-α)
+  rw [show α • (spinSOp3 N - 1) = α • spinSOp3 N + (-α) • 1 from by
+    rw [smul_sub, neg_smul]; abel]
+  rw [Matrix.exp_add_of_commute _ _ hcomm, exp_smul_one_eq,
+      Matrix.mul_smul, Matrix.mul_one]
+
+attribute [-instance] Matrix.SpecialLinearGroup.hasCoeToGeneralLinearGroup in
+set_option backward.isDefEq.respectTransparency false in
+/-- Inverse pair `exp(α Ŝ³) exp(-α Ŝ³) = 1`. -/
+nonrec theorem exp_smul_spinSOp3_mul_neg (N : ℕ) (α : ℂ) :
+    NormedSpace.exp (α • spinSOp3 N) * NormedSpace.exp ((-α) • spinSOp3 N) = 1 := by
+  have hcomm : Commute (α • spinSOp3 N) ((-α) • spinSOp3 N) :=
+    (Commute.refl (spinSOp3 N)).smul_left α |>.smul_right (-α)
+  rw [← Matrix.exp_add_of_commute _ _ hcomm,
+      show α • spinSOp3 N + (-α) • spinSOp3 N = (0 : Matrix _ _ ℂ) by
+        rw [← add_smul, add_neg_cancel, zero_smul]]
+  exact NormedSpace.exp_zero
+
+attribute [-instance] Matrix.SpecialLinearGroup.hasCoeToGeneralLinearGroup in
+set_option backward.isDefEq.respectTransparency false in
+/-- Conjugation of `Ŝ⁺` by the z-axis exponential. -/
+nonrec theorem exp_smul_spinSOp3_conj_spinSOpPlus (N : ℕ) (α : ℂ) :
+    NormedSpace.exp (α • spinSOp3 N) * spinSOpPlus N *
+      NormedSpace.exp ((-α) • spinSOp3 N) =
+    Complex.exp α • spinSOpPlus N := by
+  calc NormedSpace.exp (α • spinSOp3 N) * spinSOpPlus N *
+          NormedSpace.exp ((-α) • spinSOp3 N)
+      = spinSOpPlus N * NormedSpace.exp (α • (spinSOp3 N + 1)) *
+          NormedSpace.exp ((-α) • spinSOp3 N) := by
+        rw [exp_smul_spinSOp3_mul_spinSOpPlus]
+    _ = spinSOpPlus N * (Complex.exp α • NormedSpace.exp (α • spinSOp3 N)) *
+          NormedSpace.exp ((-α) • spinSOp3 N) := by
+        rw [exp_smul_spinSOp3_succ]
+    _ = Complex.exp α • (spinSOpPlus N * NormedSpace.exp (α • spinSOp3 N) *
+          NormedSpace.exp ((-α) • spinSOp3 N)) := by
+        rw [Matrix.mul_smul, Matrix.smul_mul]
+    _ = Complex.exp α • (spinSOpPlus N *
+          (NormedSpace.exp (α • spinSOp3 N) * NormedSpace.exp ((-α) • spinSOp3 N))) := by
+        rw [Matrix.mul_assoc]
+    _ = Complex.exp α • (spinSOpPlus N * 1) := by
+        rw [exp_smul_spinSOp3_mul_neg]
+    _ = Complex.exp α • spinSOpPlus N := by
+        rw [Matrix.mul_one]
+
+attribute [-instance] Matrix.SpecialLinearGroup.hasCoeToGeneralLinearGroup in
+set_option backward.isDefEq.respectTransparency false in
+/-- Conjugation of `Ŝ⁻` by the z-axis exponential. -/
+nonrec theorem exp_smul_spinSOp3_conj_spinSOpMinus (N : ℕ) (α : ℂ) :
+    NormedSpace.exp (α • spinSOp3 N) * spinSOpMinus N *
+      NormedSpace.exp ((-α) • spinSOp3 N) =
+    Complex.exp (-α) • spinSOpMinus N := by
+  calc NormedSpace.exp (α • spinSOp3 N) * spinSOpMinus N *
+          NormedSpace.exp ((-α) • spinSOp3 N)
+      = spinSOpMinus N * NormedSpace.exp (α • (spinSOp3 N - 1)) *
+          NormedSpace.exp ((-α) • spinSOp3 N) := by
+        rw [exp_smul_spinSOp3_mul_spinSOpMinus]
+    _ = spinSOpMinus N * (Complex.exp (-α) • NormedSpace.exp (α • spinSOp3 N)) *
+          NormedSpace.exp ((-α) • spinSOp3 N) := by
+        rw [exp_smul_spinSOp3_pred]
+    _ = Complex.exp (-α) • (spinSOpMinus N * NormedSpace.exp (α • spinSOp3 N) *
+          NormedSpace.exp ((-α) • spinSOp3 N)) := by
+        rw [Matrix.mul_smul, Matrix.smul_mul]
+    _ = Complex.exp (-α) • (spinSOpMinus N *
+          (NormedSpace.exp (α • spinSOp3 N) * NormedSpace.exp ((-α) • spinSOp3 N))) := by
+        rw [Matrix.mul_assoc]
+    _ = Complex.exp (-α) • (spinSOpMinus N * 1) := by
+        rw [exp_smul_spinSOp3_mul_neg]
+    _ = Complex.exp (-α) • spinSOpMinus N := by
+        rw [Matrix.mul_one]
+
+/-- `spinSRot3` conjugation of `Ŝ⁺`. -/
+theorem spinSRot3_conj_spinSOpPlus (N : ℕ) (θ : ℝ) :
+    spinSRot3 N θ * spinSOpPlus N * spinSRot3 N (-θ) =
+      Complex.exp (-((θ : ℂ) * Complex.I)) • spinSOpPlus N := by
+  unfold spinSRot3
+  convert exp_smul_spinSOp3_conj_spinSOpPlus N (-((θ : ℂ) * Complex.I)) using 2
+  · push_cast; ring_nf
+
+/-- `spinSRot3` conjugation of `Ŝ⁻`. -/
+theorem spinSRot3_conj_spinSOpMinus (N : ℕ) (θ : ℝ) :
+    spinSRot3 N θ * spinSOpMinus N * spinSRot3 N (-θ) =
+      Complex.exp (((θ : ℂ) * Complex.I)) • spinSOpMinus N := by
+  unfold spinSRot3
+  convert exp_smul_spinSOp3_conj_spinSOpMinus N (-((θ : ℂ) * Complex.I)) using 2
+  · push_cast
+    ring_nf
+  · congr 1
+    ring_nf
+
+/-- `exp(iπ/2) = i`. -/
+theorem cexp_neg_neg_pi_half_mul_I :
+    Complex.exp (-(((-(Real.pi / 2) : ℝ) : ℂ) * Complex.I)) = Complex.I := by
+  rw [show -(((-(Real.pi / 2) : ℝ) : ℂ) * Complex.I) =
+         (((Real.pi / 2 : ℝ) : ℂ) * Complex.I) from by push_cast; ring,
+      cexp_pi_half_mul_I]
+
+/-- `exp(-iπ/2) = -i`. -/
+theorem cexp_neg_pi_half_mul_I' :
+    Complex.exp ((((-(Real.pi / 2) : ℝ) : ℂ) * Complex.I)) = -Complex.I := by
+  rw [show (((-(Real.pi / 2) : ℝ) : ℂ) * Complex.I) =
+         -(((Real.pi / 2 : ℝ) : ℂ) * Complex.I) from by push_cast; ring,
+      cexp_neg_pi_half_mul_I]
+
+/-- The `-π/2` z-axis spin-`S` rotation conjugates `Ŝ²` to `Ŝ¹`. -/
+theorem spinSRot3_neg_pi_half_conj_spinSOp2 (N : ℕ) :
+    spinSRot3 N (-(Real.pi / 2)) * spinSOp2 N * spinSRot3 N (Real.pi / 2) =
+      spinSOp1 N := by
+  have h2I : (2 * Complex.I) • spinSOp2 N = spinSOpPlus N - spinSOpMinus N :=
+    (spinSOpPlus_sub_Minus_eq_twoI_smul_spinSOp2 N).symm
+  have hL : spinSRot3 N (-(Real.pi / 2)) *
+      (spinSOpPlus N - spinSOpMinus N) * spinSRot3 N (Real.pi / 2) =
+      ((2 * Complex.I) • spinSOp1 N) := by
+    have hplus :
+        spinSRot3 N (-(Real.pi / 2)) * spinSOpPlus N * spinSRot3 N (Real.pi / 2) =
+          Complex.I • spinSOpPlus N := by
+      simpa [cexp_neg_neg_pi_half_mul_I, show -(-(Real.pi / 2)) = (Real.pi / 2 : ℝ) by ring]
+        using spinSRot3_conj_spinSOpPlus N (-(Real.pi / 2))
+    have hminus :
+        spinSRot3 N (-(Real.pi / 2)) * spinSOpMinus N * spinSRot3 N (Real.pi / 2) =
+          -(Complex.I • spinSOpMinus N) := by
+      have hraw := spinSRot3_conj_spinSOpMinus N (-(Real.pi / 2))
+      have hcexp :
+          Complex.exp ((((-(Real.pi / 2) : ℝ) : ℂ) * Complex.I)) = -Complex.I :=
+        cexp_neg_pi_half_mul_I'
+      rw [hcexp] at hraw
+      simpa [neg_smul, show -(-(Real.pi / 2)) = (Real.pi / 2 : ℝ) by ring] using hraw
+    rw [Matrix.mul_sub, Matrix.sub_mul, hplus, hminus]
+    calc
+      Complex.I • spinSOpPlus N - -(Complex.I • spinSOpMinus N) =
+          Complex.I • (spinSOpPlus N + spinSOpMinus N) := by
+        module
+      _ = Complex.I • ((2 : ℂ) • spinSOp1 N) := by
+        rw [spinSOpPlus_add_Minus_eq_two_smul_spinSOp1]
+      _ = (2 * Complex.I) • spinSOp1 N := by
+        module
+  have hcancel : (2 * Complex.I) • (spinSRot3 N (-(Real.pi / 2)) * spinSOp2 N *
+      spinSRot3 N (Real.pi / 2)) = (2 * Complex.I) • spinSOp1 N := by
+    rw [← hL, ← h2I]
+    rw [Matrix.mul_smul, Matrix.smul_mul]
+  have h2Ine : (2 * Complex.I) ≠ 0 := by
+    simp [Complex.I_ne_zero]
+  exact smul_right_injective _ h2Ine hcancel
+
+/-! ## Lifted Problem 2.5.c input -/
+
+/-- The lifted `-π/2` z-axis rotation conjugates the single-site axis-2
+component to the axis-1 component. -/
+theorem manyBodySpinSRot3_neg_pi_half_conj_onSiteS_spinSOp2
+    (x : V) :
+    manyBodyTensorS (fun _ : V => spinSRot3 N (-(Real.pi / 2))) *
+        onSiteS x (spinSOp2 N) *
+        manyBodyTensorS (fun _ : V => spinSRot3 N (Real.pi / 2)) =
+      onSiteS x (spinSOp1 N) := by
+  simpa [show -(-(Real.pi / 2)) = (Real.pi / 2 : ℝ) by ring,
+    spinSRot3_neg_pi_half_conj_spinSOp2] using
+    (manyBodyTensorS_conj_onSiteS (Λ := V) (N := N)
+      (spinSRot3_mul_neg N (-(Real.pi / 2))) x (spinSOp2 N))
+
+omit [DecidableEq V] in
+/-- The lifted `-π/2` z-axis rotation has lifted inverse `π/2` as its adjoint. -/
+theorem manyBodySpinSRot3_neg_pi_half_conjTranspose
+    (V : Type*) [Fintype V] (N : ℕ) :
+    (manyBodyTensorS (fun _ : V => spinSRot3 N (-(Real.pi / 2)))).conjTranspose =
+      manyBodyTensorS (fun _ : V => spinSRot3 N (Real.pi / 2)) := by
+  simpa [spinSRot3_adjoint] using
+    (manyBodyTensorS_conjTranspose (V := V) (N := N)
+      (fun _ : V => spinSRot3 N (-(Real.pi / 2))))
+
+/-- If a normalized state is fixed by both the lifted axis-swap inverse and the
+inverse lifted z-axis rotation, then all three squared single-site spin
+expectations have value `N(N+2)/12`. -/
+theorem singleSiteSpinSquareExpectationS_all_axes_eq_of_axisSwapInvariant_zAxisRot
+    (x : V) {Φ : (V → Fin (N + 1)) → ℂ}
+    (hΦnorm : dotProduct (star Φ) Φ = 1)
+    (hΦswap : ((axisSwapUnitarySSpinS N).tensorInv V).mulVec Φ = Φ)
+    (hΦrot :
+      (manyBodyTensorS (fun _ : V => spinSRot3 N (Real.pi / 2))).mulVec Φ = Φ) :
+    singleSiteSpinSquareExpectationS x (spinSOp1 N) Φ =
+        (N : ℂ) * (N + 2) / 12 ∧
+      singleSiteSpinSquareExpectationS x (spinSOp2 N) Φ =
+        (N : ℂ) * (N + 2) / 12 ∧
+      singleSiteSpinSquareExpectationS x (spinSOp3 N) Φ =
+        (N : ℂ) * (N + 2) / 12 :=
+  singleSiteSpinSquareExpectationS_all_axes_eq_of_axisSwapInvariant_unitary_axis12
+    (x := x)
+    (T := manyBodyTensorS (fun _ : V => spinSRot3 N (-(Real.pi / 2))))
+    (Tinv := manyBodyTensorS (fun _ : V => spinSRot3 N (Real.pi / 2)))
+    hΦnorm hΦswap
+    (manyBodySpinSRot3_neg_pi_half_conjTranspose V N)
+    (by
+      rw [manyBodyTensorS_mul]
+      simpa [spinSRot3_mul_neg] using manyBodyTensorS_one (Λ := V) (N := N))
+    hΦrot
+    (manyBodySpinSRot3_neg_pi_half_conj_onSiteS_spinSOp2 (x := x))
+
+end LatticeSystem.Quantum

--- a/docs/index.md
+++ b/docs/index.md
@@ -2267,6 +2267,7 @@ Issue #412; assembled in PRs #875–#879. All theorems live in
 | `manyBodyTensorS_conjTranspose` / `AxisSwapUnitaryS.tensor_conjTranspose` / `axisSwapUnitarySSpinS_tensor_conjTranspose` / `singleSiteSpinSquareExpectationS_axis3_eq_axis2_of_axisSwapInvariant` | **Problem 2.5.c lifted axis-swap adjoint input**: proves `(⊗_x W_x)† = ⊗_x W_x†`, specializes `U† = U⁻¹` to the many-body spin-`S` axis-swap tensor, and uses the PR #4057 bridge plus `AxisSwapUnitaryS.tensor_conj_onSiteS` to equate the axis-3 and axis-2 squared single-site expectations under an explicit lifted-axis-swap invariance hypothesis. Tasaki, Springer 2020, Problem 2.5.c, p. 43 and Theorem 2.4 context, pp. 43-44 (PR #4058, file `Quantum/SpinS/Problem25cAxisSwapAdjointInput.lean`) |
 | `singleSiteSpinSquareExpectationS_all_axes_eq_of_axisSwapInvariant_axis1_eq_axis2` | **Problem 2.5.c axis-swap equal-axes wrapper**: combines PR #4058's axis-swap equality `E_3 = E_2` with PR #4056's all-axis algebraic bridge. For a normalized state fixed by the inverse lifted axis swap, one remaining explicit equality `E_1 = E_2` implies `E_1 = E_2 = E_3 = N(N+2)/12`. This leaves the missing axis-1/axis-2 SU(2) or rotation input explicit. Tasaki, Springer 2020, Problem 2.5.c, p. 43 and Theorem 2.4 context, pp. 43-44 (PR #4059, file `Quantum/SpinS/Problem25cAxisSwapEqualAxes.lean`) |
 | `singleSiteSpinSquareExpectationS_axis1_eq_axis2_of_unitaryInvariant` / `_all_axes_eq_of_axisSwapInvariant_unitary_axis12` | **Problem 2.5.c two-symmetry axis input**: derives the remaining equality `E_1 = E_2` from an explicit abstract unitary conjugation `T Ŝ_x^(2) T⁻¹ = Ŝ_x^(1)` plus `T⁻¹Φ = Φ`, then combines it with PR #4059's lifted-axis-swap wrapper to conclude `E_1 = E_2 = E_3 = N(N+2)/12`. The concrete general spin-`S` rotation or AFM ground-state SU(2) invariance theorem remains explicit. Tasaki, Springer 2020, Problem 2.5.c, p. 43 and Theorem 2.4 context, pp. 43-44 (PR #4060, file `Quantum/SpinS/Problem25cTwoSymmetryAxisInput.lean`) |
+| `spinSRot3` / `spinSRot3_neg_pi_half_conj_spinSOp2` / `manyBodySpinSRot3_neg_pi_half_conj_onSiteS_spinSOp2` / `singleSiteSpinSquareExpectationS_all_axes_eq_of_axisSwapInvariant_zAxisRot` | **Problem 2.5.c concrete z-axis rotation input**: constructs the general spin-`S` rotation `exp(-iθŜ³)`, proves the `-π/2` conjugation `Ŝ² ↦ Ŝ¹`, lifts it to a many-body single-site conjugation, and feeds it into PR #4060. The remaining input is invariance of the AFM ground state under the inverse lifted z-axis rotation, together with the existing lifted axis-swap invariance. Tasaki, Springer 2020, Problem 2.5.c, p. 43 and Theorem 2.4 context, pp. 43-44 (PR #4061, file `Quantum/SpinS/Problem25cZAxisRotationInput.lean`) |
 | `spinSOpPlus_one_eq_spinHalfOpPlus` / `_Minus_` / `_Op1_` / `_Op2_` / `_Op3_` | **spin-`S` ↔ spin-`1/2` bridge at `N = 1`**: `spinSOp{Plus, Minus, 1, 2, 3} 1 = spinHalfOp{Plus, Minus, 1, 2, 3}` (each is the corresponding half-Pauli matrix) (PRs #922 + #923, file `Quantum/SpinS/SpinHalfSpecialization.lean`) |
 | `onSiteS_spinSOp3_mulVec_allAlignedStateS` / `allAlignedStateS_expectation_onSiteS_spinSOp3` / `_sq` / `onSiteS_spinSOp3_sq_mulVec_allAlignedStateS` | **single-site `Ŝ^(3)_x` and `(Ŝ^(3)_x)²` on `|c..c⟩`**: `Ŝ^(3)_x · |c..c⟩ = (N/2 − c.val) · |c..c⟩` and expectation of `(Ŝ^(3)_x)²` is `(N/2 − c.val)²` (PR #925, file `Quantum/SpinS/SingleSiteZExpectation.lean`) |
 | `allAlignedStateS_expectation_onSiteS_spinSOp1_sq_add_spinSOp2_sq` | **xy-plane Casimir expectation**: `⟨((Ŝ^(1)_x)² + (Ŝ^(2)_x)²) · |c..c⟩⟩ = N(N+2)/4 − (N/2 − c.val)²`. From #920 minus #925; for `c=0` gives `S/2` (PR #926, file `Quantum/SpinS/SingleSiteXYExpectation.lean`) |
@@ -2708,10 +2709,12 @@ mathematical work):
   `Quantum/SpinS/Problem25cAxisSwapAdjointInput.lean`; the wrapper reducing the
   all-axis conclusion to lifted axis-swap invariance plus the remaining
   axis-1/axis-2 equality is live under
-  `Quantum/SpinS/Problem25cAxisSwapEqualAxes.lean`; and the wrapper reducing
-  that remaining equality to an abstract second unitary symmetry input is live
-  under `Quantum/SpinS/Problem25cTwoSymmetryAxisInput.lean`. The remaining input
-  is the concrete AFM ground-state SU(2)-symmetry/equal-axis theorem.
+  `Quantum/SpinS/Problem25cAxisSwapEqualAxes.lean`; the wrapper reducing that
+  remaining equality to an abstract second unitary symmetry input is live under
+  `Quantum/SpinS/Problem25cTwoSymmetryAxisInput.lean`; and the concrete z-axis
+  rotation input is live under
+  `Quantum/SpinS/Problem25cZAxisRotationInput.lean`. The remaining input is the
+  concrete AFM ground-state invariance under the lifted rotations.
 - **Problem 2.5.d** (two-spin correlation under MLM).
 
 The generic graph-centric `neelStateOf` (Phase 3 PR #331) is the

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -14310,6 +14310,31 @@ state is fixed by such a symmetry, remains the open mathematical input.
 Reference: Tasaki, Springer 2020, Problem~2.5.c, p.~43, and the
 Theorem~2.4 symmetry context, pp.~43--44.
 
+\textbf{Problem 2.5.c z-axis rotation input (PR~\#4061)}:
+the next module instantiates the abstract second unitary of PR~\#4060 by a
+concrete general spin-\(S\) rotation about axis \(3\).  Put
+\[
+  R_3(\theta)=\exp(-i\theta\hat S^{(3)}).
+\]
+Using the ladder identities
+\[
+  \hat S^+=\hat S^{(1)}+i\hat S^{(2)},\qquad
+  \hat S^-=\hat S^{(1)}-i\hat S^{(2)}
+\]
+and the Cartan relations, the module proves
+\[
+  R_3(-\pi/2)\hat S^{(2)}R_3(\pi/2)=\hat S^{(1)}.
+\]
+Tensoring over all sites then gives
+\[
+  (\otimes_x R_3(-\pi/2))\hat S_x^{(2)}
+  (\otimes_x R_3(\pi/2))=\hat S_x^{(1)}.
+\]
+Thus PR~\#4060 applies with this concrete rotation.  The remaining input is
+that the AFM ground state is fixed by the inverse lifted z-axis rotation, along
+with the existing lifted axis-swap invariance.  Reference: Tasaki, Springer
+2020, Problem~2.5.c, p.~43, and the Theorem~2.4 symmetry context, pp.~43--44.
+
 \textbf{Spin-`S` $\leftrightarrow$ spin-`1/2` bridge at $N = 1$
 (PRs~\#922 + \#923)}: the new file
 \texttt{Quantum/SpinS/SpinHalfSpecialization.lean} proves


### PR DESCRIPTION
Tracked in #412.

## Summary

- add the concrete spin-S z-axis rotation input needed for Tasaki Problem 2.5.c;
- prove that the lifted `-π/2` rotation about axis 3 conjugates `Ŝ_x^(2)` to `Ŝ_x^(1)`;
- feed that concrete rotation into the two-symmetry Problem 2.5.c wrapper from PR #4060.

## Verification

- `git diff --check`
- `lake env lean LatticeSystem/Quantum/SpinS/Problem25cZAxisRotationInput.lean`
- `lake build LatticeSystem.Quantum.SpinS.Problem25cZAxisRotationInput`
- `lake env lean LatticeSystem.lean`
- `cd tex && latexmk -g -pdf proof-guide.tex`
- `cd .self-local/tex && latexmk -g -pdf 4061-problem25c-z-axis-rotation-input.tex`
