### PR TITLE
Add Jordan-Wigner string action on computational basis states - #4130

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.String
+import LatticeSystem.Fermion.JordanWigner.StringBasisVecAction
 import LatticeSystem.Fermion.JordanWigner.Operators
 import LatticeSystem.Fermion.JordanWigner.CAR
 import LatticeSystem.Fermion.JordanWigner.CAR.CrossSiteOfNe

--- a/LatticeSystem/Fermion/JordanWigner/StringBasisVecAction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/StringBasisVecAction.lean
@@ -1,0 +1,94 @@
+import LatticeSystem.Fermion.JordanWigner.String
+
+/-!
+# Diagonal action of the Jordan–Wigner string on computational basis states
+
+This file provides the foundational infrastructure for computing the action of
+Jordan–Wigner operators on computational basis states `basisVec c`, needed for
+the Tasaki §11.2 hopping matrix elements (eq. (11.2.4)/(11.2.5)).
+
+The Jordan–Wigner string `jwString N i` is the product of `σ^z` over all modes
+below `i`. Since `σ^z = diag(1, -1)` is diagonal in the computational basis,
+each factor acts on `basisVec c` by the parity sign `(-1)^{c j}`, and the whole
+string acts as the scalar
+
+  `∏_{j < i} (if c j = 0 then 1 else -1)`,
+
+the fermion-parity sign of the occupied modes below `i`. This is the source of
+the fermion signs in the hopping matrix elements.
+
+Tracked in Issue #4130. Reference: Tasaki, *Physics and Mathematics of Quantum
+Many-Body Systems*, 1st edition, §11.2, pp. 382-384.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Quantum
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] [LinearOrder Λ]
+
+/-! ## Diagonal Pauli-`Z` action -/
+
+/-- Diagonal entry of `σ^z`: `pauliZ m m = 1` if `m = 0` and `-1` otherwise. -/
+private theorem pauliZ_diag (m : Fin 2) :
+    pauliZ m m = if m = 0 then (1 : ℂ) else -1 := by
+  fin_cases m <;> simp [pauliZ]
+
+/-- Off-diagonal entries of `σ^z` vanish: `pauliZ k m = 0` for `k ≠ m`. -/
+private theorem pauliZ_offdiag {k m : Fin 2} (h : k ≠ m) : pauliZ k m = 0 := by
+  fin_cases k <;> fin_cases m <;> simp_all [pauliZ]
+
+omit [LinearOrder Λ] in
+/-- A single `σ^z` at mode `j` acts on a computational basis state by the
+parity sign at `j`: `σ^z_j · |c⟩ = (-1)^{c j} |c⟩`. -/
+theorem onSite_pauliZ_mulVec_basisVec (j : Λ) (c : Λ → Fin 2) :
+    (onSite j pauliZ).mulVec (basisVec c) =
+      (if c j = 0 then (1 : ℂ) else -1) • basisVec c := by
+  rw [onSite_mulVec_basisVec]
+  funext τ
+  rw [Fintype.sum_eq_single (c j) (fun k hk => by
+    rw [pauliZ_offdiag hk, zero_mul])]
+  rw [Function.update_eq_self, pauliZ_diag]
+  simp only [Pi.smul_apply, smul_eq_mul]
+
+/-! ## Diagonal action of a commuting product on a basis state -/
+
+omit [LinearOrder Λ] in
+/-- If every factor of a non-commutative product acts on `basisVec c` by a
+scalar, the product acts by the product of those scalars. -/
+private theorem noncommProd_mulVec_basisVec_of_diagonal
+    {ι : Type*} (s : Finset ι) (f : ι → ManyBodyOp Λ)
+    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
+    (c : Λ → Fin 2) (g : ι → ℂ)
+    (hf : ∀ a ∈ s, (f a).mulVec (basisVec c) = g a • basisVec c) :
+    (s.noncommProd f hcomm).mulVec (basisVec c) =
+      (∏ a ∈ s, g a) • basisVec c := by
+  classical
+  induction s using Finset.induction_on with
+  | empty =>
+    simp only [Finset.noncommProd_empty, Finset.prod_empty, one_smul,
+      Matrix.one_mulVec]
+  | @insert a t hat ih =>
+    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
+      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
+    have hf_t : ∀ b ∈ t, (f b).mulVec (basisVec c) = g b • basisVec c :=
+      fun b hb => hf b (Finset.mem_insert_of_mem hb)
+    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat, Finset.prod_insert hat,
+      ← Matrix.mulVec_mulVec, ih hcomm_t hf_t, Matrix.mulVec_smul,
+      hf a (Finset.mem_insert_self a t), smul_smul, mul_comm]
+
+/-! ## Diagonal action of the Jordan–Wigner string -/
+
+/-- The Jordan–Wigner string acts on a computational basis state by the
+fermion-parity sign of the occupied modes below `i`:
+`jwString N i · |c⟩ = (∏_{j < i} (-1)^{c j}) |c⟩`. -/
+theorem jwString_mulVec_basisVec (N : ℕ) (i : Fin (N + 1))
+    (c : Fin (N + 1) → Fin 2) :
+    (jwString N i).mulVec (basisVec c) =
+      (∏ j ∈ (Finset.univ : Finset (Fin (N + 1))).filter (fun j => j.val < i.val),
+        (if c j = 0 then (1 : ℂ) else -1)) • basisVec c := by
+  unfold jwString
+  exact noncommProd_mulVec_basisVec_of_diagonal _ _ _ c _
+    (fun j _ => onSite_pauliZ_mulVec_basisVec j c)
+
+end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2652,6 +2652,13 @@ fermion mode acting on `ℂ²` with computational basis
 | `hubbardHardcoreBasisState_inner` | orthonormality: `⟨Φ_{x,σ} \| Φ_{x',σ'}⟩ = 1` iff their configurations coincide, else `0` | `Fermion/JordanWigner/Hubbard/HardcoreBasis.lean` |
 | `hubbardHardcoreBasisState_self_inner` | each basis state is normalised (self-overlap `1`) | `Fermion/JordanWigner/Hubbard/HardcoreBasis.lean` |
 
