### PR TITLE
Add creation operator on the Jordan-Wigner vacuum - #4130

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -1,6 +1,7 @@
 import LatticeSystem.Fermion.JordanWigner.String
 import LatticeSystem.Fermion.JordanWigner.StringBasisVecAction
 import LatticeSystem.Fermion.JordanWigner.AnnihilationCreationBasisVec
+import LatticeSystem.Fermion.JordanWigner.VacuumCreationBasisVec
 import LatticeSystem.Fermion.JordanWigner.HopBasisVec
 import LatticeSystem.Fermion.JordanWigner.Operators
 import LatticeSystem.Fermion.JordanWigner.CAR

--- a/LatticeSystem/Fermion/JordanWigner/VacuumCreationBasisVec.lean
+++ b/LatticeSystem/Fermion/JordanWigner/VacuumCreationBasisVec.lean
@@ -1,0 +1,44 @@
+import LatticeSystem.Fermion.JordanWigner.AnnihilationCreationBasisVec
+import LatticeSystem.Fermion.JordanWigner.Number
+
+/-!
+# Creation operators on the Jordan–Wigner vacuum
+
+This file records the base case of building computational basis states from the
+vacuum by creation operators, the starting point for the ordered
+creation-operator construction of the Tasaki §11.2 basis states (11.2.3).
+
+The Jordan–Wigner vacuum is the all-empty configuration `basisVec (fun _ => 0)`.
+Since no mode below `j` is occupied, the string sign `jwSign N j` of the vacuum
+is `1`, so a single creation operator simply produces the single-electron basis
+state at `j`:
+
+  `c†_j |vac⟩ = |single electron at j⟩`.
+
+Tracked in Issue #4130. Reference: Tasaki, *Physics and Mathematics of Quantum
+Many-Body Systems*, 1st edition, §11.2, eq. (11.2.3).
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Quantum
+
+/-- The Jordan–Wigner string sign of the all-empty configuration is `1`:
+no mode contributes a `-1`. -/
+theorem jwSign_zero_config (N : ℕ) (j : Fin (N + 1)) :
+    jwSign N j (fun _ : Fin (N + 1) => (0 : Fin 2)) = 1 := by
+  unfold jwSign
+  exact Finset.prod_eq_one (fun k _ => rfl)
+
+/-- A single creation operator on the vacuum produces the single-electron
+computational basis state at `j`: `c†_j |vac⟩ = |0…0, j ↦ 1⟩`. The string sign
+is `1` because the vacuum is empty below `j`. -/
+theorem fermionMultiCreation_mulVec_vacuum_eq_basisVec
+    (N : ℕ) (j : Fin (N + 1)) :
+    (fermionMultiCreation N j).mulVec (fermionMultiVacuum N) =
+      basisVec (Function.update (fun _ : Fin (N + 1) => (0 : Fin 2)) j 1) := by
+  unfold fermionMultiVacuum
+  rw [fermionMultiCreation_mulVec_basisVec, if_pos rfl, jwSign_zero_config,
+    one_smul]
+
+end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2662,6 +2662,7 @@ fermion mode acting on `ℂ²` with computational basis
 | `fermionMultiAnnihilation_mulVec_basisVec` | `c_j \|c⟩ = jwSign N j c • \|c with j↦0⟩` if `c j = 1`, else `0` | `Fermion/JordanWigner/AnnihilationCreationBasisVec.lean` |
 | `fermionMultiCreation_mulVec_basisVec` | `c†_j \|c⟩ = jwSign N j c • \|c with j↦1⟩` if `c j = 0`, else `0` | `Fermion/JordanWigner/AnnihilationCreationBasisVec.lean` |
 | `fermionMultiCreation_mul_Annihilation_mulVec_basisVec` | a single hop `c†_p c_q \|c⟩` = `(jwSign·jwSign) • \|c with q↦0, p↦1⟩` if `c q = 1` and the intermediate config is empty at `p`, else `0` | `Fermion/JordanWigner/HopBasisVec.lean` |
+| `jwSign_zero_config` / `fermionMultiCreation_mulVec_vacuum_eq_basisVec` | the string sign of the vacuum is `1`; `c†_j \|vac⟩ = \|single electron at j⟩` (base case for the ordered-`c†` Tasaki basis (11.2.3)) | `Fermion/JordanWigner/VacuumCreationBasisVec.lean` |
 
 #### Span of the one-hole hard-core sector (Tasaki §11.2, footnote 8)
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4980,6 +4980,12 @@ site-\(j\) occupation, the single-mode operators act on a basis state by
 (\texttt{jwSign}, \texttt{fermionMultiAnnihilation\_mulVec\_basisVec},
 \texttt{fermionMultiCreation\_mulVec\_basisVec} in
 \texttt{Fermion/JordanWigner/AnnihilationCreationBasisVec.lean}.)
+The base case on the vacuum (all-empty, string sign \(1\)) is
+\(\hat c_j^\dagger|\mathrm{vac}\rangle = |0\dots0,\,j\mapsto1\rangle\)
+(\texttt{jwSign\_zero\_config},
+\texttt{fermionMultiCreation\_mulVec\_vacuum\_eq\_basisVec} in
+\texttt{Fermion/JordanWigner/VacuumCreationBasisVec.lean}), the starting point
+for the ordered creation-operator construction of the (11.2.3) basis states.
 
 \medskip
 \noindent\textbf{A single hopping term.}


### PR DESCRIPTION
Tracked in #4130.

Base case of building computational basis states from the vacuum by creation operators — the starting point for the ordered creation-operator (Tasaki) basis (11.2.3), needed to recover the uniform `-t` of (11.2.5).

## Summary

Add `Fermion/JordanWigner/VacuumCreationBasisVec.lean`:

- `jwSign_zero_config` — the JW string sign of the all-empty configuration is `1`.
- `fermionMultiCreation_mulVec_vacuum_eq_basisVec` — `c†_j |vac⟩ = basisVec(update (fun _ => 0) j 1)`, the single-electron state at `j`. From `fermionMultiCreation_mulVec_basisVec` (#4137): the vacuum is empty at `j` (creation succeeds) and empty below `j` (string sign `1`).

This is correct JW algebra independent of the eventual basis-sign design choice (options A/B/C in the Issue #4130 design note); it is the fold base case for the ordered creation-operator construction.

## Verification

- `lake env lean .../VacuumCreationBasisVec.lean`; `lake build ...VacuumCreationBasisVec`; `lake env lean LatticeSystem.lean`
- `git diff --check`; `cd tex && latexmk -g -pdf proof-guide.tex` (warning-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
