### PR TITLE
Add forward-hop JW sign as a strictly-between parity (Prop 11.24 PR3c-3) — #4230

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -42,6 +42,7 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.HopMatrixElement
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonian
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiBasis
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiHopAction
+import LatticeSystem.Fermion.JordanWigner.Hubbard.HopSignBetween
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonianMatrix
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonianSpinSymmetry
 import LatticeSystem.Fermion.JordanWigner.Hubbard.WeakNagaoka
@@ -177,6 +178,7 @@ expansion):
 | `Hubbard/EffectiveHamiltonian.lean` | effective Hamiltonian `Ĥ_eff = P̂_hc H P̂_hc` + `U→∞` reduction (Tasaki §11.2) |
 | `Hubbard/TasakiBasis.lean` | Tasaki ordered-creation basis `\|Φ_{x,σ}⟩ = ε • basisVec` + orthonormality (Tasaki §11.2 eq. (11.2.3)) |
 | `Hubbard/TasakiHopAction.lean` | uniform-sign hole-filling action `ĉ†_{x,s}ĉ_{z,s}\|Φ_{x,σ}⟩ = -\|Φ_{z,σ_{z→x}}⟩` + sign `ε = (-1)^x` (Tasaki §11.2 eq. (11.2.4)) |
+| `Hubbard/HopSignBetween.lean` | **Forward-hop JW sign as a strictly-between parity** (Issue #4230 PR3c-3): `jwSign_mul_jwSign_update_forward` — for a forward hop `q→p` (`q.val<p.val`, source `c q=1`), `jwSign q c · jwSign p (update c q 0) = (-1)^(#occupied modes strictly between q,p)`; the `2·E_q` of the modes below the source cancels in parity. Model-agnostic; underlies the sign-free d=1 t-J hopping. Axiom-free |
 | `Hubbard/EffectiveHamiltonianMatrix.lean` | off-diagonal matrix element `⟨Φ_{y,τ}\|Ĥ_eff\|Φ_{x,σ}⟩ = -t_{x,y}·[τ=σ_{y→x}]` (Tasaki §11.2 eq. (11.2.5)) |
 | `Hubbard/WeakNagaoka.lean` | Cauchy–Schwarz energy bound `⟨Φ_↑\|Ĥ_eff\|Φ_↑⟩ ≤ ⟨Φ\|Ĥ_eff\|Φ⟩` (Tasaki §11.2 eq. (11.2.9)) |
 | `Hubbard/EffectiveHamiltonianSpinSymmetry.lean` | SU(2) symmetry of the effective Hamiltonian `[Ĥ_eff, Ŝ^±_tot] = 0` (Tasaki §11.2, degeneracy backbone) |

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HopSignBetween.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HopSignBetween.lean
@@ -25,9 +25,11 @@ open scoped BigOperators
 /-- **Forward-hop sign as a strictly-between parity.**  For a forward hop `q → p` (`q.val < p.val`)
 with the source occupied (`c q = 1`), the product of the two Jordan–Wigner string signs equals
 `(-1)` to the number of occupied modes strictly between `q` and `p`.  The modes below the source
-contribute `E_q` to both signs, so `2·E_q` cancels in the parity. -/
+contribute `E_q` to both signs, so `2·E_q` cancels in the parity.  (The source occupation is
+irrelevant to the parity: the update zeroes mode `q` either way, so no `c q = 1` hypothesis is
+needed.) -/
 theorem jwSign_mul_jwSign_update_forward (M : ℕ) (q p : Fin (M + 1)) (c : Fin (M + 1) → Fin 2)
-    (hqp : q.val < p.val) (hcq : c q = 1) :
+    (hqp : q.val < p.val) :
     jwSign M q c * jwSign M p (Function.update c q 0)
       = (-1 : ℂ) ^ (∑ k ∈ (Finset.univ : Finset (Fin (M + 1))).filter
           (fun k => q.val < k.val ∧ k.val < p.val), (c k).val) := by
@@ -81,3 +83,5 @@ theorem jwSign_mul_jwSign_update_forward (M : ℕ) (q p : Fin (M + 1)) (c : Fin 
   -- assemble: `E_q + E_p' = 2·E_q + inner`, and `(-1)^(2·E_q) = 1`
   rw [hEp, show ∀ a b : ℕ, a + (a + b) = 2 * a + b from fun a b => by ring, pow_add, pow_mul]
   norm_num
+
+end LatticeSystem.Fermion

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HopSignBetween.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HopSignBetween.lean
@@ -1,0 +1,83 @@
+import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiHopAction
+
+/-!
+# The forward-hop Jordan–Wigner sign as a parity over the intervening modes
+
+For a single forward hop `q → p` (`q.val < p.val`) on a computational basis state with the source
+`q` occupied, the matrix element of `ĉ†_p ĉ_q` carries the product of two Jordan–Wigner string signs
+`jwSign q c · jwSign p (update c q 0)`.  This file shows that product equals `(-1)` to the number of
+occupied modes *strictly between* `q` and `p`: the contribution `E_q` of the modes below the source
+appears in both signs, so it doubles and cancels in the parity, leaving only the strictly-between
+occupations.
+
+This is the model-agnostic "fermionic hop sign is local to the intervening modes" identity used to
+show the d=1 ferromagnetic t-J hopping is sign-free (Tasaki §11.5, Proposition 11.24).
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*
+(1st ed.), §11.2 / §11.5.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Quantum
+open scoped BigOperators
+
+/-- **Forward-hop sign as a strictly-between parity.**  For a forward hop `q → p` (`q.val < p.val`)
+with the source occupied (`c q = 1`), the product of the two Jordan–Wigner string signs equals
+`(-1)` to the number of occupied modes strictly between `q` and `p`.  The modes below the source
+contribute `E_q` to both signs, so `2·E_q` cancels in the parity. -/
+theorem jwSign_mul_jwSign_update_forward (M : ℕ) (q p : Fin (M + 1)) (c : Fin (M + 1) → Fin 2)
+    (hqp : q.val < p.val) (hcq : c q = 1) :
+    jwSign M q c * jwSign M p (Function.update c q 0)
+      = (-1 : ℂ) ^ (∑ k ∈ (Finset.univ : Finset (Fin (M + 1))).filter
+          (fun k => q.val < k.val ∧ k.val < p.val), (c k).val) := by
+  rw [jwSign_eq_neg_one_pow, jwSign_eq_neg_one_pow, ← pow_add]
+  -- partition the modes below `p` into: below `q`, the source `q`, strictly between `q` and `p`
+  have hsplit : (Finset.univ.filter (fun k : Fin (M + 1) => k.val < p.val))
+      = (Finset.univ.filter (fun k => k.val < q.val))
+        ∪ insert q (Finset.univ.filter (fun k => q.val < k.val ∧ k.val < p.val)) := by
+    ext k
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_union, Finset.mem_insert]
+    constructor
+    · intro hk
+      rcases lt_trichotomy k.val q.val with h | h | h
+      · exact Or.inl h
+      · exact Or.inr (Or.inl (Fin.ext h))
+      · exact Or.inr (Or.inr ⟨h, hk⟩)
+    · rintro (h | rfl | ⟨_, h2⟩)
+      · omega
+      · exact hqp
+      · exact h2
+  have hqnotin : q ∉ (Finset.univ.filter (fun k : Fin (M + 1) =>
+      q.val < k.val ∧ k.val < p.val)) := by
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]; omega
+  have hdisj : Disjoint (Finset.univ.filter (fun k : Fin (M + 1) => k.val < q.val))
+      (insert q (Finset.univ.filter (fun k => q.val < k.val ∧ k.val < p.val))) := by
+    rw [Finset.disjoint_left]
+    intro k hk hk'
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert] at hk hk'
+    rcases hk' with rfl | ⟨h, _⟩
+    · omega
+    · omega
+  -- `E_p' = E_q + inner`: the source term is zeroed, and on the other parts `update = c`
+  have hEp : (∑ k ∈ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < p.val)),
+        ((Function.update c q 0) k).val)
+      = (∑ k ∈ (Finset.univ.filter (fun k => k.val < q.val)), (c k).val)
+        + ∑ k ∈ (Finset.univ.filter (fun k => q.val < k.val ∧ k.val < p.val)), (c k).val := by
+    rw [hsplit, Finset.sum_union hdisj, Finset.sum_insert hqnotin, Function.update_self]
+    have h1 : (∑ k ∈ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < q.val)),
+        ((Function.update c q 0) k).val)
+        = ∑ k ∈ (Finset.univ.filter (fun k => k.val < q.val)), (c k).val :=
+      Finset.sum_congr rfl fun k hk => by
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hk
+        rw [Function.update_of_ne (fun h => by rw [h] at hk; omega)]
+    have h2 : (∑ k ∈ (Finset.univ.filter (fun k : Fin (M + 1) =>
+          q.val < k.val ∧ k.val < p.val)), ((Function.update c q 0) k).val)
+        = ∑ k ∈ (Finset.univ.filter (fun k => q.val < k.val ∧ k.val < p.val)), (c k).val :=
+      Finset.sum_congr rfl fun k hk => by
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hk
+        rw [Function.update_of_ne (fun h => by rw [h] at hk; omega)]
+    rw [h1, h2]; simp
+  -- assemble: `E_q + E_p' = 2·E_q + inner`, and `(-1)^(2·E_q) = 1`
+  rw [hEp, show ∀ a b : ℕ, a + (a + b) = 2 * a + b from fun a b => by ring, pow_add, pow_mul]
+  norm_num


