### PR TITLE
Refactor: share spinfulIndex helpers + build-speed checkpoint - #4130

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -120,7 +120,7 @@ expansion):
 | `Hubbard/EffectiveHamiltonian.lean` | effective Hamiltonian `Ĥ_eff = P̂_hc H P̂_hc` + `U→∞` reduction (Tasaki §11.2) |
 | `Hubbard/TasakiBasis.lean` | Tasaki ordered-creation basis `\|Φ_{x,σ}⟩ = ε • basisVec` + orthonormality (Tasaki §11.2 eq. (11.2.3)) |
 | `Hubbard/TasakiHopAction.lean` | uniform-sign hole-filling action `ĉ†_{x,s}ĉ_{z,s}\|Φ_{x,σ}⟩ = -\|Φ_{z,σ_{z→x}}⟩` + sign `ε = (-1)^x` (Tasaki §11.2 eq. (11.2.4)) |
-| `Hubbard/EffectiveHamiltonianMatrix.lean` | off-diagonal effective-Hamiltonian matrix element `⟨Φ_{y,τ}\|Ĥ_eff\|Φ_{x,σ}⟩ = -t_{x,y}·[τ=σ_{y→x}]` (Tasaki §11.2 eq. (11.2.5)) |
+| `Hubbard/EffectiveHamiltonianMatrix.lean` | off-diagonal matrix element `⟨Φ_{y,τ}\|Ĥ_eff\|Φ_{x,σ}⟩ = -t_{x,y}·[τ=σ_{y→x}]` (Tasaki §11.2 eq. (11.2.5)) |
 | `Hubbard/DoubleOccupancyProjection.lean` | site-`i` `Commute n_↑ n_↓` + idempotent product |
 | `Hubbard/DoubleOccupancyCommute.lean` | cross-site `Commute (n_↑(i)·n_↓(i)) (n_↑(j)·n_↓(j))` |
 | `Hubbard/SpinfulNumberHermitian.lean` | `n_↑(i)`, `n_↓(i)`, `n_↑(i)·n_↓(i)` Hermitian |

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard.lean
@@ -47,6 +47,29 @@ def spinfulIndex (N : ℕ) (i : Fin (N + 1)) (σ : Fin 2) :
     have hσ : σ.val < 2 := σ.isLt
     omega⟩
 
