### PR TITLE
Refactor post-4090 build-speed and linter checkpoint — #412

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSBalancedSectorPFTarget.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSBalancedSectorPFTarget.lean
@@ -24,7 +24,6 @@ open Matrix Module
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-set_option linter.style.longLine false in
 /-- **General spin-S balanced-sector Perron--Frobenius simplicity at the target
 point**: the anisotropic target sector matrix has a one-dimensional ground
 eigenspace in the chosen magnetization sector. -/
@@ -95,7 +94,6 @@ theorem anisotropicHeisenbergS_balanced_sector_pf_at_target
   rw [hmin_eq]
   exact hraw
 
-set_option linter.style.longLine false in
 /-- **General spin-S target ground eigenspace `finrank <= 1` with balanced-sector
 PF discharged**: the remaining explicit inputs are the full target
 `finrank <= 2` bound and balanced-sector/full-ground equality. -/
@@ -138,7 +136,6 @@ theorem anisotropicHeisenbergS_target_finrank_le_one_of_balanced_eq_full
       (Λ := Λ) (N := N) (J := J) hJ_star M_balanced h_balanced
       h_balanced_eq_full h_full_le_two hpf
 
-set_option linter.style.longLine false in
 /-- **General spin-S target ground states have zero total magnetization with
 balanced-sector PF discharged**. -/
 theorem anisotropicHeisenbergS_target_groundState_zero_magnetization_of_balanced_eq_full

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSObligation2FromSU2Unique.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSObligation2FromSU2Unique.lean
@@ -30,7 +30,6 @@ open Matrix Module Set
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 
-set_option linter.style.longLine false in
 /-- **General spin-S anisotropic `Ĥ` eigenspace `≤ 2` at its global minimum**:
 the concrete spin-`S` axis-swap unitary turns the unconditional parity-block
 bound at the axis-swapped block minimum into the corresponding bound at
@@ -76,7 +75,6 @@ theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_general
   rw [henergy_eq] at hbound
   exact hbound
 
-set_option linter.style.longLine false in
 /-- **General spin-S anisotropic `Ĥ` eigenspace `≤ 2` along the deformation
 path**: for target `(λ', D')` in strict case (i) and `0 < t ≤ 1`, the
 eigenspace of `Ĥ(γ(t))` at its global minimum has `finrank ≤ 2`. -/
@@ -130,7 +128,6 @@ theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_path_gene
     hlam_t_im hlb_t hub_t hD_t_im hDpos_t
     (hc_strict lam_t D_t) hA_ne hB_ne hN hJ_star hlam_t_star hD_t_star
 
-set_option linter.style.longLine false in
 /-- **General spin-S obligation (2), first-crossing capstone**: a non-empty
 crossing set for a non-balanced sector contradicts the strict SU(2) endpoint
 gap, the SU(2) balanced-ground equality, the path-wide balanced-ground
@@ -232,7 +229,6 @@ theorem anisotropicHeisenbergS_obligation_2_axiomatic_sup_crossing_hne_general
     h_finrank hΦ_bal_ne h_balanced hΦ_bal_eig
     hΦ_M_ne hM_ne_balanced hΦ_M_eig
 
-set_option linter.style.longLine false in
 /-- **General spin-S obligation (2) under a single SU(2)-point strict-gap
 axiom**: any target violation contradicts the first-crossing chain. -/
 theorem anisotropicHeisenbergS_obligation_2_single_axiom_general
@@ -333,7 +329,6 @@ theorem anisotropicHeisenbergS_obligation_2_single_axiom_general
     M_balanced M_chosen h_balanced hM_chosen_centered_ne hlam'_lb hlam'_ub hD'
     hM_chosen_cross h_strict_chosen axiom_GS_at_SU2 h_below
 
-set_option linter.style.longLine false in
 /-- **General spin-S obligation (2) from SU(2) global uniqueness**: the
 SU(2)-point global one-dimensional ground eigenspace supplies the strict-gap
 axiom used by the single-axiom first-crossing capstone. -/