### PR DESCRIPTION
Tracked in #4230.

## Summary
**PR3c-3: the forward-hop Jordan–Wigner sign as a strictly-between parity** — the model-agnostic fermionic hop-sign identity behind the sign-free d=1 t-J hopping.

## New file `Fermion/JordanWigner/Hubbard/HopSignBetween.lean`
- **`jwSign_mul_jwSign_update_forward`** — for a forward hop `q → p` (`q.val < p.val`) with the source occupied (`c q = 1`),

  `jwSign q c · jwSign p (update c q 0) = (-1)^(#occupied modes strictly between q and p)`.

  The modes **below** the source contribute `E_q` to **both** string signs, so `2·E_q` cancels in the parity, leaving only the strictly-between occupations. Proof: partition `{k < p}` into `{k < q} ⊔ {q} ⊔ {q < k < p}`; the source term is zeroed by the update, and `(-1)^(2·E_q) = 1`.

This is the operator-level ingredient for the d=1 ferromagnetic t-J matrix elements being sign-free: a nearest-neighbour hop leaves a single intervening orbital that the hop conditions force empty.

## Verification
- `lake build` green; **zero** linter warnings; `#print axioms` standard-only (**axiom-free**).
- Wired into the `JordanWigner` facade (verified, grep = 2); build root green (3908 jobs).

PR3c-3 of #4230. Next PR3c-4: specialise to the NN same-spin hop (`p = q+2`) on `tJConfigOf` — the single intervening orbital is empty by the hop conditions (`s a`/`s b`), so the coefficient is `+1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
