### PR TITLE
Add operator hop action on a one-hole basis state - #4130

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -35,6 +35,7 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreProjection
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreBasis
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreSpan
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HopConfig
+import LatticeSystem.Fermion.JordanWigner.Hubbard.HopAction
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonian
 import LatticeSystem.Fermion.JordanWigner.Hubbard.DoubleOccupancyProjection
 import LatticeSystem.Fermion.JordanWigner.Hubbard.DoubleOccupancyCommute

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HopAction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HopAction.lean
@@ -1,0 +1,72 @@
+import LatticeSystem.Fermion.JordanWigner.Hubbard.HopConfig
+import LatticeSystem.Fermion.JordanWigner.HopBasisVec
+
+/-!
+# Operator-level action of a hopping term on a one-hole basis state
+
+This file assembles the operator content of Tasaki eq. (11.2.4): the action of
+a single spinful hopping term `c†_{(x,s)} c_{(y,s)}` — creating at the hole
+site `x` and annihilating at an occupied site `y` — on the one-hole hard-core
+basis state `|Φ_{x,σ}⟩`. Combining the basis-state hop computation
+(`fermionMultiCreation_mul_Annihilation_mulVec_basisVec`) with the hop
+configuration identity (`hubbardOneHoleConfig_hop`), the result is the moved
+basis state `|Φ_{y, σ_{y→x}}⟩` weighted by the product of the two
+Jordan–Wigner string signs.
+
+The scalar coefficient here is the honest computational-basis fermion sign
+`jwSign · jwSign`; this is the operator-level fact in the sign-free `basisVec`
+convention. (Tasaki's uniform `-t_{x,y}` of (11.2.5) arises in his ordered
+creation-operator basis (11.2.3); recovering it is the next layer.)
+
+Tracked in Issue #4130. Reference: Tasaki, *Physics and Mathematics of Quantum
+Many-Body Systems*, 1st edition, §11.2, eq. (11.2.4), pp. 383-384.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Quantum
+
+/-- A `Fin 2` value that is not `0` is `1`. -/
+private theorem fin_two_ne_zero {v : Fin 2} (h : v ≠ 0) : v = 1 := by
+  have h2 := v.isLt
+  exact Fin.ext (by have : v.val ≠ 0 := fun hv => h (Fin.ext hv); omega)
+
+/-- The one-hole configuration is empty on both orbitals at the hole site. -/
+private theorem hubbardOneHoleConfig_hole_zero
+    (N : ℕ) (x : Fin (N + 1)) (σ : Fin (N + 1) → Bool) (s : Fin 2) :
+    hubbardOneHoleConfig N x σ (spinfulIndex N x s) = 0 := by
+  by_cases h : s = 0
+  · subst h; rw [hubbardOneHoleConfig_apply_up, if_pos rfl]
+  · obtain rfl : s = 1 := fin_two_ne_zero h
+    rw [hubbardOneHoleConfig_apply_down, if_pos rfl]
+
+/-- Operator content of (11.2.4): the hole-filling hopping term
+`c†_{(x,s)} c_{(y,s)}` (create at the hole `x`, annihilate at the occupied site
+`y` of spin `s`) sends `|Φ_{x,σ}⟩` to the moved basis state
+`|Φ_{y, σ_{y→x}}⟩` weighted by the product of the two Jordan–Wigner string
+signs. The hypothesis `hs` records that the `s`-orbital at `y` is occupied. -/
+theorem hubbardHop_mulVec_hardcoreBasisState
+    (N : ℕ) (x y : Fin (N + 1)) (σ : Fin (N + 1) → Bool) (s : Fin 2)
+    (hxy : x ≠ y)
+    (hs : hubbardOneHoleConfig N x σ (spinfulIndex N y s) = 1) :
+    (fermionMultiCreation (2 * N + 1) (spinfulIndex N x s) *
+        fermionMultiAnnihilation (2 * N + 1) (spinfulIndex N y s)).mulVec
+        (hubbardHardcoreBasisState N x σ) =
+      (jwSign (2 * N + 1) (spinfulIndex N y s) (hubbardOneHoleConfig N x σ) *
+          jwSign (2 * N + 1) (spinfulIndex N x s)
+            (Function.update (hubbardOneHoleConfig N x σ)
+              (spinfulIndex N y s) 0)) •
+        hubbardHardcoreBasisState N y (hubbardSpinMove N σ x y) := by
+  unfold hubbardHardcoreBasisState
+  rw [fermionMultiCreation_mul_Annihilation_mulVec_basisVec]
+  have hpq : spinfulIndex N x s ≠ spinfulIndex N y s := by
+    intro h
+    have hv := congrArg Fin.val h
+    simp only [spinfulIndex] at hv
+    exact hxy (Fin.ext (by omega))
+  have hp0 : (Function.update (hubbardOneHoleConfig N x σ)
+      (spinfulIndex N y s) 0) (spinfulIndex N x s) = 0 := by
+    rw [Function.update_of_ne hpq, hubbardOneHoleConfig_hole_zero]
+  rw [if_pos ⟨hs, hp0⟩, hubbardOneHoleConfig_hop N x y σ s hxy hs]
+
+end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2680,6 +2680,7 @@ fermion mode acting on `ℂ²` with computational basis
 |---|---|---|
 | `hubbardSpinMove N σ x y` | `σ_{y→x}`: `σ` with the spin at `x` set to `σ y` (the electron moved from `y` to the hole `x`) | `Fermion/JordanWigner/Hubbard/HopConfig.lean` |
 | `hubbardOneHoleConfig_hop` | filling the hole `x` with an electron of spin `s` hopped from `y` turns the configuration of `\|Φ_{x,σ}⟩` into that of `\|Φ_{y, σ_{y→x}}⟩` | `Fermion/JordanWigner/Hubbard/HopConfig.lean` |
