### PR TITLE
Refactor: Problem 2.5.d build-speed checkpoint — #412

### DIFF
--- a/docs/refactoring-conventions.md
+++ b/docs/refactoring-conventions.md
@@ -337,6 +337,22 @@ The goal is that **anyone reviewing a PR can apply this checklist
 mechanically** and catch most regressions / drift.
 
 ### History
+- **2026-06-01 (PR #4070)**: Refactor checkpoint after the 20 post-#4049
+  Tasaki Problem 2.5.b--d feature PRs (#4050--#4069). Build-speed evaluation
+  focused on the largest current `Quantum/SpinS` module:
+  `lake env lean LatticeSystem/Quantum/SpinS/Theorem24SU2GlobalUniquenessFromMLM.lean`
+  completed in `real 15.83s` (`user 9.13s`, `sys 3.29s`) on updated
+  `main`. A preliminary size survey also measured the next largest
+  `Quantum/SpinS` files at roughly 4--5s focused elaboration, so
+  `Theorem24SU2GlobalUniquenessFromMLM.lean` is the only near-threshold file.
+  No module split was performed: the consumer-facing SU(2)-endpoint theorems
+  are a suffix of the same proof chain, but they depend on the zero-Casimir,
+  outside-sector, common-energy, and sector-PF infrastructure earlier in the
+  file. A suffix extraction would therefore create a serial parent/suffix
+  dependency rather than an independent parallel build target, while adding
+  import churn to the active Theorem 2.4 / Problem 2.5.c consumers. Revisit a
+  real split if this file persistently exceeds about 18s or if a future theorem
+  creates an independent downstream-facing endpoint cluster.
 - **2026-05-25 (PR #3605)**: Refactor checkpoint after the 20
   post-#3584 Tasaki §2.5 Theorem 2.3 feature PRs (#3585--#3604).
   Build-speed evaluation for the active outside-ground/common-energy final


### PR DESCRIPTION
Tracked in #412.

## Scope

This is the required 20-PR cadence refactor checkpoint after PR #4069.

The PR records a build-speed evaluation for the heaviest current
`Quantum/SpinS` candidate and documents why this round is evaluate-only rather
than a module split.

## Build-speed evaluation

Measured on updated `main` after PR #4069:

```text
/usr/bin/time -p lake env lean LatticeSystem/Quantum/SpinS/Theorem24SU2GlobalUniquenessFromMLM.lean
real 15.83
user 9.13
sys 3.29
```

Earlier candidate survey while #4069 CI was pending:

```text
Theorem24SU2GlobalUniquenessFromMLM.lean: 13.76s
AllAlignedState.lean: 4.61s
MagSectorEmbedding.lean: 4.23s
SaturatedLadderJointEigenspace.lean: 4.89s
SingleClusterHamiltonian.lean: 4.42s
MultiSite.lean: 4.44s
```

## Split decision

No module split in this checkpoint.

`Theorem24SU2GlobalUniquenessFromMLM.lean` is near the historical watch range,
but its consumer-facing SU(2) endpoint suffix depends directly on the earlier
zero-Casimir, outside-sector, common-energy, and sector-PF infrastructure in
the same proof chain.  A suffix extraction would create a serial parent/suffix
dependency rather than an independent parallel build target, while adding
import churn to active Theorem 2.4 / Problem 2.5.c consumers.

Revisit a real split if this file persistently exceeds about 18s or if a future
theorem creates an independent downstream-facing endpoint cluster.

## Verification

- `lake env lean LatticeSystem/Quantum/SpinS/Theorem24SU2GlobalUniquenessFromMLM.lean`
- `git diff --check`

No Lean declarations were added or changed; therefore `docs/index.md` and
`tex/proof-guide.tex` do not need theorem-index updates.
