### PR TITLE
Add total-spin conservation of the effective Hamiltonian - #4130

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean
@@ -1,5 +1,6 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonian
 import LatticeSystem.Fermion.JordanWigner.Hubbard.SpinSymmetry
+import LatticeSystem.Fermion.JordanWigner.Hubbard.SaturatedFerromagnetism
 
 /-!
 # SU(2) symmetry of the Hubbard effective Hamiltonian
@@ -79,5 +80,57 @@ theorem fermionTotalSpinMinus_commute_hubbardEffectiveHamiltonian
   simp only [Matrix.conjTranspose_mul, fermionTotalSpinPlus_conjTranspose N,
     h_He.eq] at h_adj
   exact h_adj.symm
+
+/-! ## Conservation of total spin -/
+
+/-- `Ŝ^z_tot` commutes with each same-site double-occupancy operator (all number
+operators commute). -/
+theorem fermionTotalSpinZ_commute_hubbardDoubleOccupancy (N : ℕ) (i : Fin (N + 1)) :
+    Commute (fermionTotalSpinZ N) (hubbardDoubleOccupancy N i) := by
+  unfold fermionTotalSpinZ hubbardDoubleOccupancy fermionTotalUpNumber
+    fermionTotalDownNumber fermionUpNumber fermionDownNumber
+  refine Commute.smul_left ?_ _
+  refine Commute.sub_left ?_ ?_ <;>
+    refine Commute.sum_left _ _ _ (fun k _ => ?_) <;>
+    exact (fermionMultiNumber_commute (2 * N + 1) _ (spinfulIndex N i 0)).mul_right
+      (fermionMultiNumber_commute (2 * N + 1) _ (spinfulIndex N i 1))
+
+/-- `Ŝ^z_tot` commutes with each hard-core factor. -/
+theorem fermionTotalSpinZ_commute_hubbardHardcoreFactor (N : ℕ) (i : Fin (N + 1)) :
+    Commute (fermionTotalSpinZ N) (hubbardHardcoreFactor N i) := by
+  unfold hubbardHardcoreFactor
+  exact (Commute.one_right _).sub_right
+    (fermionTotalSpinZ_commute_hubbardDoubleOccupancy N i)
+
+/-- `Ŝ^z_tot` commutes with the hard-core projection. -/
+theorem fermionTotalSpinZ_commute_hubbardHardcoreProjection (N : ℕ) :
+    Commute (fermionTotalSpinZ N) (hubbardHardcoreProjection N) := by
+  unfold hubbardHardcoreProjection
+  exact Finset.noncommProd_commute _ _ _ _
+    (fun i _ => fermionTotalSpinZ_commute_hubbardHardcoreFactor N i)
+
+/-- `[Ĥ_eff, Ŝ^z_tot] = 0`. -/
+theorem fermionTotalSpinZ_commute_hubbardEffectiveHamiltonian
+    (N : ℕ) (t : Fin (N + 1) → Fin (N + 1) → ℂ) (U : ℂ) :
+    Commute (fermionTotalSpinZ N) (hubbardEffectiveHamiltonian N t U) := by
+  unfold hubbardEffectiveHamiltonian
+  exact ((fermionTotalSpinZ_commute_hubbardHardcoreProjection N).mul_right
+    (fermionTotalSpinZ_commute_hubbardHamiltonian N t U)).mul_right
+    (fermionTotalSpinZ_commute_hubbardHardcoreProjection N)
+
+/-- `[Ĥ_eff, (Ŝ_tot)²] = 0`: the effective Hamiltonian conserves total spin, so
+its eigenspaces split into fixed-`S_tot` sectors. This is the conservation law
+underlying the `S_tot = S_max` statement of the weak Nagaoka theorem (11.5) and
+the per-sector Perron–Frobenius analysis of the full theorem (11.7). -/
+theorem fermionTotalSpinSquared_commute_hubbardEffectiveHamiltonian
+    (N : ℕ) (t : Fin (N + 1) → Fin (N + 1) → ℂ) (U : ℂ)
+    (hJ : ∀ i j, star (t i j) = t j i) (hU : star U = U) :
+    Commute (fermionTotalSpinSquared N) (hubbardEffectiveHamiltonian N t U) := by
+  unfold fermionTotalSpinSquared
+  have hz := fermionTotalSpinZ_commute_hubbardEffectiveHamiltonian N t U
+  refine Commute.add_left
+    ((fermionTotalSpinMinus_commute_hubbardEffectiveHamiltonian N t U hJ hU).mul_left
+      (fermionTotalSpinPlus_commute_hubbardEffectiveHamiltonian N t U)) ?_
+  exact hz.mul_left (hz.add_left (Commute.one_left _))
 
 end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2743,6 +2743,7 @@ fermion mode acting on `ℂ²` with computational basis
 |---|---|---|
 | `fermionTotalSpinPlus_commute_hubbardHardcoreProjection` | `Ŝ^+_tot` commutes with the hard-core projection `P̂_hc` (spin operators preserve the no-double-occupancy subspace) | `Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean` |
 | `fermionTotalSpinPlus_commute_hubbardEffectiveHamiltonian` / `fermionTotalSpinMinus_commute_hubbardEffectiveHamiltonian` | `[Ĥ_eff, Ŝ^±_tot] = 0` — the effective Hamiltonian inherits SU(2) symmetry (the backbone of the `(2S_max+1)`-degeneracy in Theorem 11.5) | `Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean` |
