### PR TITLE
Add single hopping-term action on computational basis states - #4130

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -1,6 +1,7 @@
 import LatticeSystem.Fermion.JordanWigner.String
 import LatticeSystem.Fermion.JordanWigner.StringBasisVecAction
 import LatticeSystem.Fermion.JordanWigner.AnnihilationCreationBasisVec
+import LatticeSystem.Fermion.JordanWigner.HopBasisVec
 import LatticeSystem.Fermion.JordanWigner.Operators
 import LatticeSystem.Fermion.JordanWigner.CAR
 import LatticeSystem.Fermion.JordanWigner.CAR.CrossSiteOfNe

--- a/LatticeSystem/Fermion/JordanWigner/HopBasisVec.lean
+++ b/LatticeSystem/Fermion/JordanWigner/HopBasisVec.lean
@@ -1,0 +1,46 @@
+import LatticeSystem.Fermion.JordanWigner.AnnihilationCreationBasisVec
+
+/-!
+# Action of a single hopping term on computational basis states
+
+Composing the single-mode annihilation/creation actions
+(`fermionMultiAnnihilation_mulVec_basisVec`,
+`fermionMultiCreation_mulVec_basisVec`), this file computes the action of a
+single hopping term `c†_p c_q` on a computational basis state `basisVec c`, the
+final operator-level ingredient for the Tasaki §11.2 hopping matrix elements
+(eq. (11.2.4)/(11.2.5)).
+
+The term `c†_p c_q` first annihilates an electron at mode `q` (requiring
+`c q = 1`) and then creates one at mode `p` (requiring the intermediate
+configuration to be empty at `p`). The result is the hopped basis state
+`|c with q ↦ 0, p ↦ 1⟩` weighted by the product of the two Jordan–Wigner string
+signs, and `0` otherwise.
+
+Tracked in Issue #4130. Reference: Tasaki, *Physics and Mathematics of Quantum
+Many-Body Systems*, 1st edition, §11.2, pp. 382-384.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Quantum
+
+/-- Action of a single hopping term `c†_p c_q` on a computational basis state:
+the electron hops from `q` to `p` when `q` is occupied and the intermediate
+configuration is empty at `p`, picking up the product of the two Jordan–Wigner
+string signs; otherwise the result is `0`. -/
+theorem fermionMultiCreation_mul_Annihilation_mulVec_basisVec
+    (M : ℕ) (p q : Fin (M + 1)) (c : Fin (M + 1) → Fin 2) :
+    (fermionMultiCreation M p * fermionMultiAnnihilation M q).mulVec (basisVec c) =
+      if c q = 1 ∧ (Function.update c q 0) p = 0 then
+        (jwSign M q c * jwSign M p (Function.update c q 0)) •
+          basisVec (Function.update (Function.update c q 0) p 1)
+      else 0 := by
+  rw [← Matrix.mulVec_mulVec, fermionMultiAnnihilation_mulVec_basisVec]
+  by_cases hq : c q = 1
+  · rw [if_pos hq, Matrix.mulVec_smul, fermionMultiCreation_mulVec_basisVec]
+    by_cases hp : (Function.update c q 0) p = 0
+    · rw [if_pos hp, if_pos ⟨hq, hp⟩, smul_smul]
+    · rw [if_neg hp, smul_zero, if_neg (fun h => hp h.2)]
+  · rw [if_neg hq, Matrix.mulVec_zero, if_neg (fun h => hq h.1)]
+
+end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2661,6 +2661,7 @@ fermion mode acting on `ℂ²` with computational basis
 | `jwSign N j c` | the JW string sign `∏_{k<j} (-1)^{c k}` of a configuration | `Fermion/JordanWigner/AnnihilationCreationBasisVec.lean` |
 | `fermionMultiAnnihilation_mulVec_basisVec` | `c_j \|c⟩ = jwSign N j c • \|c with j↦0⟩` if `c j = 1`, else `0` | `Fermion/JordanWigner/AnnihilationCreationBasisVec.lean` |
 | `fermionMultiCreation_mulVec_basisVec` | `c†_j \|c⟩ = jwSign N j c • \|c with j↦1⟩` if `c j = 0`, else `0` | `Fermion/JordanWigner/AnnihilationCreationBasisVec.lean` |
+| `fermionMultiCreation_mul_Annihilation_mulVec_basisVec` | a single hop `c†_p c_q \|c⟩` = `(jwSign·jwSign) • \|c with q↦0, p↦1⟩` if `c q = 1` and the intermediate config is empty at `p`, else `0` | `Fermion/JordanWigner/HopBasisVec.lean` |
 
 #### Span of the one-hole hard-core sector (Tasaki §11.2, footnote 8)
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4981,6 +4981,24 @@ site-\(j\) occupation, the single-mode operators act on a basis state by
 \texttt{fermionMultiCreation\_mulVec\_basisVec} in
 \texttt{Fermion/JordanWigner/AnnihilationCreationBasisVec.lean}.)
 
+\medskip
+\noindent\textbf{A single hopping term.}
+Composing the two, the hopping term \(\hat c_p^\dagger \hat c_q\) moves the
+electron from \(q\) to \(p\):
+\[
+  \hat c_p^\dagger \hat c_q\,|c\rangle =
+    \begin{cases}
+      \varepsilon_q(c)\,\varepsilon_p(c^{q\mapsto0})\,
+        |c^{q\mapsto0,\,p\mapsto1}\rangle
+        & c_q = 1 \text{ and } (c^{q\mapsto0})_p = 0,\\
+      0 & \text{otherwise.}
+    \end{cases}
+\]
+(\texttt{fermionMultiCreation\_mul\_Annihilation\_mulVec\_basisVec} in
+\texttt{Fermion/JordanWigner/HopBasisVec.lean}.) This is the operator-level
+content of (11.2.4); the fermion signs \(\varepsilon\) combine into the
+sign of the hopping matrix element (11.2.5).
+
 %======================================================================
 \subsection{Span of the one-hole hard-core sector (Tasaki §11.2, footnote 8)}
 \label{subsec:hubbard-hardcore-span}


### PR DESCRIPTION
Tracked in #4130.

Action of a single hopping term `c†_p c_q` on a computational basis state, composing the single-mode actions (#4137). Final operator-level ingredient for the Tasaki §11.2 matrix elements (11.2.4)/(11.2.5).

## Summary

Add `Fermion/JordanWigner/HopBasisVec.lean`:

- `fermionMultiCreation_mul_Annihilation_mulVec_basisVec`: `c†_p c_q |c⟩ = (jwSign M q c * jwSign M p (update c q 0)) • |c with q↦0, p↦1⟩` if `c q = 1` and `(update c q 0) p = 0`, else `0`. Proof composes the annihilation lemma (push `mulVec` through the resulting scalar/if) and the creation lemma, combining the two string signs via `smul_smul`.

This is the operator content of (11.2.4); the two JW signs combine into the matrix-element sign (11.2.5).

## Verification

- `lake env lean .../HopBasisVec.lean`
- `lake build LatticeSystem.Fermion.JordanWigner.HopBasisVec`
- `lake env lean LatticeSystem.lean`
- `git diff --check`
- `cd tex && latexmk -g -pdf proof-guide.tex` (warning-free; pdfLaTeX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
