### PR TITLE
Add per-term hop matrix element between one-hole basis states - #4130

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -36,6 +36,7 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreBasis
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreSpan
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HopConfig
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HopAction
+import LatticeSystem.Fermion.JordanWigner.Hubbard.HopMatrixElement
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonian
 import LatticeSystem.Fermion.JordanWigner.Hubbard.DoubleOccupancyProjection
 import LatticeSystem.Fermion.JordanWigner.Hubbard.DoubleOccupancyCommute

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HopMatrixElement.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HopMatrixElement.lean
@@ -1,0 +1,61 @@
+import LatticeSystem.Fermion.JordanWigner.Hubbard.HopAction
+
+/-!
+# Matrix element of a single hopping term between one-hole basis states
+
+This file computes the (real bilinear) matrix element of a single hole-filling
+hopping term `c†_{(x,s)} c_{(y,s)}` between two one-hole hard-core basis
+states, the per-term content of Tasaki eq. (11.2.5). Combining the operator
+hop action (`hubbardHop_mulVec_hardcoreBasisState`) with the orthonormality of
+the basis states (`hubbardHardcoreBasisState_inner`), the matrix element is the
+Jordan–Wigner sign product times the indicator that the target spin
+configuration equals the moved configuration `σ_{y→x}`.
+
+The scalar prefactor is the honest computational-basis fermion sign in the
+sign-free `basisVec` convention; the uniform `-t_{x,y}` of (11.2.5) requires the
+ordered creation-operator basis (11.2.3) and is assembled in a later layer.
+
+Tracked in Issue #4130. Reference: Tasaki, *Physics and Mathematics of Quantum
+Many-Body Systems*, 1st edition, §11.2, eq. (11.2.5), p. 384.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Quantum
+
+/-- Matrix element of the hole-filling hopping term `c†_{(x,s)} c_{(y,s)}`
+between one-hole basis states: it is the Jordan–Wigner sign product times the
+indicator that the target configuration `|Φ_{y,τ}⟩` is the moved configuration
+`|Φ_{y, σ_{y→x}}⟩`. This is the per-term content of (11.2.5); the off-diagonal
+support is exactly `τ = σ_{y→x}`. -/
+theorem hubbardHopTerm_inner_hardcoreBasisState
+    (N : ℕ) (x y : Fin (N + 1)) (σ τ : Fin (N + 1) → Bool) (s : Fin 2)
+    (hxy : x ≠ y)
+    (hs : hubbardOneHoleConfig N x σ (spinfulIndex N y s) = 1) :
+    (∑ w : Fin (2 * N + 2) → Fin 2,
+        hubbardHardcoreBasisState N y τ w *
+          (fermionMultiCreation (2 * N + 1) (spinfulIndex N x s) *
+              fermionMultiAnnihilation (2 * N + 1) (spinfulIndex N y s)).mulVec
+            (hubbardHardcoreBasisState N x σ) w) =
+      (jwSign (2 * N + 1) (spinfulIndex N y s) (hubbardOneHoleConfig N x σ) *
+          jwSign (2 * N + 1) (spinfulIndex N x s)
+            (Function.update (hubbardOneHoleConfig N x σ)
+              (spinfulIndex N y s) 0)) *
+        (if hubbardOneHoleConfig N y (hubbardSpinMove N σ x y) =
+            hubbardOneHoleConfig N y τ then 1 else 0) := by
+  set coeff :=
+    jwSign (2 * N + 1) (spinfulIndex N y s) (hubbardOneHoleConfig N x σ) *
+      jwSign (2 * N + 1) (spinfulIndex N x s)
+        (Function.update (hubbardOneHoleConfig N x σ) (spinfulIndex N y s) 0)
+    with hcoeff
+  rw [hubbardHop_mulVec_hardcoreBasisState N x y σ s hxy hs]
+  simp only [Pi.smul_apply, smul_eq_mul]
+  rw [Finset.sum_congr rfl (fun w _ =>
+    show hubbardHardcoreBasisState N y τ w *
+        (coeff * hubbardHardcoreBasisState N y (hubbardSpinMove N σ x y) w) =
+      coeff * (hubbardHardcoreBasisState N y τ w *
+        hubbardHardcoreBasisState N y (hubbardSpinMove N σ x y) w) from by ring),
+    ← Finset.mul_sum,
+    hubbardHardcoreBasisState_inner N y y τ (hubbardSpinMove N σ x y)]
+
+end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2681,6 +2681,7 @@ fermion mode acting on `ℂ²` with computational basis
 | `hubbardSpinMove N σ x y` | `σ_{y→x}`: `σ` with the spin at `x` set to `σ y` (the electron moved from `y` to the hole `x`) | `Fermion/JordanWigner/Hubbard/HopConfig.lean` |
 | `hubbardOneHoleConfig_hop` | filling the hole `x` with an electron of spin `s` hopped from `y` turns the configuration of `\|Φ_{x,σ}⟩` into that of `\|Φ_{y, σ_{y→x}}⟩` | `Fermion/JordanWigner/Hubbard/HopConfig.lean` |
 | `hubbardHop_mulVec_hardcoreBasisState` | operator content of (11.2.4): `c†_{(x,s)} c_{(y,s)} \|Φ_{x,σ}⟩ = (jwSign·jwSign) • \|Φ_{y, σ_{y→x}}⟩` (create at hole `x`, annihilate at occupied `y`) | `Fermion/JordanWigner/Hubbard/HopAction.lean` |
