### PR TITLE
Refactor: extract gauge-reflection su(2) helpers + build-speed eval — #4205

### DIFF
--- a/LatticeSystem/Math/TasakiAppendixA/AngularLadder.lean
+++ b/LatticeSystem/Math/TasakiAppendixA/AngularLadder.lean
@@ -337,6 +337,36 @@ private theorem angLower_conjTranspose (h1 : J1.IsHermitian) (h2 : J2.IsHermitia
   rw [conjTranspose_sub, conjTranspose_smul, h1.eq, h2.eq, Complex.star_def, Complex.conj_I,
     neg_smul, sub_neg_eq_add]
 
+/-! ### Gauge reflection `(Ĵ⁽¹⁾, −Ĵ⁽²⁾, −Ĵ⁽³⁾)`
+
+The reflected triple satisfies the same `su(2)` relations with `M ↦ −M`; this is used to obtain the
+lowering results from the raising machinery (`AngularQuantization.lean`, `AngularMultiplet.lean`)
+without writing a separate mirror development. -/
+
+omit [DecidableEq d] in
+/-- Reflected `[Ĵ⁽¹⁾, −Ĵ⁽²⁾] = i(−Ĵ⁽³⁾)` from `[Ĵ⁽¹⁾, Ĵ⁽²⁾] = i Ĵ⁽³⁾`. -/
+theorem su2Reflect12 (h12 : J1 * J2 - J2 * J1 = Complex.I • J3) :
+    J1 * (-J2) - (-J2) * J1 = Complex.I • (-J3) := by
+  rw [show J1 * (-J2) - (-J2) * J1 = -(J1 * J2 - J2 * J1) by noncomm_ring, h12, smul_neg]
+
+omit [DecidableEq d] in
+/-- Reflected `[−Ĵ⁽²⁾, −Ĵ⁽³⁾] = i Ĵ⁽¹⁾` from `[Ĵ⁽²⁾, Ĵ⁽³⁾] = i Ĵ⁽¹⁾`. -/
+theorem su2Reflect23 (h23 : J2 * J3 - J3 * J2 = Complex.I • J1) :
+    (-J2) * (-J3) - (-J3) * (-J2) = Complex.I • J1 := by
+  rw [show (-J2) * (-J3) - (-J3) * (-J2) = J2 * J3 - J3 * J2 by noncomm_ring, h23]
+
+omit [DecidableEq d] in
+/-- Reflected `[−Ĵ⁽³⁾, Ĵ⁽¹⁾] = i(−Ĵ⁽²⁾)` from `[Ĵ⁽³⁾, Ĵ⁽¹⁾] = i Ĵ⁽²⁾`. -/
+theorem su2Reflect31 (h31 : J3 * J1 - J1 * J3 = Complex.I • J2) :
+    (-J3) * J1 - J1 * (-J3) = Complex.I • (-J2) := by
+  rw [show (-J3) * J1 - J1 * (-J3) = -(J3 * J1 - J1 * J3) by noncomm_ring, h31, smul_neg]
+
+omit [DecidableEq d] in
+/-- The Casimir `Ĵ²` is invariant under the reflection `(Ĵ⁽¹⁾, −Ĵ⁽²⁾, −Ĵ⁽³⁾)`. -/
+theorem casimirReflect :
+    J1 * J1 + (-J2) * (-J2) + (-J3) * (-J3) = J1 * J1 + J2 * J2 + J3 * J3 := by
+  noncomm_ring
+
 omit [DecidableEq d] in
 /-- **Tasaki eq. (A.3.9), raising.**  `‖Ĵ⁺ Φ‖² = {J(J+1) − M(M+1)} ‖Φ‖²` on `H_{J,M}`
 (self-adjoint `Ĵ⁽¹⁾, Ĵ⁽²⁾`), as a complex identity. -/

--- a/LatticeSystem/Math/TasakiAppendixA/AngularMultiplet.lean
+++ b/LatticeSystem/Math/TasakiAppendixA/AngularMultiplet.lean
@@ -77,16 +77,12 @@ theorem ham_su2_multiplet (hcH1 : H * J1 = J1 * H) (hcH2 : H * J2 = J2 * H)
     have := hTeig.2; rw [show ((M0 + (t : ℝ)) : ℝ) = Jr from hMt] at this; exact this
   have hHT : H.mulVec T = E • T := ham_mulVec_raiseIter H J1 J2 hcH1 hcH2 hH t
   -- Reflected operators `(Ĵ⁽¹⁾, −Ĵ⁽²⁾, −Ĵ⁽³⁾)`: same `su(2)` relations, raising = `Ĵ⁻`.
-  have h12' : J1 * (-J2) - (-J2) * J1 = Complex.I • (-J3) := by
-    rw [show J1 * (-J2) - (-J2) * J1 = -(J1 * J2 - J2 * J1) by noncomm_ring, h12, smul_neg]
-  have h23' : (-J2) * (-J3) - (-J3) * (-J2) = Complex.I • J1 := by
-    rw [show (-J2) * (-J3) - (-J3) * (-J2) = J2 * J3 - J3 * J2 by noncomm_ring, h23]
-  have h31' : (-J3) * J1 - J1 * (-J3) = Complex.I • (-J2) := by
-    rw [show (-J3) * J1 - J1 * (-J3) = -(J3 * J1 - J1 * J3) by noncomm_ring, h31, smul_neg]
+  have h12' := su2Reflect12 J1 J2 J3 h12
+  have h23' := su2Reflect23 J1 J2 J3 h23
+  have h31' := su2Reflect31 J1 J2 J3 h31
   have hsqT' : (J1 * J1 + (-J2) * (-J2) + (-J3) * (-J3)).mulVec T
       = ((Jr * (Jr + 1) : ℝ) : ℂ) • T := by
-    rw [show J1 * J1 + (-J2) * (-J2) + (-J3) * (-J3) = J1 * J1 + J2 * J2 + J3 * J3 by noncomm_ring]
-    exact hTsq
+    rw [casimirReflect J1 J2 J3]; exact hTsq
   have h3T' : (-J3).mulVec T = ((-Jr : ℝ) : ℂ) • T := by
     rw [Matrix.neg_mulVec, hT3]; push_cast; module
   -- Descend `k` times: `Ψ = (Ĵ⁻)^k T = raiseIter J1 (−J2) k T`.
@@ -97,7 +93,7 @@ theorem ham_su2_multiplet (hcH1 : H * J1 = J1 * H) (hcH2 : H * J2 = J2 * H)
     have : (i : ℝ) < (k : ℝ) := by exact_mod_cast hi
     linarith
   · have hRe := raiseIter_eigenspace J1 (-J2) (-J3) h12' h23' h31' hsqT' h3T' k
-    rw [show J1 * J1 + J2 * J2 + J3 * J3 = J1 * J1 + (-J2) * (-J2) + (-J3) * (-J3) by noncomm_ring]
+    rw [← casimirReflect J1 J2 J3]
     exact hRe.1
   · have hRe := raiseIter_eigenspace J1 (-J2) (-J3) h12' h23' h31' hsqT' h3T' k
     have h3R := hRe.2

--- a/LatticeSystem/Math/TasakiAppendixA/AngularQuantization.lean
+++ b/LatticeSystem/Math/TasakiAppendixA/AngularQuantization.lean
@@ -131,16 +131,12 @@ theorem angMom_J_eq_half_nat (h1 : J1.IsHermitian) (h2 : J2.IsHermitian)
   -- `J − M ∈ ℤ≥0` (raising direction).
   obtain ⟨nsub, hsub⟩ := angMom_sub_mem_nat J1 J2 J3 h1 h2 h12 h23 h31 hΦ hJ hsq h3
   -- Gauge-reflected operators `(Ĵ⁽¹⁾, −Ĵ⁽²⁾, −Ĵ⁽³⁾)` satisfy the same `su(2)` relations.
-  have h12' : J1 * (-J2) - (-J2) * J1 = Complex.I • (-J3) := by
-    rw [show J1 * (-J2) - (-J2) * J1 = -(J1 * J2 - J2 * J1) by noncomm_ring, h12, smul_neg]
-  have h23' : (-J2) * (-J3) - (-J3) * (-J2) = Complex.I • J1 := by
-    rw [show (-J2) * (-J3) - (-J3) * (-J2) = J2 * J3 - J3 * J2 by noncomm_ring, h23]
-  have h31' : (-J3) * J1 - J1 * (-J3) = Complex.I • (-J2) := by
-    rw [show (-J3) * J1 - J1 * (-J3) = -(J3 * J1 - J1 * J3) by noncomm_ring, h31, smul_neg]
+  have h12' := su2Reflect12 J1 J2 J3 h12
+  have h23' := su2Reflect23 J1 J2 J3 h23
+  have h31' := su2Reflect31 J1 J2 J3 h31
   have hsq' : (J1 * J1 + (-J2) * (-J2) + (-J3) * (-J3)).mulVec Φ
       = ((Jr * (Jr + 1) : ℝ) : ℂ) • Φ := by
-    rw [show J1 * J1 + (-J2) * (-J2) + (-J3) * (-J3) = J1 * J1 + J2 * J2 + J3 * J3 by noncomm_ring]
-    exact hsq
+    rw [casimirReflect J1 J2 J3]; exact hsq
   have h3' : (-J3).mulVec Φ = ((-M : ℝ) : ℂ) • Φ := by
     rw [Matrix.neg_mulVec, h3]; push_cast; module
   -- `J + M ∈ ℤ≥0` (lowering direction = reflected raising).


### PR DESCRIPTION
Tracked in #4205.

## Refactoring PR (20-PR cadence)
Refactor inserted per the **20-PR cadence** (last refactor #4201; A.18 #4221 was the 20th feature merged since).

## Deduplication
The gauge-reflection identities for `(Ĵ⁽¹⁾, −Ĵ⁽²⁾, −Ĵ⁽³⁾)` — the three reflected `su(2)` relations and the Casimir invariance — were derived **inline** (via per-call `noncomm_ring` `show`s) in both `angMom_J_eq_half_nat` (Theorem A.13, `AngularQuantization.lean`) and `ham_su2_multiplet` (Theorem A.16, `AngularMultiplet.lean`). Extracted to four reusable lemmas in `AngularLadder.lean`:
- `su2Reflect12` / `su2Reflect23` / `su2Reflect31` — reflected `su(2)` relations.
- `casimirReflect` — `Ĵ²` invariance under the reflection.

Both consumers now call these instead of repeating the algebra (and the reverse Casimir rewrite uses `← casimirReflect`).

## Build-speed evaluation (required)
Clean rebuild of the `AngularLadder → AngularQuantization → AngularMultiplet` chain: **23.62s → 21.03s (~11%)**, from elaborating the reflected-`su(2)` `noncomm_ring` identities **once** in the base module rather than inline at each (previously two) call sites.

## Verification
- All proofs unchanged; `#print axioms` still clean (`propext/Classical.choice/Quot.sound`) for A.13 and A.16.
- Zero linter warnings; build root green (3698 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
