### PR TITLE
Refactor: dedupe Fin-2 dichotomy helper + t-J build-speed evaluation — #4230

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopConfig.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopConfig.lean
@@ -32,8 +32,8 @@ private theorem tJ_hop_ne_down (s : Fin (N + 1) → Fin 3) (a b : Fin (N + 1)) (
     (hb : s b = 0) : a ≠ b := by
   rintro rfl; rw [ha] at hb; exact absurd hb (by decide)
 
-/-- Either spin label is `0` or `1`. -/
-private theorem tJ_fin2_eq (r : Fin 2) : r = 0 ∨ r = 1 := by
+/-- A spin label is `0` or `1` (the two-element dichotomy used throughout the t-J sector files). -/
+theorem tJ_fin2_eq (r : Fin 2) : r = 0 ∨ r = 1 := by
   rcases eq_or_ne r 0 with h | h
   · exact Or.inl h
   · refine Or.inr (Fin.ext ?_)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopWrap.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopWrap.lean
@@ -39,12 +39,7 @@ private theorem tJ_wrap_ge_eq_zero (N : ℕ) (s : Fin (N + 1) → Fin 3) (b : Fi
     rw [h2] at hk
     exact Fin.ext (by omega)
   subst hi
-  have hr2 : r = 0 ∨ r = 1 := by
-    rcases eq_or_ne r 0 with h | h
-    · exact Or.inl h
-    · exact Or.inr (Fin.ext (by
-        have := r.isLt; have : r.val ≠ 0 := fun hh => h (Fin.ext hh); omega))
-  rcases hr2 with rfl | rfl
+  rcases tJ_fin2_eq r with rfl | rfl
   · rw [tJConfigOf_apply_up, if_neg (by rw [hsb]; decide)]
     rfl
   · rw [tJConfigOf_apply_down, if_neg (by rw [hsb]; decide)]


### PR DESCRIPTION
Tracked in #4230 (refactoring PR; not a textbook-theorem unit).

## Build-speed evaluation (mandatory)
Per-file `lake env lean` timings of the §11.5 t-J sector files showed apparent outliers — TJHermitian ~33s, TJSectorReduction ~15s, TJSpinSymmetry ~13s. **A profiler run on TJHermitian shows <200ms of actual tactic/elaboration work**; the wall-clock is dominated by **olean import-loading** of the deep Fermion/Hubbard/Quantum transitive closure into memory, not proof cost. In a full `lake build` the oleans are loaded once and shared, so the incremental per-file cost is small (each t-J file builds in ~2-4s incrementally; full root = 3912 jobs).

**Conclusion:** no proof-level hotspot warrants optimisation. The t-J module is well-factored (files 48–253 lines, no duplicate imports, consistent idioms). Evaluated; no build-speed code change taken (documented reason above).

## Consolidation
The Fin-2 dichotomy `(r : Fin 2) → r = 0 ∨ r = 1` had been introduced twice (private `tJ_fin2_eq` in `TJSectorHopConfig` + inline in `TJSectorHopWrap.tJ_wrap_ge_eq_zero`). Promoted `tJ_fin2_eq` to a **public** helper and reused it in the wrap file, removing the inline duplicate.

Deferred (noted, not done — wider cross-module change, future non-t-J refactor): the same dichotomy also appears as private helpers `fin2_eq_one_of_ne_zero` (WeakNagaokaGroundState) and `fin_two_ne_zero` (HopConfig).

## Verification
- `lake build` green (3912 jobs); zero linter warnings on changed files.
- All t-J theorems remain axiom-free (standard `[propext, Classical.choice, Quot.sound]`).

Resets the 20-PR refactoring cadence counter (last refactor #4222).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
