### PR TITLE
Refactor: prune 27 redundant imports in §11.5 t-J tree + build-speed eval — #4230

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJDiagonalMatrixElement.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJDiagonalMatrixElement.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJModel
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorBasis
-import LatticeSystem.Fermion.JordanWigner.Hubbard.WeakNagaokaTheorem
 
 /-!
 # Tasaki 11.5: the diagonal terms have no off-diagonal matrix elements (Prop 11.24 PR-B6)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJExchangeBondSum.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJExchangeBondSum.lean
@@ -1,8 +1,6 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJExchangeNonneg
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJDiagonalMatrixElement
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJKineticSummand
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJOffDiagonal
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJEffMatrix
 import LatticeSystem.Math.AnticommuteCommute
 
 /-!

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJExchangeNonneg.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJExchangeNonneg.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJExchangeMatrixElement
-import LatticeSystem.Lattice.Graph
 
 /-!
 # Tasaki 11.5: the exchange spin-flip matrix element is `0` or `1` (Prop 11.24 PR-B7-3g)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergy.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergy.lean
@@ -1,6 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJEigenvectorLift
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorGroundState
-import LatticeSystem.Fermion.JordanWigner.Hubbard.GroundSubspaceAtFilling
 
 /-!
 # Tasaki 11.5: variational bound on the t-J ground energy (Prop 11.24 PR-E2, `≤` direction)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergyReverse.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergyReverse.lean
@@ -1,6 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJGroundEnergy
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJOperatorLift
-import LatticeSystem.Quantum.SpinS.RealComplexEigenspaceBridge
 
 /-!
 # Tasaki 11.5: spin-½ `W`-eigenvalues are sector-matrix eigenvalues (Prop 11.24 PR-E2, `≥` crux)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHardcorePreserve.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHardcorePreserve.lean
@@ -1,6 +1,4 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJModel
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJHermitian
-import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonianSpinSymmetry
 
 /-!
 # Tasaki 11.5: the t-J Hamiltonian preserves the hard-core subspace (Prop 11.24 PR-E1b-hardcore)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticMatrixElement.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticMatrixElement.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopNN
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopWrap
 
 /-!

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticNonneg.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticNonneg.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorBasis
-import LatticeSystem.Fermion.JordanWigner.HopBasisVec
 
 /-!
 # Tasaki 11.5: the general single-hop matrix element on the sector basis (Prop 11.24 PR-B7-3d)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSummand.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSummand.lean
@@ -1,9 +1,7 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJKineticNonneg
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJKineticMatrixElement
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJOffDiagonal
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopBackward
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopBackwardWrap
-import LatticeSystem.Lattice.Graph
 
 /-!
 # Tasaki 11.5: each cyclic kinetic summand is `0` or `1` (Prop 11.24 PR-B7-3f)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJModel.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJModel.lean
@@ -1,6 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.FermionSiteSpin
-import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreProjection
-import LatticeSystem.Fermion.JordanWigner.Hubbard.Graph
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GroundSubspaceAtFilling
 import LatticeSystem.Fermion.JordanWigner.Hubbard.MielkeTheorems
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJNumberCommute.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJNumberCommute.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJModel
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSpinSymmetry
 
 /-!

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorBasis.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorBasis.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreBasis
 import LatticeSystem.Fermion.JordanWigner.Hubbard.WeakNagaokaGroundState
 
 /-!

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorIrreducible.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorIrreducible.lean
@@ -1,7 +1,6 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorShifted
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSwapReachable
 import LatticeSystem.Quantum.MarshallLiebMattis.MatrixPowExtend
-import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
 
 /-!
 # Tasaki 11.5: the shifted t-J sector matrix is irreducible (Prop 11.24 PR-C3b)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorNumber.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorNumber.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorSpin
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiHopAction
 
 /-!
 # Tasaki 11.5: the electron-number eigenvalue of the t-J sector basis (Prop 11.24 PR3b)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorReduction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorReduction.lean
@@ -1,7 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJHermitian
 import LatticeSystem.Fermion.JordanWigner.Hubbard.SpinTotHermitian
-import LatticeSystem.Fermion.JordanWigner.Hubbard.WeakNagaokaTheorem
-import LatticeSystem.Fermion.JordanWigner.Hubbard.SaturatedFerromagnetism
 import LatticeSystem.Math.TasakiAppendixA.AngularSpinHalfSector
 
 /-!

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorSpin.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorSpin.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorBasis
-import LatticeSystem.Fermion.JordanWigner.Hubbard.WeakNagaokaTheorem
 
 /-!
 # Tasaki 11.5: spin eigenvalues of the t-J sector basis (Prop 11.24 PR3a)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSpinSymmetry.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSpinSymmetry.lean
@@ -1,6 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJModel
-import LatticeSystem.Fermion.JordanWigner.Hubbard.SpinSymmetryAux
-import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonianSpinSymmetry
 
 /-!
 # Total-`Ŝ³` conservation of the ferromagnetic t-J model (Tasaki §11.5)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJStepRelation.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJStepRelation.lean
@@ -1,6 +1,4 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHop
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorExchange
-import LatticeSystem.Lattice.Graph
 
 /-!
 # Tasaki 11.5: the elementary connectivity step on t-J sector states (Prop 11.24 PR-C1)


### PR DESCRIPTION
Tracked in #4230. The mandated 20-PR-cadence refactoring PR (18 feature PRs since the last refactor #4264).

**Import hygiene.** Removed 27 imports across 18 §11.5 t-J modules that are already transitively provided by a sibling import of the same file (detected by transitive-closure analysis, mathlib `shake`-style). The full library build (3944 jobs) is green, confirming the removed imports were genuinely redundant (symbols remain available transitively).

**Build-speed evaluation (mandated).** The §11.5 t-J tree is healthy: per-file compile times ~2.0s typical, max 5.41s (`TJExchangeBondSum`), every file < 300 lines — no split or restructuring warranted. Import pruning does not change wall-clock build time (Lean dedups imports) but clarifies the dependency graph and reduces incidental coupling.

No new declarations; no `docs/index.md` / `tex/proof-guide.tex` changes required.