@@ -401,7 +396,6 @@ theorem anisotropicHeisenbergS_obligation_2_of_SU2_global_unique_general
     M_balanced M_orig h_balanced hM_orig_ne h_centered_nonzero
     hlam'_lb hlam'_ub hD' h_violation_orig h_strict_gap_at_SU2
 
-set_option linter.style.longLine false in
 /-- **General spin-S obligation (2) from only SU(2) global uniqueness**:
 the balanced SU(2)-sector/full-ground equality is derived from the same global
 uniqueness input, leaving one public SU(2) endpoint hypothesis. -/
@@ -448,7 +442,6 @@ theorem anisotropicHeisenbergS_obligation_2_of_SU2_global_unique_only_general
     M_balanced M_orig h_balanced hM_orig_ne h_centered_nonzero
     hlam'_lb hlam'_ub hD' h_violation_orig h_SU2_global_unique h_GS_at_SU2
 
-set_option linter.style.longLine false in
 /-- **General spin-S target strict gap from SU(2) global uniqueness**: at the
 target point of the deformation path, every non-balanced non-empty sector has
 strictly larger minimum energy than the balanced sector. -/
@@ -501,7 +494,6 @@ theorem anisotropicHeisenbergS_strict_gap_all_M_of_SU2_global_unique_general
   simp only [anisotropicHeisenbergParametricPath_one] at hpath
   exact hpath
 
-set_option linter.style.longLine false in
 /-- **General spin-S target uniqueness from SU(2) global uniqueness**: the
 SU(2) global uniqueness input supplies the target strict-gap callback consumed
 by `anisotropicHeisenbergS_target_finrank_le_one_of_strict_gap`. -/
@@ -576,7 +568,6 @@ theorem anisotropicHeisenbergS_target_finrank_le_one_of_SU2_global_unique_genera
     A hJim hJnn hJpos hJbip hJ_star hJ_sym hA_ne hB_ne hN
     M_balanced h_balanced h_strict_gap h_global_two
 
-set_option linter.style.longLine false in
 /-- **General spin-S target ground states have zero magnetization from SU(2)
 global uniqueness**: the uniqueness wrapper above feeds the existing
 zero-magnetization theorem. -/

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSTargetConditionalBridge.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSTargetConditionalBridge.lean
@@ -26,7 +26,6 @@ open Matrix Module
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-set_option linter.style.longLine false in
 /-- **General spin-S target ground eigenspace `finrank <= 1` from balanced-sector
 inputs**: full `finrank <= 2`, balanced-sector/full-ground equality, and
 balanced-sector PF simplicity imply full target ground-state uniqueness. -/
@@ -105,7 +104,6 @@ theorem anisotropicHeisenbergS_target_finrank_le_one_of_balanced_sector_pf
     (by simpa [hμ_full_def] using h_full_le_two)
     hΦ_admis0 hΦ_ne hΦ_eig_full h_admis_pf
 
-set_option linter.style.longLine false in
 /-- **General spin-S target ground states have zero total magnetization from
 balanced-sector inputs**: the target uniqueness bridge composed with the
 existing uniqueness-implies-zero-magnetization theorem. -/

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSTargetFromStrictGap.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSTargetFromStrictGap.lean
@@ -22,7 +22,6 @@ open Matrix Module
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-set_option linter.style.longLine false in
 /-- **General spin-S target ground eigenspace `finrank <= 1` from strict sector
 gap**: the strict gap over every non-balanced non-empty magnetization sector
 supplies balanced/full equality, and the PR #4088 balanced-sector PF target
@@ -67,7 +66,6 @@ theorem anisotropicHeisenbergS_target_finrank_le_one_of_strict_gap
       (Λ := Λ) (N := N) A hJim hJnn hJpos hJbip hJ_star hJ_sym hA_ne hB_ne hN
       M_balanced h_balanced h_balanced_eq_full h_full_le_two
 