+/-- Joint injectivity of `spinfulIndex` in the site and the spin label:
+`spinfulIndex N a r = spinfulIndex N b s` iff `a = b` and `r = s`. -/
+theorem spinfulIndex_eq_iff (N : ℕ) (a b : Fin (N + 1)) (r s : Fin 2) :
+    spinfulIndex N a r = spinfulIndex N b s ↔ a = b ∧ r = s := by
+  constructor
+  · intro h
+    have hv : 2 * a.val + r.val = 2 * b.val + s.val := by
+      have := congrArg Fin.val h; simpa [spinfulIndex] using this
+    have := r.isLt; have := s.isLt
+    exact ⟨Fin.ext (by omega), Fin.ext (by omega)⟩
+  · rintro ⟨rfl, rfl⟩; rfl
+
+/-- Every spinful Jordan–Wigner index decomposes as `spinfulIndex N a r` for a
+unique site `a` and spin label `r`. -/
+theorem exists_spinfulIndex (N : ℕ) (k : Fin (2 * N + 2)) :
+    ∃ (a : Fin (N + 1)) (r : Fin 2), k = spinfulIndex N a r := by
+  have hk := k.isLt
+  refine ⟨⟨k.val / 2, (Nat.div_lt_iff_lt_mul (by norm_num)).mpr (by omega)⟩,
+    ⟨k.val % 2, Nat.mod_lt _ (by norm_num)⟩, ?_⟩
+  apply Fin.ext
+  simp only [spinfulIndex]
+  omega
+
 /-- Spin-up annihilation operator at spinful site `i`:
 the JW annihilation at the underlying single-species position
 `2 * i`. -/

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/EffectiveHamiltonianMatrix.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/EffectiveHamiltonianMatrix.lean
@@ -68,17 +68,6 @@ private theorem hardcore_proj_apply (N : ℕ) (y : Fin (N + 1)) (τ : Fin (N + 1
 
 /-! ## Auxiliary facts about one-hole configurations -/
 
-/-- Joint injectivity of `spinfulIndex`. -/
-private theorem spinful_eq_iff' (N : ℕ) (a b : Fin (N + 1)) (r s : Fin 2) :
-    spinfulIndex N a r = spinfulIndex N b s ↔ a = b ∧ r = s := by
-  constructor
-  · intro h
-    have hv : 2 * a.val + r.val = 2 * b.val + s.val := by
-      have := congrArg Fin.val h; simpa [spinfulIndex] using this
-    have := r.isLt; have := s.isLt
-    exact ⟨Fin.ext (by omega), Fin.ext (by omega)⟩
-  · rintro ⟨rfl, rfl⟩; rfl
-
 /-- A `Fin 2` value is `0` or `1`. -/
 private theorem fin_two_cases (r : Fin 2) : r = 0 ∨ r = 1 := by
   rcases r with ⟨rv, hrv⟩; interval_cases rv
@@ -129,7 +118,7 @@ private theorem hop_config_forces (N : ℕ) (x y i j : Fin (N + 1))
     · rw [if_pos h1] at e1; exact absurd e1 one_ne_zero
     · rw [if_neg h1] at e1
       by_cases h2 : spinfulIndex N y (if σ y then 0 else 1) = spinfulIndex N j s
-      · obtain ⟨hyj, hsy⟩ := (spinful_eq_iff' N y j _ s).mp h2
+      · obtain ⟨hyj, hsy⟩ := (spinfulIndex_eq_iff N y j _ s).mp h2
         exact ⟨hyj.symm, hsy.symm⟩
       · rw [if_neg h2] at e1; exact absurd e1 one_ne_zero
   obtain ⟨hjy', hsy'⟩ := hjy
@@ -139,7 +128,7 @@ private theorem hop_config_forces (N : ℕ) (x y i j : Fin (N + 1))
   -- The annihilation orbital `(j, s) = (y, σ_y)` differs from `(x, τ_x)` (x ≠ y).
   have hxne : ¬ spinfulIndex N x (if τ x then 0 else 1) = spinfulIndex N j s := by
     rw [hjy', hsy']
-    intro h; exact hxy ((spinful_eq_iff' N x y _ _).mp h).1
+    intro h; exact hxy ((spinfulIndex_eq_iff N x y _ _).mp h).1
   rw [if_neg hxne,
     show hubbardOneHoleConfig N x σ (spinfulIndex N x (if τ x then 0 else 1)) = 0 from
       by rcases fin_two_cases (if τ x then (0 : Fin 2) else 1) with h | h <;>
@@ -147,7 +136,7 @@ private theorem hop_config_forces (N : ℕ) (x y i j : Fin (N + 1))
           rw [hubbardOneHoleConfig_apply_down, if_pos rfl]],
     oneHole_occupied N y τ x hxy] at e2
   by_cases h3 : spinfulIndex N x (if τ x then 0 else 1) = spinfulIndex N i s
-  · obtain ⟨hxi, _⟩ := (spinful_eq_iff' N x i _ s).mp h3
+  · obtain ⟨hxi, _⟩ := (spinfulIndex_eq_iff N x i _ s).mp h3
     exact ⟨hxi.symm, hjy', hsy'⟩
   · rw [if_neg h3] at e2; exact absurd e2.symm one_ne_zero
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreSpan.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreSpan.lean
@@ -38,17 +38,6 @@ def IsOneHoleHardcoreConfig (N : ℕ) (c : Fin (2 * N + 2) → Fin 2) : Prop :=
     ∃! i : Fin (N + 1),
       c (spinfulIndex N i 0) = 0 ∧ c (spinfulIndex N i 1) = 0
 
-/-- Every spinful JW index decomposes as a `spinfulIndex`: `k = spinfulIndex N
-⟨k/2, _⟩ ⟨k%2, _⟩`. -/
-private theorem exists_spinfulIndex_eq (N : ℕ) (k : Fin (2 * N + 2)) :
-    ∃ (i : Fin (N + 1)) (s : Fin 2), k = spinfulIndex N i s := by
-  have hk := k.isLt
-  refine ⟨⟨k.val / 2, (Nat.div_lt_iff_lt_mul (by norm_num)).mpr (by omega)⟩,
-    ⟨k.val % 2, Nat.mod_lt _ (by norm_num)⟩, ?_⟩
-  apply Fin.ext
-  simp only [spinfulIndex]
-  omega
-
 /-- A `Fin 2` value that is not `1` is `0`. -/
 private theorem fin_two_eq_zero_of_ne_one {v : Fin 2} (h : v ≠ 1) : v = 0 := by
   have h2 := v.isLt
@@ -97,7 +86,7 @@ theorem exists_eq_hubbardOneHoleConfig_of_isOneHoleHardcore
   obtain ⟨hnd, x, hx_hole, hx_uniq⟩ := hc
   refine ⟨x, fun i => decide (c (spinfulIndex N i 0) = 1), ?_⟩
   funext k
-  obtain ⟨i, s, rfl⟩ := exists_spinfulIndex_eq N k
+  obtain ⟨i, s, rfl⟩ := exists_spinfulIndex N k
   by_cases hs : s = 0
   · -- up orbital
     subst hs

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HopConfig.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HopConfig.lean
@@ -25,29 +25,6 @@ def hubbardSpinMove (N : ℕ) (σ : Fin (N + 1) → Bool) (x y : Fin (N + 1)) :
     Fin (N + 1) → Bool :=
   Function.update σ x (σ y)
 
-/-- Every spinful JW index decomposes as a `spinfulIndex`. -/
-private theorem exists_spinfulIndex_eq (N : ℕ) (k : Fin (2 * N + 2)) :
-    ∃ (a : Fin (N + 1)) (r : Fin 2), k = spinfulIndex N a r := by
-  have hk := k.isLt
-  refine ⟨⟨k.val / 2, (Nat.div_lt_iff_lt_mul (by norm_num)).mpr (by omega)⟩,
-    ⟨k.val % 2, Nat.mod_lt _ (by norm_num)⟩, ?_⟩
-  apply Fin.ext
-  simp only [spinfulIndex]
-  omega
-
-/-- Injectivity of `spinfulIndex` jointly in the site and the spin label. -/
-private theorem spinfulIndex_eq_iff (N : ℕ) (a a' : Fin (N + 1)) (r r' : Fin 2) :
-    spinfulIndex N a r = spinfulIndex N a' r' ↔ a = a' ∧ r = r' := by
-  constructor
-  · intro h
-    have hv : 2 * a.val + r.val = 2 * a'.val + r'.val := by
-      have := congrArg Fin.val h
-      simpa [spinfulIndex] using this
-    have hr := r.isLt
-    have hr' := r'.isLt
-    exact ⟨Fin.ext (by omega), Fin.ext (by omega)⟩
-  · rintro ⟨rfl, rfl⟩; rfl
-
 /-- A `Fin 2` value that is not `0` is `1`. -/
 private theorem fin_two_ne_zero {v : Fin 2} (h : v ≠ 0) : v = 1 := by
   have h2 := v.isLt
@@ -79,7 +56,7 @@ theorem hubbardOneHoleConfig_hop
       refine ⟨fun hσ => ?_, fun h => absurd h (by decide)⟩
       rw [hσ] at hs; simp at hs
   funext k
-  obtain ⟨a, r, rfl⟩ := exists_spinfulIndex_eq N k
+  obtain ⟨a, r, rfl⟩ := exists_spinfulIndex N k
   simp only [Function.update_apply, spinfulIndex_eq_iff]
   -- LHS = if a=x ∧ r=s then 1 else if a=y ∧ r=s then 0
   --       else hubbardOneHoleConfig N x σ (spinfulIndex N a r)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiBasis.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiBasis.lean
@@ -115,26 +115,6 @@ noncomputable def hubbardTasakiBasisState (N : ℕ) (x : Fin (N + 1))
 
 /-! ## Auxiliary facts about `tasakiIndexList` -/
 
-/-- Joint injectivity of `spinfulIndex` in the site and the spin label. -/
-private theorem spinfulIndex_inj (N : ℕ) {a a' : Fin (N + 1)} {r r' : Fin 2}
-    (h : spinfulIndex N a r = spinfulIndex N a' r') : a = a' ∧ r = r' := by
-  have hv : 2 * a.val + r.val = 2 * a'.val + r'.val := by
-    have := congrArg Fin.val h
-    simpa [spinfulIndex] using this
-  have hr := r.isLt
-  have hr' := r'.isLt
-  exact ⟨Fin.ext (by omega), Fin.ext (by omega)⟩
-
-/-- Every spinful index decomposes as `spinfulIndex N a r`. -/
-private theorem exists_spinfulIndex (N : ℕ) (k : Fin (2 * N + 2)) :
-    ∃ (a : Fin (N + 1)) (r : Fin 2), k = spinfulIndex N a r := by
-  have hk := k.isLt
-  refine ⟨⟨k.val / 2, (Nat.div_lt_iff_lt_mul (by norm_num)).mpr (by omega)⟩,
-    ⟨k.val % 2, Nat.mod_lt _ (by norm_num)⟩, ?_⟩
-  apply Fin.ext
-  simp only [spinfulIndex]
-  omega
-
 /-- Membership in `tasakiIndexList`: `spinfulIndex N a r` is occupied exactly
 when `r` is the orbital selected by the spin `τ a`. -/
 theorem mem_tasakiIndexList_iff (N : ℕ) (τ : Fin (N + 1) → Bool)
@@ -144,7 +124,7 @@ theorem mem_tasakiIndexList_iff (N : ℕ) (τ : Fin (N + 1) → Bool)
   rw [List.mem_map]
   constructor
   · rintro ⟨s, _, hs⟩
-    obtain ⟨rfl, hr⟩ := spinfulIndex_inj N hs
+    obtain ⟨rfl, hr⟩ := (spinfulIndex_eq_iff N _ _ _ _).mp hs
     exact hr.symm
   · intro hr
     exact ⟨a, List.mem_finRange a, by rw [hr]⟩
@@ -199,12 +179,12 @@ private theorem update_occupationOf_eq_oneHoleConfig (N : ℕ) (x : Fin (N + 1))
     rcases hr2 with rfl | rfl
     · rw [if_pos rfl, hubbardOneHoleConfig_apply_up, if_pos rfl]
     · have hne : spinfulIndex N a 1 ≠ spinfulIndex N a 0 := fun h =>
-        absurd (spinfulIndex_inj N h).2 (by decide)
+        absurd ((spinfulIndex_eq_iff N _ _ _ _).mp h).2 (by decide)
       rw [if_neg hne, hubbardOneHoleConfig_apply_down, if_pos rfl]
       decide
   · -- Away from the hole: `σ̄_a = σ_a`, and the hole-orbital update never fires.
     have hne : spinfulIndex N a r ≠ spinfulIndex N x 0 := fun h =>
-      hax (spinfulIndex_inj N h).1
+      hax ((spinfulIndex_eq_iff N _ _ _ _).mp h).1
     have hax' : a.val ≠ x.val := fun h => hax (Fin.ext h)
     rw [if_neg hne, Function.update_of_ne hax]
     rcases hr2 with rfl | rfl

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiHopAction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiHopAction.lean
@@ -156,17 +156,6 @@ private theorem config_exp_eq_card (N : ℕ) (b : ℕ) (holes : Finset (Fin (N +
 
 /-! ## Auxiliary identities for the one-hole configuration -/
 
-/-- Joint injectivity of `spinfulIndex`. -/
-private theorem spinful_eq_iff (N : ℕ) (t z : Fin (N + 1)) (r s : Fin 2) :
-    spinfulIndex N t r = spinfulIndex N z s ↔ t = z ∧ r = s := by
-  constructor
-  · intro h
-    have hv : 2 * t.val + r.val = 2 * z.val + s.val := by
-      have := congrArg Fin.val h; simpa [spinfulIndex] using this
-    have := r.isLt; have := s.isLt
-    exact ⟨Fin.ext (by omega), Fin.ext (by omega)⟩
-  · rintro ⟨rfl, rfl⟩; rfl
-
 /-- Occupation-value form of the one-hole configuration, expressed in the
 hole-set / orbital format consumed by `config_exp_eq_card`. -/
 private theorem onehole_hc (N : ℕ) (x : Fin (N + 1)) (σ : Fin (N + 1) → Bool)
@@ -276,7 +265,7 @@ theorem hop_jwSign_target (N : ℕ) (x z : Fin (N + 1)) (σ : Fin (N + 1) → Bo
       (fun t => if σ t then 0 else 1) _ (fun t r => by
         rw [Function.update_apply]
         by_cases hk : spinfulIndex N t r = spinfulIndex N z s
-        · obtain ⟨rfl, rfl⟩ := (spinful_eq_iff N t z r s).mp hk
+        · obtain ⟨rfl, rfl⟩ := (spinfulIndex_eq_iff N t z r s).mp hk
           simp [Finset.mem_insert, Finset.mem_singleton]
         · rw [if_neg hk, onehole_hc]
           by_cases htz : t = z

--- a/docs/index.md
+++ b/docs/index.md
@@ -2537,6 +2537,7 @@ fermion mode acting on `ℂ²` with computational basis
 | `fermionTotalNumber_mulVec_twoParticle` | `c_i† c_j† |vac⟩` is an `N̂`-eigenstate of eigenvalue 2 (Leibniz on the commutator gives `[N̂, c_i† c_j†] = 2 c_i† c_j†`) | `Fermion/JordanWigner.lean` |
 | `fermionTotalNumber_mulVec_eigenstate_of_commute` | generic charge-eigenstate helper: if `[N̂, X] = α X` and `N̂ v = 0` then `N̂ (X v) = α (X v)`; abstracts the single- and two-particle constructions | `Fermion/JordanWigner.lean` |
 | `spinfulIndex N i σ` | bijection `(i, σ : Fin 2) ↦ 2 * i + σ ∈ Fin (2*N+2)`, embedding two-species data into a single-species JW chain | `Fermion/JordanWigner.lean` |
+| `spinfulIndex_eq_iff`, `exists_spinfulIndex` | shared injectivity (`spinfulIndex N a r = spinfulIndex N b s ↔ a = b ∧ r = s`) and decomposition (`∃ a r, k = spinfulIndex N a r`) of the spinful index | `Fermion/JordanWigner.lean` |
 | `fermionUpAnnihilation`, `fermionDownAnnihilation`, `fermionUpCreation`, `fermionDownCreation` | spinful annihilation / creation operators as wrappers around the underlying single-species operators at `2i` (up) and `2i+1` (down) | `Fermion/JordanWigner.lean` |
 | `fermionUpNumber`, `fermionDownNumber` | spinful site-occupation numbers `n_{i,↑}`, `n_{i,↓}` | `Fermion/JordanWigner.lean` |
 | `hubbardOnSiteInteraction N U` | the on-site Hubbard interaction `H_int = U Σ_i n_{i,↑} · n_{i,↓}` | `Fermion/JordanWigner.lean` |


### PR DESCRIPTION
Tracked in #4130.

## Summary

Refactoring PR (20-PR cadence: last refactor was #4112, >20 feature PRs since).

Consolidates five duplicated **private** `spinfulIndex` injectivity / decomposition
helpers — `spinfulIndex_inj`, `spinful_eq_iff`, `spinful_eq_iff'`,
`spinfulIndex_eq_iff`, `exists_spinfulIndex(_eq)` — copied across
`TasakiBasis`, `TasakiHopAction`, `EffectiveHamiltonianMatrix`, `HopConfig`, and
`HardcoreSpan`, into two shared **public** lemmas next to `spinfulIndex` in
`Hubbard.lean`:

- `spinfulIndex_eq_iff` — `spinfulIndex N a r = spinfulIndex N b s ↔ a = b ∧ r = s`
- `exists_spinfulIndex` — `∃ a r, k = spinfulIndex N a r`

No new mathematical content (pre-existing helper proofs are merely consolidated),
so `tex/proof-guide.tex` is unchanged; `docs/index.md` records the two shared
lemmas.

## Build-speed evaluation

Warm `lake env lean` times of the §11.2 Tasaki tip files after the refactor:

| file | warm time |
|---|---|
| `TasakiBasis.lean` | 3.6s |
| `TasakiHopAction.lean` | 4.3s |
| `EffectiveHamiltonianMatrix.lean` | 3.7s |
| `HopConfig.lean` | 3.6s |
| `HardcoreSpan.lean` | 3.3s |

All build in <5s warm; **no module split needed**. Removing the ~5 duplicated
proofs is a minor build/maintenance win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
