### PR TITLE
Add SU(2) symmetry of the effective Hamiltonian - #4130

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -42,6 +42,7 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonian
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiBasis
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiHopAction
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonianMatrix
+import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonianSpinSymmetry
 import LatticeSystem.Fermion.JordanWigner.Hubbard.WeakNagaoka
 import LatticeSystem.Fermion.JordanWigner.Hubbard.DoubleOccupancyProjection
 import LatticeSystem.Fermion.JordanWigner.Hubbard.DoubleOccupancyCommute
@@ -123,6 +124,7 @@ expansion):
 | `Hubbard/TasakiHopAction.lean` | uniform-sign hole-filling action `ĉ†_{x,s}ĉ_{z,s}\|Φ_{x,σ}⟩ = -\|Φ_{z,σ_{z→x}}⟩` + sign `ε = (-1)^x` (Tasaki §11.2 eq. (11.2.4)) |
 | `Hubbard/EffectiveHamiltonianMatrix.lean` | off-diagonal matrix element `⟨Φ_{y,τ}\|Ĥ_eff\|Φ_{x,σ}⟩ = -t_{x,y}·[τ=σ_{y→x}]` (Tasaki §11.2 eq. (11.2.5)) |
 | `Hubbard/WeakNagaoka.lean` | Cauchy–Schwarz energy bound `⟨Φ_↑\|Ĥ_eff\|Φ_↑⟩ ≤ ⟨Φ\|Ĥ_eff\|Φ⟩` (Tasaki §11.2 eq. (11.2.9)) |