+| `fermionTotalSpinZ_commute_hubbardEffectiveHamiltonian` / `fermionTotalSpinSquared_commute_hubbardEffectiveHamiltonian` | `[Ĥ_eff, Ŝ^z_tot] = 0` and `[Ĥ_eff, (Ŝ_tot)²] = 0` — `Ĥ_eff` conserves total spin, so its eigenspaces split into fixed-`S_tot` sectors (Theorem 11.5 / 11.7) | `Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean` |
 
 | `hubbardKineticOnGraph N G J` | spinful Hubbard kinetic operator from a `SimpleGraph G` and edge weight `J` | `Fermion/JordanWigner.lean` |
 | `hubbardKineticOnGraph_commute_fermionTotalNumber` / `hubbardKineticOnGraph_isHermitian` | charge conservation always; Hermiticity for real `J` | `Fermion/JordanWigner.lean` |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5427,6 +5427,18 @@ state to the full degenerate spin multiplet.
 \texttt{fermionTotalSpinPlus\_commute\_hubbardEffectiveHamiltonian},
 \texttt{fermionTotalSpinMinus\_commute\_hubbardEffectiveHamiltonian}.
 
+\medskip
+\noindent\textbf{Conservation of total spin.}
+The same argument applied to \(\hat S^z_{\rm tot}\) (which commutes with every
+double-occupancy operator, all number operators commuting) gives
+\([\hat H_{\rm eff}, \hat S^z_{\rm tot}] = 0\), and combining with the
+raising/lowering versions yields \([\hat H_{\rm eff}, (\hat S_{\rm tot})^2] = 0\):
+the effective Hamiltonian conserves total spin, so its eigenspaces split into
+fixed-\(S_{\rm tot}\) sectors — the conservation law behind the
+\(S_{\rm tot} = S_{\max}\) statement of Theorem 11.5 and the per-sector
+Perron--Frobenius analysis of Theorem 11.7. (\texttt{fermionTotalSpinZ\_commute\_hubbardEffectiveHamiltonian},
+\texttt{fermionTotalSpinSquared\_commute\_hubbardEffectiveHamiltonian}.)
+
 %======================================================================
 \subsection{Total-spin Casimir and Definition 11.1 (Tasaki §11.1.1)}
 \label{subsec:hubbard-saturated-ferro}


### PR DESCRIPTION
Tracked in #4130.

## Summary

Extends the SU(2) symmetry of the effective Hamiltonian (#4149) to **total-spin
conservation**:

```
[Ĥ_eff, Ŝ^z_tot] = 0,    [Ĥ_eff, (Ŝ_tot)²] = 0.
```

`Ŝ^z_tot` commutes with each double-occupancy operator (all number operators
commute pairwise), hence with each hard-core factor, hence with `P̂_hc`, hence
with `P̂_hc Ĥ P̂_hc`. Combining `[Ĥ_eff, Ŝ^z_tot] = 0` with the raising/lowering
symmetries (#4149) gives `[Ĥ_eff, (Ŝ_tot)²] = 0`.

So the effective Hamiltonian conserves total spin: its eigenspaces split into
fixed-`S_tot` sectors — the conservation law behind the `S_tot = S_max` statement
of the weak Nagaoka theorem (11.5) and the per-sector Perron–Frobenius analysis
of the full theorem (11.7).

## Contents (added to `Fermion/JordanWigner/Hubbard/EffectiveHamiltonianSpinSymmetry.lean`)

- `fermionTotalSpinZ_commute_hubbardDoubleOccupancy` / `_hubbardHardcoreFactor`
  / `_hubbardHardcoreProjection` / `_hubbardEffectiveHamiltonian`.
- `fermionTotalSpinSquared_commute_hubbardEffectiveHamiltonian` (`[Ĥ_eff, (Ŝ_tot)²]=0`).

Axioms: standard 3, no `sorry`.

## References

H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer,
1st edition, §9.3.3 and §11.2, pp. 332, 384–385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
