### PR TITLE
Refactor: dedup the cross-site spin commutator + build-speed checkpoint — #4314

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJAllUpSpinDot.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJAllUpSpinDot.lean
@@ -1,6 +1,5 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.FermionSiteSpin
 import LatticeSystem.Fermion.JordanWigner.Hubbard.AllUpState
-import LatticeSystem.Fermion.JordanWigner.CAR.CrossSiteOfNe
+import LatticeSystem.Fermion.JordanWigner.Hubbard.TJCrossSiteSpinCommute
 
 /-!
 # Tasaki 11.5.3: the spin dot product on the all-up state (Theorem 11.26 PR3a)
@@ -41,28 +40,6 @@ theorem fermionSiteSpinZ_mulVec_allUpState (N : ℕ) (i : Fin (N + 1)) :
     show fermionUpCreation N i * fermionUpAnnihilation N i = fermionUpNumber N i from rfl,
     show fermionDownCreation N i * fermionDownAnnihilation N i = fermionDownNumber N i from rfl,
     fermionUpNumber_mulVec_allUpState, fermionDownNumber_mulVec_allUpState, sub_zero]
-
-/-- For `i ≠ j`, `ĉ_{i↓}` commutes through the different-site lowering operator `Ŝ⁻_j` (they act on
-disjoint Jordan–Wigner orbitals). -/
-private theorem fermionDownAnnihilation_commute_fermionSiteSpinMinus_of_ne
-    (i j : Fin (N + 1)) (hij : i ≠ j) :
-    Commute (fermionDownAnnihilation N i) (fermionSiteSpinMinus N j) := by
-  unfold fermionDownAnnihilation fermionSiteSpinMinus fermionDownCreation fermionUpAnnihilation
-  have hac : fermionMultiAnnihilation (2 * N + 1) (spinfulIndex N i 1) *
-        fermionMultiCreation (2 * N + 1) (spinfulIndex N j 1) +
-      fermionMultiCreation (2 * N + 1) (spinfulIndex N j 1) *
-        fermionMultiAnnihilation (2 * N + 1) (spinfulIndex N i 1) = 0 :=
-    fermionMultiAnnihilation_creation_anticomm_of_ne
-      (fun h => hij (spinfulIndex_down_injective N h))
-  have haa : fermionMultiAnnihilation (2 * N + 1) (spinfulIndex N i 1) *
-        fermionMultiAnnihilation (2 * N + 1) (spinfulIndex N j 0) +
-      fermionMultiAnnihilation (2 * N + 1) (spinfulIndex N j 0) *
-        fermionMultiAnnihilation (2 * N + 1) (spinfulIndex N i 1) = 0 :=
-    fermionMultiAnnihilation_anticomm_of_ne (spinfulIndex_up_ne_down N j i).symm
-  unfold Commute SemiconjBy
-  linear_combination (norm := noncomm_ring)
-    hac * fermionMultiAnnihilation (2 * N + 1) (spinfulIndex N j 0) -
-      fermionMultiCreation (2 * N + 1) (spinfulIndex N j 1) * haa
 
 /-- **The spin dot product on the all-up state.**  For `i ≠ j`, `Ŝ_i·Ŝ_j |↑…↑⟩ = ¼ |↑…↑⟩`: the
 raising/lowering terms annihilate `|↑…↑⟩`, leaving `Ŝ³_i Ŝ³_j = ¼`. -/

--- a/docs/refactoring-conventions.md
+++ b/docs/refactoring-conventions.md
@@ -1003,3 +1003,27 @@ mechanically** and catch most regressions / drift.
   only warnings in the build are pre-existing in `Quantum/SpinS/Rayleigh*`).
   **No split warranted**; the chain is well-factored; build-speed and
   import hygiene healthy; no code change.
+
+### 2026-06-07 — t-J Theorem 11.26 chain dedup + build-speed checkpoint (Issue #4314)
+
+Refactoring checkpoint at 17 feature PRs since the previous refactor (#4303):
+PRs #4304–#4313 (Prop 11.24 capstone) and #4315–#4321 (Theorem 11.26
+half-filling: kinetic vanishing, exchange reduction, all-up spin-dot/ground,
+singlet annihilation, the Heisenberg-bond CAR identity, and the bond
+`= ½ Δ†Δ` / positive-semidefiniteness).
+
+**Code change (dedup):** `TJAllUpSpinDot.lean` (#4317) had carried a *private*
+copy of `fermionDownAnnihilation_commute_fermionSiteSpinMinus_of_ne`; the same
+cross-site annihilation–site-spin commutator was later published in
+`TJCrossSiteSpinCommute.lean` (#4320). `TJAllUpSpinDot.lean` now imports
+`TJCrossSiteSpinCommute` and reuses the public lemma, removing the ~20-line
+duplicated CAR proof (and a redundant `CrossSiteOfNe`/`FermionSiteSpin`
+transitive import).
+
+**Build-speed evaluation:** the 82 `TJ*.lean` modules total ≈ 8.3k lines, all
+small (≤ 282 lines; largest `TJExchangeBondSum.lean` 282, `TJSpinSymmetry.lean`
+251). Single-file rebuilds are light (`TJAllUpSpinDot` ≈ 5 s incremental, ≈ 11 s
+with dependency replay), well under the historical split trigger
+(~2000–4000 lines / ~16 s). Zero linter warnings in the t-J chain. **No split
+warranted**; the only structural improvement this cycle is the dedup above.
+Cadence counter reset.


### PR DESCRIPTION
Tracked in #4314.

**20-PR-cadence refactoring PR** (17 feature PRs since the last refactor #4303: #4304–#4313 Prop
11.24 capstone + #4315–#4321 Theorem 11.26 half-filling chain).

**Dedup:** `TJAllUpSpinDot.lean` (#4317) carried a *private* copy of
`fermionDownAnnihilation_commute_fermionSiteSpinMinus_of_ne`; the same cross-site
annihilation–site-spin commutator was later published in `TJCrossSiteSpinCommute.lean` (#4320).
`TJAllUpSpinDot` now imports `TJCrossSiteSpinCommute` and reuses the public lemma, removing the
~20-line duplicated CAR proof and the now-redundant `CrossSiteOfNe`/`FermionSiteSpin` transitive
imports. Public API unchanged.

**Build-speed evaluation** (recorded in `docs/refactoring-conventions.md`): the 82 `TJ*.lean` modules
total ≈ 8.3k lines, all small (≤ 282 lines; largest `TJExchangeBondSum.lean` 282). Single-file
rebuilds are light (`TJAllUpSpinDot` ≈ 5 s incremental / ≈ 11 s with dependency replay), well under
the historical split trigger. Zero linter warnings in the t-J chain. **No split warranted.** Cadence
counter reset.

Axiom-clean; the whole facade rebuilds.