-set_option linter.style.longLine false in
 /-- **General spin-S target ground states have zero total magnetization from
 strict sector gap**: target uniqueness follows from the strict-gap wrapper, then
 the existing uniqueness-implies-zero-magnetization theorem applies. -/

--- a/docs/refactoring-conventions.md
+++ b/docs/refactoring-conventions.md
@@ -337,6 +337,20 @@ The goal is that **anyone reviewing a PR can apply this checklist
 mechanically** and catch most regressions / drift.
 
 ### History
+- **2026-06-02 (PR #4091)**: Refactor checkpoint after the 20 post-#4070
+  Tasaki Theorem 2.4 / Problem 2.5 feature PRs (#4071--#4090).
+  Build-speed evaluation rechecked the largest current Theorem 2.4 SU(2)
+  endpoint module and the newly added general spin-S obligation-(2) wrapper:
+  `lake env lean LatticeSystem/Quantum/SpinS/Theorem24SU2GlobalUniquenessFromMLM.lean`
+  completed in `real 5.59s` (`user 8.22s`, `sys 1.65s`), and
+  `lake env lean LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSObligation2FromSU2Unique.lean`
+  completed in `real 3.82s` (`user 2.88s`, `sys 1.53s`).  Both are below the
+  prior PR #4070 measurement and well below the recorded roughly-18s threshold
+  for reconsidering a split of `Theorem24SU2GlobalUniquenessFromMLM.lean`, so
+  no module split was performed.  The PR also removed unnecessary
+  `set_option linter.style.longLine false in` wrappers from the recent general
+  spin-S target/obligation modules after focused Lean checks showed they were
+  no longer needed.
 - **2026-06-01 (PR #4070)**: Refactor checkpoint after the 20 post-#4049
   Tasaki Problem 2.5.b--d feature PRs (#4050--#4069). Build-speed evaluation
   focused on the largest current `Quantum/SpinS` module:


### PR DESCRIPTION
Tracked in #412.

This is the required refactor checkpoint after PR #4090, the twentieth merged
PR since refactor checkpoint #4070.

Scope:

- Re-measure build speed for the current largest Theorem 2.4 SU(2)-endpoint
  module and the newly added general spin-S obligation-(2) wrapper.
- Keep `Theorem24SU2GlobalUniquenessFromMLM.lean` unsplit if the updated
  timings remain below the prior split threshold and no independent endpoint
  cluster appears.
- Remove now-unnecessary `set_option linter.style.longLine false in` wrappers
  from recent general spin-S target/obligation files, if focused Lean
  verification remains clean.
- Update `docs/refactoring-conventions.md`, `docs/index.md` if needed, and the
  proof guide only if the public module/API description changes.

Build-speed precheck while PR #4090 was pending:

- `lake env lean LatticeSystem/Quantum/SpinS/Theorem24SU2GlobalUniquenessFromMLM.lean`
  measured `real 9.00s`.
- `lake env lean LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSObligation2FromSU2Unique.lean`
  measured `real 5.95s`.

These numbers are below the PR #4070 measurement and below the recorded
roughly-18s threshold for reconsidering a split of
`Theorem24SU2GlobalUniquenessFromMLM.lean`.

Verification:

- `lake env lean LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSTargetConditionalBridge.lean`
- `lake env lean LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSBalancedSectorPFTarget.lean`
- `lake env lean LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSTargetFromStrictGap.lean`
- `lake env lean LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSObligation2FromSU2Unique.lean`
- `lake env lean LatticeSystem/Quantum/SpinS/Theorem24SU2GlobalUniquenessFromMLM.lean`
  measured `real 5.59s` (`user 8.22s`, `sys 1.65s`)
- `lake env lean LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSObligation2FromSU2Unique.lean`
  measured `real 3.82s` (`user 2.88s`, `sys 1.53s`)
- `lake env lean LatticeSystem.lean`
- `git diff --check`
- `lake build LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSpinSObligation2FromSU2Unique`
  (succeeded; replayed existing warnings from older modules)
- TBD: codex review, CI
