### PR TITLE
Refactor checkpoint after case II local signs - #412

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIBlockPFMin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIBlockPFMin.lean
@@ -266,7 +266,6 @@ theorem anisotropicHeisenbergS_case_ii_target_finrank_le_one_of_block_pf_min_pat
     M_balanced h_balanced hlam_case_ii hD_case_ii h_centered_nonzero
     h_strict_gap_at_SU2 h_GS_at_SU2 h_even h_odd
 
-set_option linter.style.longLine false in
 /-- **General spin-S case-(ii) target zero magnetization from pathwise
 parity-block PF/min callbacks**. -/
 theorem anisotropicHeisenbergS_case_ii_target_zero_magnetization_of_block_pf_min_path

--- a/docs/refactoring-conventions.md
+++ b/docs/refactoring-conventions.md
@@ -337,7 +337,7 @@ The goal is that **anyone reviewing a PR can apply this checklist
 mechanically** and catch most regressions / drift.
 
 ### History
-- **2026-06-02 (PR pending)**: Refactor checkpoint after the 20 post-#4091
+- **2026-06-02 (PR #4112)**: Refactor checkpoint after the 20 post-#4091
   Tasaki Theorem 2.4 case-(ii) feature PRs (#4092--#4111). Build-speed
   evaluation focused on the recent case-(ii) parity-gauged shifted-matrix
   modules. The largest new local-sign file,

--- a/docs/refactoring-conventions.md
+++ b/docs/refactoring-conventions.md
@@ -337,6 +337,19 @@ The goal is that **anyone reviewing a PR can apply this checklist
 mechanically** and catch most regressions / drift.
 
 ### History
+- **2026-06-02 (PR pending)**: Refactor checkpoint after the 20 post-#4091
+  Tasaki Theorem 2.4 case-(ii) feature PRs (#4092--#4111). Build-speed
+  evaluation focused on the recent case-(ii) parity-gauged shifted-matrix
+  modules. The largest new local-sign file,
+  `lake env lean LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIILocalSigns.lean`,
+  measured `real 17.19s` (`user 3.67s`, `sys 3.46s`) on the first run and
+  `real 5.71s` (`user 3.62s`, `sys 1.97s`) on a warm rerun. The structural
+  sign-transfer and shifted-matrix files measured `real 4.22s` and `real 3.70s`,
+  while the block PF/min bridge measured `real 4.00s`. The warm local-sign time
+  and small downstream times do not justify a module split yet; the first run is
+  tracked as dependency/cache cost. The PR therefore keeps the checkpoint narrow
+  and removes one now-unnecessary `set_option linter.style.longLine false in`
+  wrapper from the case-(ii) block PF/min bridge.
 - **2026-06-02 (PR #4091)**: Refactor checkpoint after the 20 post-#4070
   Tasaki Theorem 2.4 / Problem 2.5 feature PRs (#4071--#4090).
   Build-speed evaluation rechecked the largest current Theorem 2.4 SU(2)


### PR DESCRIPTION
Tracked in #412.

This is the required 20-PR cadence refactor checkpoint after PR #4111.

Scope:

- record build-speed measurements for the recent case-(ii) shifted-matrix files;
- keep this as an evaluate-focused checkpoint because the only near-threshold file is healthy on warm replay;
- remove one now-unnecessary `set_option linter.style.longLine false in` wrapper from the case-(ii) block PF/min bridge.

Build-speed measurements:

- `AnisotropicHeisenbergSpinSCaseIILocalSigns.lean`: first run `real 17.19s`, warm run `real 5.71s`;
- `AnisotropicHeisenbergSpinSCaseIIParityGaugedSigns.lean`: `real 4.22s`;
- `AnisotropicHeisenbergSpinSCaseIIParityGaugedMatrix.lean`: `real 3.70s`;
- `AnisotropicHeisenbergSpinSCaseIIBlockPFMin.lean`: `real 4.00s`.

Decision:

- no module split is justified yet;
- the first local-sign run is treated as dependency/cache cost rather than a warm-build regression;
- continue theorem-level case-(ii) work only after this checkpoint merges.

Verification:

- `lake env lean LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIBlockPFMin.lean`
- `lake env lean LatticeSystem.lean`
- `git diff --check`