+#### Jordan–Wigner string action on basis states (Tasaki §11.2 infrastructure)
+
+| Lean name | Statement | File |
+|---|---|---|
+| `onSite_pauliZ_mulVec_basisVec` | `σ^z_j · \|c⟩ = (-1)^{c j} \|c⟩` (single `σ^z` acts by the parity sign at `j`) | `Fermion/JordanWigner/StringBasisVecAction.lean` |
+| `jwString_mulVec_basisVec` | `jwString N i · \|c⟩ = (∏_{j<i} (-1)^{c j}) \|c⟩` (the JW string acts by the fermion-parity sign of the occupied modes below `i`) | `Fermion/JordanWigner/StringBasisVecAction.lean` |
+
 #### Span of the one-hole hard-core sector (Tasaki §11.2, footnote 8)
 
 | Lean name | Statement | File |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4936,6 +4936,34 @@ pp.~381--388).
 \end{itemize}
 
 %======================================================================
+\subsection{Jordan--Wigner string action on basis states (Tasaki §11.2)}
+\label{subsec:jwstring-basisvec}
+%======================================================================
+
+\noindent\textbf{Statement.}
+The Jordan--Wigner string \(\hat J_i := \prod_{j<i}\sigma^z_j\) is diagonal in
+the computational basis, since \(\sigma^z = \operatorname{diag}(1,-1)\). On a
+basis state \(|c\rangle\) each factor contributes the parity sign
+\((-1)^{c_j}\), so
+\[
+  \hat J_i\,|c\rangle = \Bigl(\prod_{j<i}(-1)^{c_j}\Bigr)\,|c\rangle,
+\]
+the fermion-parity sign of the modes occupied below \(i\). This is the origin
+of the fermion signs in the hopping matrix elements (11.2.4)/(11.2.5), and is
+the foundation for computing the action of \(\hat c_i\), \(\hat c_i^\dagger\) on
+basis states.
+
+\medskip
+\noindent\textbf{Lean declarations}
+(file \texttt{Fermion/JordanWigner/StringBasisVecAction.lean}):
+\begin{itemize}
+  \item \texttt{onSite\_pauliZ\_mulVec\_basisVec}:
+    \(\sigma^z_j|c\rangle = (-1)^{c_j}|c\rangle\).
+  \item \texttt{jwString\_mulVec\_basisVec}:
+    \(\hat J_i|c\rangle = \bigl(\prod_{j<i}(-1)^{c_j}\bigr)|c\rangle\).
+\end{itemize}
+
+%======================================================================
 \subsection{Span of the one-hole hard-core sector (Tasaki §11.2, footnote 8)}
 \label{subsec:hubbard-hardcore-span}
 %======================================================================


### PR DESCRIPTION
Tracked in #4130.

Foundational Jordan–Wigner infrastructure for the Tasaki §11.2 hopping matrix
elements (11.2.4)/(11.2.5): the diagonal action of the JW string on
computational basis states, where the fermion signs originate.

## Summary

Add `Fermion/JordanWigner/StringBasisVecAction.lean`:

- `onSite_pauliZ_mulVec_basisVec` — `σ^z_j · |c⟩ = (-1)^{c j} |c⟩` (a single
  `σ^z` acts by the parity sign at `j`, since `σ^z = diag(1,-1)`).
- `noncommProd_mulVec_basisVec_of_diagonal` (private) — if every factor of a
  `noncommProd` acts on `|c⟩` by a scalar, the product acts by the product of
  the scalars (induction over the finset).
- `jwString_mulVec_basisVec` — `jwString N i · |c⟩ = (∏_{j<i} (-1)^{c j}) |c⟩`,
  the fermion-parity sign of the occupied modes below `i`.

This is introduced in book order as the prerequisite for the next §11.2 step
(the action 11.2.4 and matrix elements 11.2.5), not deferred.

## Verification

- `lake env lean LatticeSystem/Fermion/JordanWigner/StringBasisVecAction.lean`
- `lake build LatticeSystem.Fermion.JordanWigner.StringBasisVecAction`
- `lake env lean LatticeSystem/Fermion/JordanWigner.lean`
- `lake env lean LatticeSystem.lean`
- `git diff --check`
- `cd tex && latexmk -g -pdf proof-guide.tex` (warning-free; pdfLaTeX, no
  TEXMF overrides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