+| `Hubbard/EffectiveHamiltonianSpinSymmetry.lean` | SU(2) symmetry of the effective Hamiltonian `[Ĥ_eff, Ŝ^±_tot] = 0` (Tasaki §11.2, degeneracy backbone) |
 | `Hubbard/DoubleOccupancyProjection.lean` | site-`i` `Commute n_↑ n_↓` + idempotent product |
 | `Hubbard/DoubleOccupancyCommute.lean` | cross-site `Commute (n_↑(i)·n_↓(i)) (n_↑(j)·n_↓(j))` |
 | `Hubbard/SpinfulNumberHermitian.lean` | `n_↑(i)`, `n_↓(i)`, `n_↑(i)·n_↓(i)` Hermitian |

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean
@@ -1,0 +1,83 @@
+import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonian
+import LatticeSystem.Fermion.JordanWigner.Hubbard.SpinSymmetry
+
+/-!
+# SU(2) symmetry of the Hubbard effective Hamiltonian
+
+This file lifts the full SU(2) spin symmetry of the Hubbard Hamiltonian
+(`[Ĥ, Ŝ^±_tot] = 0`, Tasaki §9.3.3) to the one-hole effective Hamiltonian
+`Ĥ_eff = P̂_hc Ĥ P̂_hc` of §11.2. The key new ingredient is that the hard-core
+projection commutes with the total spin raising/lowering operators, because the
+spin operators preserve the no-double-occupancy subspace (each `Ŝ^+_tot` term
+`ĉ†_{k,↑} ĉ_{k,↓}` commutes with every double-occupancy operator
+`n_{i,↑} n_{i,↓}`).
+
+The SU(2) symmetry of `Ĥ_eff` is the structural reason behind the
+`(2 S_max + 1)`-fold degeneracy in the weak Nagaoka theorem (Theorem 11.5):
+applying `Ŝ^-_tot` to a ferromagnetic ground state produces the full spin
+multiplet of degenerate ground states.
+
+Tracked in Issue #4130. Reference: Tasaki, *Physics and Mathematics of Quantum
+Many-Body Systems*, 1st edition, §9.3.3 and §11.2.1, pp. 332, 384.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix
+
+/-! ## The spin operators commute with the hard-core projection -/
+
+/-- The total spin raising operator commutes with each same-site
+double-occupancy operator. -/
+theorem fermionTotalSpinPlus_commute_hubbardDoubleOccupancy (N : ℕ) (i : Fin (N + 1)) :
+    Commute (fermionTotalSpinPlus N) (hubbardDoubleOccupancy N i) := by
+  unfold fermionTotalSpinPlus hubbardDoubleOccupancy
+  apply Commute.sum_left
+  intro k _
+  exact fermionSpinPlusTerm_commute_interactionTerm N k i
+
+/-- The total spin raising operator commutes with each hard-core factor
+`1 - n_{i,↑} n_{i,↓}`. -/
+theorem fermionTotalSpinPlus_commute_hubbardHardcoreFactor (N : ℕ) (i : Fin (N + 1)) :
+    Commute (fermionTotalSpinPlus N) (hubbardHardcoreFactor N i) := by
+  unfold hubbardHardcoreFactor
+  exact (Commute.one_right _).sub_right
+    (fermionTotalSpinPlus_commute_hubbardDoubleOccupancy N i)
+
+/-- The total spin raising operator commutes with the hard-core projection
+`P̂_hc = ∏_i (1 - n_{i,↑} n_{i,↓})`: the spin operators preserve the
+no-double-occupancy subspace. -/
+theorem fermionTotalSpinPlus_commute_hubbardHardcoreProjection (N : ℕ) :
+    Commute (fermionTotalSpinPlus N) (hubbardHardcoreProjection N) := by
+  unfold hubbardHardcoreProjection
+  exact Finset.noncommProd_commute _ _ _ _
+    (fun i _ => fermionTotalSpinPlus_commute_hubbardHardcoreFactor N i)
+
+/-! ## SU(2) symmetry of the effective Hamiltonian -/
+
+/-- `[Ĥ_eff, Ŝ^+_tot] = 0`: the effective Hamiltonian inherits the SU(2)
+raising symmetry, since `Ŝ^+_tot` commutes with both `Ĥ` and the hard-core
+projection. -/
+theorem fermionTotalSpinPlus_commute_hubbardEffectiveHamiltonian
+    (N : ℕ) (t : Fin (N + 1) → Fin (N + 1) → ℂ) (U : ℂ) :
+    Commute (fermionTotalSpinPlus N) (hubbardEffectiveHamiltonian N t U) := by
+  unfold hubbardEffectiveHamiltonian
+  exact ((fermionTotalSpinPlus_commute_hubbardHardcoreProjection N).mul_right
+    (fermionTotalSpinPlus_commute_hubbardHamiltonian N t U)).mul_right
+    (fermionTotalSpinPlus_commute_hubbardHardcoreProjection N)
+
+/-- `[Ĥ_eff, Ŝ^-_tot] = 0`: derived from the raising version by taking adjoints,
+using that `Ĥ_eff` is Hermitian and `(Ŝ^+_tot)ᴴ = Ŝ^-_tot`. -/
+theorem fermionTotalSpinMinus_commute_hubbardEffectiveHamiltonian
+    (N : ℕ) (t : Fin (N + 1) → Fin (N + 1) → ℂ) (U : ℂ)
+    (hJ : ∀ i j, star (t i j) = t j i) (hU : star U = U) :
+    Commute (fermionTotalSpinMinus N) (hubbardEffectiveHamiltonian N t U) := by
+  have h_plus :=
+    (fermionTotalSpinPlus_commute_hubbardEffectiveHamiltonian N t U).eq
+  have h_He := hubbardEffectiveHamiltonian_isHermitian N hJ hU
+  have h_adj := congrArg Matrix.conjTranspose h_plus
+  simp only [Matrix.conjTranspose_mul, fermionTotalSpinPlus_conjTranspose N,
+    h_He.eq] at h_adj
+  exact h_adj.symm
+
+end LatticeSystem.Fermion

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/SpinSymmetry.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/SpinSymmetry.lean
@@ -700,7 +700,7 @@ private theorem fermionDownNumber_mul_fermionDownAnnihilation_same (N : ℕ) (x 
 /-- Per-pair: $c^\dagger_{k,\uparrow} c_{k,\downarrow}$ commutes with
 $n_{x,\uparrow} n_{x,\downarrow}$.  Same-site ($k = x$): both products vanish by Pauli
 exclusion.  Different sites ($k \neq x$): all four constituent operators commute pairwise. -/
-private theorem fermionSpinPlusTerm_commute_interactionTerm
+theorem fermionSpinPlusTerm_commute_interactionTerm
     (N : ℕ) (k x : Fin (N + 1)) :
     Commute (fermionUpCreation N k * fermionDownAnnihilation N k)
             (fermionUpNumber N x * fermionDownNumber N x) := by

--- a/docs/index.md
+++ b/docs/index.md
@@ -2735,6 +2735,13 @@ fermion mode acting on `ℂ²` with computational basis
 | `tasakiQuadForm_ferro_le` | the Cauchy–Schwarz bound on the real quadratic form: `Q(Φ_↑) ≤ Q(Φ)` for `t ≥ 0` | `Fermion/JordanWigner/Hubbard/WeakNagaoka.lean` |
 | `hubbardWeakNagaoka_energy_bound` | eq. (11.2.9): `⟨Φ_↑\|Ĥ_eff\|Φ_↑⟩ ≤ ⟨Φ\|Ĥ_eff\|Φ⟩` (`t ≥ 0`, `t_{ii}=0`) — the ferromagnetic state is also a ground state | `Fermion/JordanWigner/Hubbard/WeakNagaoka.lean` |
 
+#### SU(2) symmetry of the effective Hamiltonian (Tasaki §11.2)
+
+| Lean name | Statement | File |
+|---|---|---|
+| `fermionTotalSpinPlus_commute_hubbardHardcoreProjection` | `Ŝ^+_tot` commutes with the hard-core projection `P̂_hc` (spin operators preserve the no-double-occupancy subspace) | `Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean` |
+| `fermionTotalSpinPlus_commute_hubbardEffectiveHamiltonian` / `fermionTotalSpinMinus_commute_hubbardEffectiveHamiltonian` | `[Ĥ_eff, Ŝ^±_tot] = 0` — the effective Hamiltonian inherits SU(2) symmetry (the backbone of the `(2S_max+1)`-degeneracy in Theorem 11.5) | `Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean` |
+
 | `hubbardKineticOnGraph N G J` | spinful Hubbard kinetic operator from a `SimpleGraph G` and edge weight `J` | `Fermion/JordanWigner.lean` |
 | `hubbardKineticOnGraph_commute_fermionTotalNumber` / `hubbardKineticOnGraph_isHermitian` | charge conservation always; Hermiticity for real `J` | `Fermion/JordanWigner.lean` |
 | `hubbardHamiltonianOnGraph N G J U` | full Hubbard Hamiltonian from a graph + on-site coupling | `Fermion/JordanWigner.lean` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5382,6 +5382,38 @@ corresponding term of \(|\Phi_\uparrow\rangle\) (whose quadratic form is
 \end{itemize}
 
 %======================================================================
+\subsection{SU(2) symmetry of the effective Hamiltonian (Tasaki §11.2)}
+\label{subsec:hubbard-effham-su2}
+%======================================================================
+
+\noindent\textbf{Statement.}
+The effective Hamiltonian inherits the full SU(2) spin symmetry of the Hubbard
+model: \([\hat H_{\rm eff}, \hat S^\pm_{\rm tot}] = 0\).
+
+\medskip
+\noindent\textbf{Proof.}
+Since \(\hat H_{\rm eff} = \hat P_{\rm hc}\hat H\hat P_{\rm hc}\) and
+\([\hat H, \hat S^+_{\rm tot}] = 0\) (Tasaki §9.3.3), it suffices that
+\(\hat S^+_{\rm tot}\) commutes with the hard-core projection. Each raising term
+\(\hat c^\dagger_{k,\uparrow}\hat c_{k,\downarrow}\) commutes with every
+double-occupancy operator \(n_{i,\uparrow}n_{i,\downarrow}\) (same site: both
+products vanish by Pauli exclusion; distinct sites: the constituents commute),
+hence with each hard-core factor \(1 - n_{i,\uparrow}n_{i,\downarrow}\), hence
+with their non-commutative product \(\hat P_{\rm hc}\). The lowering symmetry
+follows by taking adjoints, using that \(\hat H_{\rm eff}\) is Hermitian and
+\((\hat S^+_{\rm tot})^\dagger = \hat S^-_{\rm tot}\). This SU(2) symmetry is the
+structural reason for the \((2S_{\max}+1)\)-fold degeneracy of the weak Nagaoka
+ground states (Theorem 11.5): \(\hat S^-_{\rm tot}\) maps a ferromagnetic ground
+state to the full degenerate spin multiplet.
+
+\medskip
+\noindent\textbf{Lean declarations}
+(file \texttt{Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean}):
+\texttt{fermionTotalSpinPlus\_commute\_hubbardHardcoreProjection},
+\texttt{fermionTotalSpinPlus\_commute\_hubbardEffectiveHamiltonian},
+\texttt{fermionTotalSpinMinus\_commute\_hubbardEffectiveHamiltonian}.
+
+%======================================================================
 \subsection{Total-spin Casimir and Definition 11.1 (Tasaki §11.1.1)}
 \label{subsec:hubbard-saturated-ferro}
 %======================================================================


### PR DESCRIPTION
Tracked in #4130.

## Summary

Lifts the full SU(2) spin symmetry `[Ĥ, Ŝ^±_tot] = 0` (Tasaki §9.3.3) to the
one-hole **effective** Hamiltonian `Ĥ_eff = P̂_hc Ĥ P̂_hc` of §11.2:

```
[Ĥ_eff, Ŝ^+_tot] = 0,   [Ĥ_eff, Ŝ^-_tot] = 0.
```

The key new ingredient is that `Ŝ^+_tot` commutes with the **hard-core
projection** `P̂_hc`: each raising term `ĉ†_{k,↑} ĉ_{k,↓}` commutes with every
double-occupancy operator `n_{i,↑} n_{i,↓}` (same site: both products vanish by
Pauli exclusion; distinct sites: constituents commute), hence with each
hard-core factor `1 - n_{i,↑} n_{i,↓}` and with their non-commutative product.
The lowering version follows by adjoints (`Ĥ_eff` Hermitian,
`(Ŝ^+_tot)ᴴ = Ŝ^-_tot`).

This SU(2) symmetry is the structural reason for the `(2S_max+1)`-fold
degeneracy in the weak Nagaoka theorem (Theorem 11.5): `Ŝ^-_tot` maps a
ferromagnetic ground state to the full degenerate spin multiplet.

## Contents (`Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean`)

- `fermionTotalSpinPlus_commute_hubbardDoubleOccupancy` / `_hubbardHardcoreFactor`
  / `_hubbardHardcoreProjection`.
- `fermionTotalSpinPlus_commute_hubbardEffectiveHamiltonian` (`[Ĥ_eff, Ŝ⁺]=0`).
- `fermionTotalSpinMinus_commute_hubbardEffectiveHamiltonian` (`[Ĥ_eff, Ŝ⁻]=0`).

Also exposes the per-term commutator `fermionSpinPlusTerm_commute_interactionTerm`
in `SpinSymmetry.lean` (previously `private`). Axioms: standard 3, no `sorry`.

## References

H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer,
1st edition, §9.3.3 and §11.2.1, pp. 332, 384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
