### PR TITLE
Add Tasaki Lemmas A.4, A.5 (positive-semidefinite basics), proved — #4205

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -19,6 +19,7 @@ import LatticeSystem.Math.HermitianSpectrumShift
 import LatticeSystem.Math.HermitianMinEqOfShiftPF
 import LatticeSystem.Math.InvariantSubmoduleEigenvector
 import LatticeSystem.Math.TasakiAppendixA.LieProduct
+import LatticeSystem.Math.TasakiAppendixA.PosSemidefBasics
 import LatticeSystem.Quantum.SpinS.DressedBareSubmatrixMinEqPF
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphAltPath
 import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphStructural

--- a/LatticeSystem/Math/TasakiAppendixA/PosSemidefBasics.lean
+++ b/LatticeSystem/Math/TasakiAppendixA/PosSemidefBasics.lean
@@ -1,0 +1,40 @@
+import Mathlib.Analysis.Matrix.PosDef
+
+/-!
+# Tasaki Appendix A.2.3: positive-semidefinite operator basics (Lemmas A.4, A.5)
+
+Elementary facts about nonnegative (positive-semidefinite) self-adjoint operators from
+Tasaki's Mathematical Appendix, here for finite complex matrices `Matrix n n ℂ` (the operator
+algebra of a finite-volume quantum system).  Unlike the Lie product formula (Theorem A.1),
+these are available in mathlib, so they are **proved** (thin wrappers), not axiomatized:
+
+* **Lemma A.4**: a Hermitian operator is positive-semidefinite iff all its eigenvalues are
+  nonnegative.
+* **Lemma A.5**: the sum of two positive-semidefinite operators is positive-semidefinite.
+
+(Lemma A.6 — `B̂†B̂ ≥ 0` and the existence/uniqueness of the square root `Ĉ = √Â` — follows in a
+separate PR.)
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*
+(1st ed.), Appendix A.2.3, Lemmas A.4–A.5, pp. 467–468.
+-/
+
+namespace LatticeSystem.Math
+
+open Matrix
+open scoped ComplexOrder
+
+/-- **Tasaki Lemma A.4.**  A Hermitian matrix `A` is positive-semidefinite iff every
+eigenvalue is nonnegative. -/
+theorem posSemidef_iff_eigenvalues_nonneg {n : Type*} [Fintype n] [DecidableEq n]
+    {A : Matrix n n ℂ} (hA : A.IsHermitian) :
+    A.PosSemidef ↔ ∀ i, 0 ≤ hA.eigenvalues i :=
+  hA.posSemidef_iff_eigenvalues_nonneg
+
+/-- **Tasaki Lemma A.5.**  The sum of two positive-semidefinite matrices is
+positive-semidefinite (`⟨Φ|(Â+B̂)|Φ⟩ = ⟨Φ|Â|Φ⟩ + ⟨Φ|B̂|Φ⟩ ≥ 0`). -/
+theorem PosSemidef.add {n : Type*} {A B : Matrix n n ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef) : (A + B).PosSemidef :=
+  hA.add hB
+
+end LatticeSystem.Math

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ recommended replacement, and earliest-removal window.
 | P3 | CAR algebras, quasi-local C*-algebras, KMS states | Not started |
 | P4 | Thermodynamic limit, phase transitions | Not started |
 | P5 | Lattice QCD | Not started |
