### PR TITLE
Refactor (20-PR cadence): build-speed checkpoint for the t-J Prop 11.24 chain

### DIFF
--- a/docs/refactoring-conventions.md
+++ b/docs/refactoring-conventions.md
@@ -987,3 +987,19 @@ mechanically** and catch most regressions / drift.
   split trigger (~16s); each file is small (one-/few-theorem grain), so
   **no split warranted**. The chain is well-factored; build-speed healthy;
   no code change.
+- **2026-06-07 (PR #4303, 20-PR cadence checkpoint, evaluate-only)**:
+  Build-speed checkpoint for the t-J Proposition 11.24 discharge chain
+  (Issue #4230, PRs #4277–#4302: operator↔sector-matrix bridge, ground
+  energy `= μ`, the `Ŝ³=½` block `finrank ≤ 1`, and the full E3b raising
+  machinery — sign-free single/total raising action, tower eigenvalue
+  tracking, termination, conditional highest weight, the coefficient-sum
+  functional and recursion, hard-core preservation, and the Marshall
+  positivity non-vanishing). The ~30 new `TJ*.lean` modules are all small
+  (≤ 282 lines; the largest is `TJExchangeBondSum.lean` at 282, then
+  `TJSpinSymmetry.lean` 251, `TJStepMatrixEntry.lean` 242) — every file is
+  split at the one-/few-theorem grain and each single-file rebuild is
+  light (a few seconds), well under the historical split trigger
+  (~2000–4000 lines / ~16s). The chain carries zero linter warnings (the
+  only warnings in the build are pre-existing in `Quantum/SpinS/Rayleigh*`).
+  **No split warranted**; the chain is well-factored; build-speed and
+  import hygiene healthy; no code change.


### PR DESCRIPTION
**Refactoring PR (20-PR cadence checkpoint, evaluate-only).**

Per the `CLAUDE.local.md` "20-PR cadence" rule, a refactoring PR is due before
the next feature PR (19 feature PRs since the last refactor #4283: #4284–#4302).

**Build-speed evaluation** of the t-J Proposition 11.24 discharge chain
(Issue #4230, PRs #4277–#4302 — operator↔sector-matrix bridge, ground energy
`= μ`, the `Ŝ³=½` block `finrank ≤ 1`, and the full E3b raising/positivity
machinery):

- The ~30 new `TJ*.lean` modules are all small: **≤ 282 lines** (max
  `TJExchangeBondSum.lean` 282, then `TJSpinSymmetry.lean` 251,
  `TJStepMatrixEntry.lean` 242).
- Each file is split at the one-/few-theorem grain; each single-file rebuild is
  light (a few seconds), well under the historical split trigger
  (~2000–4000 lines / ~16s).
- The chain carries **zero linter warnings** (the only build warnings are
  pre-existing in `Quantum/SpinS/Rayleigh*`).

**Conclusion: no split warranted** — the chain is well-factored; build-speed and
import hygiene are healthy. Recorded in `docs/refactoring-conventions.md`
(2026-06-07 entry). No Lean code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