+| `hubbardHop_mulVec_hardcoreBasisState` | operator content of (11.2.4): `c†_{(x,s)} c_{(y,s)} \|Φ_{x,σ}⟩ = (jwSign·jwSign) • \|Φ_{y, σ_{y→x}}⟩` (create at hole `x`, annihilate at occupied `y`) | `Fermion/JordanWigner/Hubbard/HopAction.lean` |
 
 #### Hubbard effective Hamiltonian on the hard-core sector (Tasaki §11.2)
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5011,6 +5011,23 @@ to be the spin of the electron at \(y\). (\texttt{hubbardSpinMove},
 \texttt{hubbardOneHoleConfig\_hop} in
 \texttt{Fermion/JordanWigner/Hubbard/HopConfig.lean}.)
 
+\medskip
+\noindent\textbf{Operator action of the hopping term (11.2.4).}
+Assembling the configuration identity with the basis-state hop computation, the
+hole-filling hopping term acts on a one-hole basis state by
+\[
+  \hat c^\dagger_{(x,s)}\,\hat c_{(y,s)}\,|\Phi_{x,\sigma}\rangle
+    = \varepsilon_{(y,s)}(c_{x,\sigma})\,
+      \varepsilon_{(x,s)}\!\bigl(c_{x,\sigma}^{(y,s)\mapsto0}\bigr)\,
+      |\Phi_{y,\sigma_{y\to x}}\rangle,
+\]
+when the \(s\)-orbital at \(y\) is occupied (and \(x\neq y\)). The scalar is the
+honest computational-basis fermion sign in the sign-free \(\mathtt{basisVec}\)
+convention; Tasaki's uniform \(-t_{x,y}\) of (11.2.5) arises in his ordered
+creation-operator basis (11.2.3), recovered in a later layer.
+(\texttt{hubbardHop\_mulVec\_hardcoreBasisState} in
+\texttt{Fermion/JordanWigner/Hubbard/HopAction.lean}.)
+
 %======================================================================
 \subsection{Span of the one-hole hard-core sector (Tasaki §11.2, footnote 8)}
 \label{subsec:hubbard-hardcore-span}


### PR DESCRIPTION
Tracked in #4130.

Operator content of Tasaki eq. (11.2.4): the action of the hole-filling hopping term on a one-hole basis state.

## Summary

Add `Fermion/JordanWigner/Hubbard/HopAction.lean`:

- `hubbardHop_mulVec_hardcoreBasisState` — for `x ≠ y` and the `s`-orbital at `y` occupied: `(c†_{(x,s)} c_{(y,s)}) |Φ_{x,σ}⟩ = (jwSign (spinfulIndex y s) c * jwSign (spinfulIndex x s) (update c (spinfulIndex y s) 0)) • |Φ_{y, hubbardSpinMove σ x y}⟩`. Combines the composite hop (#4138) with the hop config identity (#4139); the intermediate config is empty at the hole orbital `spinfulIndex x s` because `x` is the hole.

## Design note (sign convention / next layer)

The scalar coefficient is the honest computational-basis fermion sign `jwSign·jwSign` in the sign-free `basisVec` convention. Tasaki (11.2.5) states a UNIFORM `-t_{x,y}`, which arises in his ordered creation-operator basis (11.2.3); in the `basisVec` basis the coefficient is config-dependent `(-1)^(electrons between x,y)`. Recovering the uniform `-t` (needed for the downstream Perron-Frobenius `≤ 0` off-diagonal property) is the next layer: a Tasaki-ordered / signed basis state. This PR provides the faithful operator action that layer will consume.

## Verification

- `lake env lean .../HopAction.lean`; `lake build ...HopAction`; `lake env lean LatticeSystem.lean`
- `git diff --check`; `cd tex && latexmk -g -pdf proof-guide.tex` (warning-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