-| Appendix A (Tasaki Mathematical Appendices) | The book-order content after Chapter 11; foundations for the deferred Chapter-11 proof discharges (frustration-free A.9/A.10, limit A.11/A.12, Perron–Frobenius A.17/A.18 — the last largely already in `Math/PerronFrobenius*`/`CollatzWielandt*`). **In progress** (Issue #4205): **Theorem A.1 (Lie product formula)** `e^{A+B} = lim_N (e^{A/N}e^{B/N})^N` (`Math/TasakiAppendixA/LieProduct.lean`, `lieProductFormula`, documented axiom — mathlib has only the commuting case `Matrix.exp_add_of_commute`). Prove-first where mathlib supports (A.2.3 PSD cluster), axiomatize-first for the heavy analytic results, strict book order. |
+| Appendix A (Tasaki Mathematical Appendices) | The book-order content after Chapter 11; foundations for the deferred Chapter-11 proof discharges (frustration-free A.9/A.10, limit A.11/A.12, Perron–Frobenius A.17/A.18 — the last largely already in `Math/PerronFrobenius*`/`CollatzWielandt*`). **In progress** (Issue #4205): **Theorem A.1 (Lie product formula)** `e^{A+B} = lim_N (e^{A/N}e^{B/N})^N` (`Math/TasakiAppendixA/LieProduct.lean`, `lieProductFormula`, documented axiom — mathlib has only the commuting case `Matrix.exp_add_of_commute`); **Lemma A.4** (Hermitian `Â` is `≥0` iff all eigenvalues `≥0`) + **Lemma A.5** (`Â,B̂≥0 ⇒ Â+B̂≥0`) **proved** (axiom-free, `Math/TasakiAppendixA/PosSemidefBasics.lean`, mathlib `PosSemidef`). Prove-first where mathlib supports, axiomatize-first for the heavy analytic results, strict book order. |
 
 ## Formalized theorems
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -6683,6 +6683,16 @@ documented axiom \texttt{lieProductFormula} (\texttt{Math/TasakiAppendixA/LiePro
 \texttt{NormedSpace.exp} and \texttt{Filter.Tendsto}.  It is not on the critical path of any
 Chapter-11 proof; to be discharged later.
 
+\medskip\noindent\textbf{Lemmas A.4--A.5 (positive-semidefinite basics, proved).}  Unlike the
+Lie product formula, these are available in mathlib and are \emph{proved} (axiom-free, thin
+wrappers, \texttt{Math/TasakiAppendixA/PosSemidefBasics.lean}).  \textbf{Lemma A.4}
+(\texttt{posSemidef\_iff\_eigenvalues\_nonneg}): a Hermitian matrix is positive-semidefinite
+iff every eigenvalue is nonnegative.  \textbf{Lemma A.5} (\texttt{PosSemidef.add}): the sum of
+two positive-semidefinite matrices is positive-semidefinite,
+$\langle\Phi|(\hat A+\hat B)|\Phi\rangle=\langle\Phi|\hat A|\Phi\rangle+\langle\Phi|\hat B|\Phi\rangle\ge0$.
+(Lemma A.6 --- $\hat B^\dagger\hat B\ge0$ and the square root $\hat C=\sqrt{\hat A}$ --- follows
+separately.)
+
 \section{Open items / TODO and axioms}
 \label{sec:open-items}
 %======================================================================


### PR DESCRIPTION
Tracked in #4205.

## Summary
**Tasaki Lemmas A.4 and A.5** (Appendix A.2.3, positive-semidefinite operator basics). Unlike Theorem A.1 (Lie product), these are available in mathlib and are **proved** (axiom-free thin wrappers), not axiomatized.

## New file `Math/TasakiAppendixA/PosSemidefBasics.lean`
- **Lemma A.4** `posSemidef_iff_eigenvalues_nonneg`: a Hermitian matrix `A` is positive-semidefinite iff every eigenvalue is nonnegative (`Matrix.IsHermitian.posSemidef_iff_eigenvalues_nonneg`).
- **Lemma A.5** `PosSemidef.add`: `Â≥0, B̂≥0 ⇒ Â+B̂≥0` (`Matrix.PosSemidef.add`).

## Notes
- Both **axiom-free** (`#print axioms`: only `propext/Classical.choice/Quot.sound`).
- **Lemma A.6** (`B̂†B̂≥0` and the square root `Ĉ=√Â`) is deferred to a **separate PR** (kept whole — the square-root converse needs mathlib's `cfc`/CFC machinery, handled carefully on its own rather than split across PRs).
- `lake build` green, zero linter warnings; wired into the `LatticeSystem` build root (3688 jobs). `docs/index.md` Roadmap + `tex/proof-guide.tex` (246 pp) updated.

Next (#4205): Lemma A.6 (`B̂†B̂≥0` + square root), then Theorem A.7 (min-max), Lemma A.9/A.10 (frustration-free), A.11, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
