### PR TITLE
Add Tasaki Theorem A.1 (Lie product formula) — #4205

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -18,6 +18,7 @@ import LatticeSystem.Math.HermitianMaxEqPF
 import LatticeSystem.Math.HermitianSpectrumShift
 import LatticeSystem.Math.HermitianMinEqOfShiftPF
 import LatticeSystem.Math.InvariantSubmoduleEigenvector
+import LatticeSystem.Math.TasakiAppendixA.LieProduct
 import LatticeSystem.Quantum.SpinS.DressedBareSubmatrixMinEqPF
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphAltPath
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphStructural

--- a/LatticeSystem/Math/TasakiAppendixA/LieProduct.lean
+++ b/LatticeSystem/Math/TasakiAppendixA/LieProduct.lean
@@ -1,0 +1,38 @@
+import Mathlib.Analysis.Normed.Algebra.MatrixExponential
+
+/-!
+# Tasaki Appendix A.2.2: the Lie product formula (Theorem A.1)
+
+The first numbered result of Tasaki's Mathematical Appendix.  For any (bounded) operators
+`Â`, `B̂` — here finite complex matrices `Matrix n n ℂ`, the operator algebra of a
+finite-volume quantum system — the exponential of a sum is the limit of symmetrically split
+products:
+`e^{Â+B̂} = lim_{N↑∞} (e^{Â/N} e^{B̂/N})^N`  (Tasaki eq. (A.2.21)).
+Mathlib provides the *commuting* case (`Matrix.exp_add_of_commute`); the general
+non-commuting Lie/Trotter formula for bounded operators is a standard but non-trivial
+real-analysis result (Tasaki's footnote: "nineteenth century mathematics"), not currently in
+mathlib.  Per the project's axiomatize-first policy it is recorded here as a documented axiom,
+to be discharged later; it is not on the critical path of any Chapter-11 proof.
+
+`NormedSpace.exp` is the matrix exponential used throughout the project (e.g. the Gibbs
+exponential `e^{-βH}`); `(N : ℂ)⁻¹ • A = A/N`.
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*
+(1st ed.), Appendix A.2.2, Theorem A.1, eq. (A.2.21), p. 465.
+-/
+
+namespace LatticeSystem.Math
+
+open Filter Topology
+
+/-- **Tasaki Theorem A.1 (Lie product formula), AXIOM.**  For finite complex matrices `A`, `B`,
+the exponential of the sum is the limit of the symmetric split product,
+`e^{A+B} = lim_{N↑∞} (e^{A/N} e^{B/N})^N`.  Specializes to `Matrix.exp_add_of_commute` when
+`A`, `B` commute; the general case is recorded as a documented axiom (standard analysis,
+deferred). -/
+axiom lieProductFormula {n : Type*} [Fintype n] [DecidableEq n] (A B : Matrix n n ℂ) :
+    Tendsto
+      (fun N : ℕ => (NormedSpace.exp ((N : ℂ)⁻¹ • A) * NormedSpace.exp ((N : ℂ)⁻¹ • B)) ^ N)
+      atTop (𝓝 (NormedSpace.exp (A + B)))
+
+end LatticeSystem.Math

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,7 @@ recommended replacement, and earliest-removal window.
 | P3 | CAR algebras, quasi-local C*-algebras, KMS states | Not started |
 | P4 | Thermodynamic limit, phase transitions | Not started |
 | P5 | Lattice QCD | Not started |
+| Appendix A (Tasaki Mathematical Appendices) | The book-order content after Chapter 11; foundations for the deferred Chapter-11 proof discharges (frustration-free A.9/A.10, limit A.11/A.12, Perron–Frobenius A.17/A.18 — the last largely already in `Math/PerronFrobenius*`/`CollatzWielandt*`). **In progress** (Issue #4205): **Theorem A.1 (Lie product formula)** `e^{A+B} = lim_N (e^{A/N}e^{B/N})^N` (`Math/TasakiAppendixA/LieProduct.lean`, `lieProductFormula`, documented axiom — mathlib has only the commuting case `Matrix.exp_add_of_commute`). Prove-first where mathlib supports (A.2.3 PSD cluster), axiomatize-first for the heavy analytic results, strict book order. |
 
 ## Formalized theorems
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -6660,6 +6660,29 @@ the class \texttt{LatticeWithSpacing}, the accessor
 \texttt{spacing\_fin\_succ}, \texttt{spacingOf\_fin\_succ}. Tests
 pinning these values are in \texttt{LatticeSystem/Tests/Scale.lean}.
 
+\section{Tasaki Appendix A: Mathematical Appendices}
+\label{sec:appendix-a}
+
+The book-order content following Chapter 11.  Many results here are the foundations of the
+deferred Chapter-11 proof discharges (frustration-free Hamiltonians A.9/A.10 for §11.3/§11.4,
+the strong-coupling limit A.11/A.12 for §11.5, and the Perron--Frobenius theorem A.17/A.18 for
+§11.2/§11.5, the last largely already formalised in \texttt{Math/PerronFrobenius*} and
+\texttt{Math/CollatzWielandt*}).  We prove results where mathlib supports them and axiomatize
+the heavy analytic ones, in strict book order (Issue \#4205).
+
+\medskip\noindent\textbf{Theorem A.1 (Lie product formula, axiomatized).}  For finite complex
+matrices $A,B$ --- the operator algebra of a finite-volume quantum system --- the exponential
+of a sum is the limit of the symmetric split product (Tasaki eq.~(A.2.21)),
+\[
+  e^{A+B} \;=\; \lim_{N\uparrow\infty}\bigl(e^{A/N}\,e^{B/N}\bigr)^{N}.
+\]
+Mathlib provides only the commuting case (\texttt{Matrix.exp\_add\_of\_commute}); the general
+non-commuting Lie/Trotter formula for bounded operators is a standard but non-trivial
+real-analysis result (Tasaki's footnote: ``nineteenth century mathematics''), recorded as the
+documented axiom \texttt{lieProductFormula} (\texttt{Math/TasakiAppendixA/LieProduct.lean}) via
+\texttt{NormedSpace.exp} and \texttt{Filter.Tendsto}.  It is not on the critical path of any
+Chapter-11 proof; to be discharged later.
+
 \section{Open items / TODO and axioms}
 \label{sec:open-items}
 %======================================================================


### PR DESCRIPTION
Tracked in #4205.

## Summary
**Tasaki Theorem A.1 (Lie product formula)** — the first numbered result of the Mathematical Appendix (Appendix A.2.2), the book-order content immediately after Chapter 11 (now complete).

## New file `Math/TasakiAppendixA/LieProduct.lean`
```lean
axiom lieProductFormula {n : Type*} [Fintype n] [DecidableEq n] (A B : Matrix n n ℂ) :
    Tendsto (fun N : ℕ => (NormedSpace.exp ((N : ℂ)⁻¹ • A) * NormedSpace.exp ((N : ℂ)⁻¹ • B)) ^ N)
      atTop (𝓝 (NormedSpace.exp (A + B)))
```
`e^{A+B} = lim_{N↑∞} (e^{A/N} e^{B/N})^N` (Tasaki eq. (A.2.21)), via `NormedSpace.exp` (the project's matrix exponential, as in the Gibbs exponential) and `Filter.Tendsto`.

## Why an axiom
Mathlib provides only the **commuting** case (`Matrix.exp_add_of_commute`). The general non-commuting Lie/Trotter product formula for bounded operators is a standard but non-trivial real-analysis result (Tasaki's footnote: "nineteenth century mathematics"), not in mathlib. Per the project's axiomatize-first policy it is a documented axiom, to be discharged later. It is **not** on the critical path of any Chapter-11 proof.

## Verification
- `lake build` green; wired into the `LatticeSystem` build root (3687 jobs).
- `#print axioms lieProductFormula`: clean (only `propext/Classical.choice/Quot.sound` + itself).
- `docs/index.md` Roadmap (new Appendix A row) + `tex/proof-guide.tex` (new Appendix A section, 245 pp) updated.

Next (#4205): A.2.3 PSD cluster (Lemma A.4/A.5/A.6 — these are mathlib-provable, not axioms), then frustration-free A.9/A.10, limit A.11/A.12, etc., in book order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