+| `hubbardHopTerm_inner_hardcoreBasisState` | per-term content of (11.2.5): the matrix element `⟨Φ_{y,τ}\| c†_{(x,s)} c_{(y,s)} \|Φ_{x,σ}⟩` is the JW sign product times the indicator `τ = σ_{y→x}` | `Fermion/JordanWigner/Hubbard/HopMatrixElement.lean` |
 
 #### Hubbard effective Hamiltonian on the hard-core sector (Tasaki §11.2)
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5028,6 +5028,21 @@ creation-operator basis (11.2.3), recovered in a later layer.
 (\texttt{hubbardHop\_mulVec\_hardcoreBasisState} in
 \texttt{Fermion/JordanWigner/Hubbard/HopAction.lean}.)
 
+\medskip
+\noindent\textbf{Per-term matrix element (11.2.5).}
+Pairing with another one-hole basis state and using orthonormality, the matrix
+element of the hopping term between basis states is the sign product times the
+indicator that the target is the moved configuration:
+\[
+  \langle \Phi_{y,\tau} |\, \hat c^\dagger_{(x,s)}\hat c_{(y,s)}\,|
+    \Phi_{x,\sigma}\rangle
+    = \varepsilon_{(y,s)}\,\varepsilon_{(x,s)}\,
+      [\,\tau = \sigma_{y\to x}\,].
+\]
+The off-diagonal support is exactly \(\tau = \sigma_{y\to x}\), matching the
+structure of (11.2.5). (\texttt{hubbardHopTerm\_inner\_hardcoreBasisState} in
+\texttt{Fermion/JordanWigner/Hubbard/HopMatrixElement.lean}.)
+
 %======================================================================
 \subsection{Span of the one-hole hard-core sector (Tasaki §11.2, footnote 8)}
 \label{subsec:hubbard-hardcore-span}


### PR DESCRIPTION
Tracked in #4130.

Per-term content of Tasaki eq. (11.2.5): the matrix element of a single hole-filling hopping term between one-hole basis states.

## Summary

Add `Fermion/JordanWigner/Hubbard/HopMatrixElement.lean`:

- `hubbardHopTerm_inner_hardcoreBasisState` — for `x ≠ y` and the `s`-orbital at `y` occupied: `∑_w |Φ_{y,τ}⟩_w · (c†_{(x,s)} c_{(y,s)} |Φ_{x,σ}⟩)_w = (jwSign·jwSign) · [σ_{y→x}-config = τ-config]`. Combines `hubbardHop_mulVec_hardcoreBasisState` (#4140) with `hubbardHardcoreBasisState_inner` (orthonormality), pulling the scalar out of the sum.

The off-diagonal support is exactly `τ = σ_{y→x}`, matching the structure of (11.2.5). The scalar prefactor is the honest computational-basis fermion sign in the sign-free `basisVec` convention; the uniform `-t_{x,y}` of (11.2.5) requires the ordered creation-operator basis (11.2.3) — the next layer (see Issue #4130 design note).

## Verification

- `lake env lean .../HopMatrixElement.lean`; `lake build ...HopMatrixElement`; `lake env lean LatticeSystem.lean`
- `git diff --check`; `cd tex && latexmk -g -pdf proof-guide.tex` (warning-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
