### PR TITLE
Extract noncommProd + mul_of_commute generic helpers to Math — #4339

### DIFF
--- a/LatticeSystem/Fermion/JWAbstract.lean
+++ b/LatticeSystem/Fermion/JWAbstract.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner
+import LatticeSystem.Math.MatrixAnalysis.NoncommProd
 
 /-!
 # Abstract Jordan–Wigner string
@@ -27,68 +28,11 @@ noncomputable def jwStringAbstract (i : Λ) : ManyBodyOp Λ :=
     (fun j => onSite j pauliZ)
     (fun _ _ _ _ hab => onSite_mul_onSite_of_ne hab pauliZ pauliZ)
 
-/-- A noncomm-product of pairwise-commuting Hermitian matrices is
-Hermitian. Public version of the private helper in
-`JordanWigner.lean`. -/
-theorem noncommProd_isHermitian
-    {ι : Type*} {n : Type*} [Fintype n] [DecidableEq n]
-    (s : Finset ι) (f : ι → Matrix n n ℂ)
-    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
-    (hHerm : ∀ a ∈ s, (f a).IsHermitian) :
-    (s.noncommProd f hcomm).IsHermitian := by
-  classical
-  induction s using Finset.induction_on with
-  | empty =>
-    simp only [Finset.noncommProd_empty]
-    exact Matrix.isHermitian_one
-  | @insert a t hat ih =>
-    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
-    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
-      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
-    have hHerm_t : ∀ b ∈ t, (f b).IsHermitian :=
-      fun b hb => hHerm b (Finset.mem_insert_of_mem hb)
-    refine Matrix.IsHermitian.mul_of_commute
-      (hHerm a (Finset.mem_insert_self a t)) (ih hcomm_t hHerm_t) ?_
-    apply Finset.noncommProd_commute
-    intro b hb
-    have hab : a ≠ b := fun h => hat (h ▸ hb)
-    exact hcomm (Finset.mem_insert_self a t) (Finset.mem_insert_of_mem hb) hab
-
-/-- A noncomm-product of pairwise-commuting matrices, each
-squaring to the identity, itself squares to the identity. -/
-theorem noncommProd_sq_of_sq_one
-    {ι : Type*} {n : Type*} [Fintype n] [DecidableEq n]
-    (s : Finset ι) (f : ι → Matrix n n ℂ)
-    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
-    (hSq : ∀ a ∈ s, f a * f a = 1) :
-    s.noncommProd f hcomm * s.noncommProd f hcomm = 1 := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simp only [Finset.noncommProd_empty]; rw [Matrix.one_mul]
-  | @insert a t hat ih =>
-    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
-    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
-      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
-    have hSq_t : ∀ b ∈ t, f b * f b = 1 :=
-      fun b hb => hSq b (Finset.mem_insert_of_mem hb)
-    have hcomm_a : Commute (f a) (t.noncommProd f hcomm_t) := by
-      apply Finset.noncommProd_commute
-      intro b hb
-      have hab : a ≠ b := fun h => hat (h ▸ hb)
-      exact hcomm (Finset.mem_insert_self a t) (Finset.mem_insert_of_mem hb) hab
-    rw [show f a * t.noncommProd f hcomm_t * (f a * t.noncommProd f hcomm_t)
-          = (f a * f a) * (t.noncommProd f hcomm_t * t.noncommProd f hcomm_t) by
-        rw [Matrix.mul_assoc,
-          ← Matrix.mul_assoc (t.noncommProd f hcomm_t) (f a),
-          ← hcomm_a.eq, Matrix.mul_assoc, Matrix.mul_assoc]]
-    rw [hSq a (Finset.mem_insert_self a t), Matrix.one_mul,
-      ih hcomm_t hSq_t]
-
 /-- The abstract JW string is Hermitian. -/
 theorem jwStringAbstract_isHermitian (i : Λ) :
     (jwStringAbstract i).IsHermitian := by
   unfold jwStringAbstract
-  apply noncommProd_isHermitian
+  apply Matrix.noncommProd_isHermitian
   intro j _
   exact onSite_isHermitian j pauliZ_isHermitian
 
@@ -96,7 +40,7 @@ theorem jwStringAbstract_isHermitian (i : Λ) :
 theorem jwStringAbstract_sq (i : Λ) :
     jwStringAbstract i * jwStringAbstract i = 1 := by
   unfold jwStringAbstract
-  apply noncommProd_sq_of_sq_one
+  apply Matrix.noncommProd_sq_of_sq_one
   intro j _
   rw [onSite_mul_onSite_same, pauliZ_mul_self, onSite_one]
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreProjection.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreProjection.lean
@@ -1,5 +1,6 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreSubspace
 import LatticeSystem.Fermion.JordanWigner.Hubbard.DoubleOccupancyCommute
+import LatticeSystem.Math.MatrixAnalysis.NoncommProd
 
 /-!
 # Hubbard hard-core projection
@@ -33,87 +34,11 @@ namespace LatticeSystem.Fermion
 
 open Matrix LatticeSystem.Quantum
 
-/-! ## Generic `noncommProd` helpers for commuting idempotents -/
+/-! ## The hard-core factor `1 - n_{i,↑} n_{i,↓}`
 
-/-- A non-commutative product of pairwise-commuting idempotent matrices is
-itself idempotent. This is the projection analogue of
-`noncommProd_sq_of_sq_one`: instead of `f a * f a = 1` we assume
-`f a * f a = f a`. -/
-private theorem noncommProd_mul_self_of_idempotent
-    {ι : Type*} {n : Type*} [Fintype n] [DecidableEq n]
-    (s : Finset ι) (f : ι → Matrix n n ℂ)
-    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
-    (hId : ∀ a ∈ s, f a * f a = f a) :
-    s.noncommProd f hcomm * s.noncommProd f hcomm = s.noncommProd f hcomm := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simp only [Finset.noncommProd_empty]; rw [Matrix.one_mul]
-  | @insert a t hat ih =>
-    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
-    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
-      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
-    have hId_t : ∀ b ∈ t, f b * f b = f b :=
-      fun b hb => hId b (Finset.mem_insert_of_mem hb)
-    have hcomm_a : Commute (f a) (t.noncommProd f hcomm_t) := by
-      apply Finset.noncommProd_commute
-      intro b hb
-      have hab : a ≠ b := fun h => hat (h ▸ hb)
-      exact hcomm (Finset.mem_insert_self a t) (Finset.mem_insert_of_mem hb) hab
-    rw [show f a * t.noncommProd f hcomm_t * (f a * t.noncommProd f hcomm_t)
-          = (f a * f a) * (t.noncommProd f hcomm_t * t.noncommProd f hcomm_t) by
-        rw [Matrix.mul_assoc,
-          ← Matrix.mul_assoc (t.noncommProd f hcomm_t) (f a),
-          ← hcomm_a.eq, Matrix.mul_assoc, Matrix.mul_assoc]]
-    rw [hId a (Finset.mem_insert_self a t), ih hcomm_t hId_t]
-
-/-- A non-commutative product of matrices, each of which fixes a vector `ψ`
-under `mulVec`, also fixes `ψ`. -/
-private theorem noncommProd_mulVec_eq_self
-    {ι : Type*} {n : Type*} [Fintype n] [DecidableEq n]
-    (s : Finset ι) (f : ι → Matrix n n ℂ)
-    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
-    (ψ : n → ℂ) (hfix : ∀ a ∈ s, (f a).mulVec ψ = ψ) :
-    (s.noncommProd f hcomm).mulVec ψ = ψ := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simp only [Finset.noncommProd_empty]; rw [Matrix.one_mulVec]
-  | @insert a t hat ih =>
-    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
-    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
-      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
-    have hfix_t : ∀ b ∈ t, (f b).mulVec ψ = ψ :=
-      fun b hb => hfix b (Finset.mem_insert_of_mem hb)
-    rw [← Matrix.mulVec_mulVec, ih hcomm_t hfix_t,
-      hfix a (Finset.mem_insert_self a t)]
-
-/-- A non-commutative product of pairwise-commuting Hermitian matrices is
-Hermitian. Local copy of the `JWAbstract` helper, duplicated here because
-`JWAbstract` imports `JordanWigner`, which in turn imports this file. -/
-private theorem noncommProd_isHermitian
-    {ι : Type*} {n : Type*} [Fintype n] [DecidableEq n]
-    (s : Finset ι) (f : ι → Matrix n n ℂ)
-    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
-    (hHerm : ∀ a ∈ s, (f a).IsHermitian) :
-    (s.noncommProd f hcomm).IsHermitian := by
-  classical
-  induction s using Finset.induction_on with
-  | empty =>
-    simp only [Finset.noncommProd_empty]
-    exact Matrix.isHermitian_one
-  | @insert a t hat ih =>
-    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
-    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
-      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
-    have hHerm_t : ∀ b ∈ t, (f b).IsHermitian :=
-      fun b hb => hHerm b (Finset.mem_insert_of_mem hb)
-    refine Matrix.IsHermitian.mul_of_commute
-      (hHerm a (Finset.mem_insert_self a t)) (ih hcomm_t hHerm_t) ?_
-    apply Finset.noncommProd_commute
-    intro b hb
-    have hab : a ≠ b := fun h => hat (h ▸ hb)
-    exact hcomm (Finset.mem_insert_self a t) (Finset.mem_insert_of_mem hb) hab
-
-/-! ## The hard-core factor `1 - n_{i,↑} n_{i,↓}` -/
+The generic `Finset.noncommProd` helpers used below
+(`Matrix.noncommProd_isHermitian`, `Matrix.noncommProd_mul_self_of_idempotent`,
+`Matrix.noncommProd_mulVec_eq_self`) live in `Math/MatrixAnalysis/NoncommProd.lean`. -/
 
 /-- The single-site hard-core factor `1 - n_{i,↑} n_{i,↓}` at spinful site
 `i`: the complementary projection that annihilates the doubly-occupied
@@ -198,7 +123,7 @@ theorem hubbardHardcoreProjection_mul_self (N : ℕ) :
     hubbardHardcoreProjection N * hubbardHardcoreProjection N =
       hubbardHardcoreProjection N := by
   unfold hubbardHardcoreProjection
-  exact noncommProd_mul_self_of_idempotent _ _ _
+  exact Matrix.noncommProd_mul_self_of_idempotent _ _ _
     (fun i _ => hubbardHardcoreFactor_mul_self N i)
 
 /-- The hard-core projection is Hermitian: it is a non-commutative product
@@ -206,7 +131,7 @@ of pairwise-commuting Hermitian factors. -/
 theorem hubbardHardcoreProjection_isHermitian (N : ℕ) :
     (hubbardHardcoreProjection N).IsHermitian := by
   unfold hubbardHardcoreProjection
-  exact noncommProd_isHermitian _ _ _
+  exact Matrix.noncommProd_isHermitian _ _ _
     (fun i _ => hubbardHardcoreFactor_isHermitian N i)
 
 /-- Each same-site double-occupancy operator annihilates the hard-core
@@ -231,7 +156,7 @@ theorem hubbardHardcoreProjection_mulVec_eq_self_of_mem
     (hψ : ψ ∈ hubbardHardcoreSubspace N) :
     (hubbardHardcoreProjection N).mulVec ψ = ψ := by
   unfold hubbardHardcoreProjection
-  exact noncommProd_mulVec_eq_self _ _ _ ψ
+  exact Matrix.noncommProd_mulVec_eq_self _ _ _ ψ
     (fun i _ => hubbardHardcoreFactor_mulVec_eq_self_of_mem N hψ i)
 
 /-- The hard-core projection lands in the hard-core subspace: every

--- a/LatticeSystem/Fermion/JordanWigner/Operators.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Operators.lean
@@ -1,5 +1,6 @@
 import LatticeSystem.Fermion.JordanWigner.String
 import LatticeSystem.Quantum.SpinHalfBasis
+import LatticeSystem.Math.MatrixAnalysis.NoncommProd
 
 /-!
 # Multi-mode JW fermion operators
@@ -112,38 +113,11 @@ lemma onSite_conjTranspose {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
       fun hp => h (fun k hki => (hp k hki).symm)
     rw [if_neg h, if_neg h', star_zero]
 
-/-- A noncomm-product of pairwise-commuting Hermitian matrices is
-Hermitian. Used here for the JW string, which is a product of
-mutually commuting Hermitian `σ^z_j` factors. -/
-private lemma noncommProd_isHermitian_of_pairwise_commute_of_isHermitian
-    {ι : Type*} {n : Type*} [Fintype n] [DecidableEq n]
-    (s : Finset ι) (f : ι → Matrix n n ℂ)
-    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
-    (hHerm : ∀ a ∈ s, (f a).IsHermitian) :
-    (s.noncommProd f hcomm).IsHermitian := by
-  classical
-  induction s using Finset.induction_on with
-  | empty =>
-    simp only [Finset.noncommProd_empty]
-    exact Matrix.isHermitian_one
-  | @insert a t hat ih =>
-    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
-    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
-      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
-    have hHerm_t : ∀ b ∈ t, (f b).IsHermitian :=
-      fun b hb => hHerm b (Finset.mem_insert_of_mem hb)
-    refine Matrix.IsHermitian.mul_of_commute
-      (hHerm a (Finset.mem_insert_self a t)) (ih hcomm_t hHerm_t) ?_
-    apply Finset.noncommProd_commute
-    intro b hb
-    have hab : a ≠ b := fun h => hat (h ▸ hb)
-    exact hcomm (Finset.mem_insert_self a t) (Finset.mem_insert_of_mem hb) hab
-
 /-- The Jordan–Wigner string is Hermitian: `(jwString N i)ᴴ = jwString N i`. -/
 theorem jwString_isHermitian (N : ℕ) (i : Fin (N + 1)) :
     (jwString N i).IsHermitian := by
   unfold jwString
-  apply noncommProd_isHermitian_of_pairwise_commute_of_isHermitian
+  apply Matrix.noncommProd_isHermitian
   intro j _
   exact onSite_isHermitian j pauliZ_isHermitian
 
@@ -167,45 +141,12 @@ theorem fermionMultiCreation_conjTranspose (N : ℕ) (i : Fin (N + 1)) :
 
 /-! ## Site-occupation number operator -/
 
-/-- A noncomm-product of pairwise-commuting matrices, each squaring to
-the identity, itself squares to the identity. Used here for the JW
-string, where each `σ^z_j` satisfies `σ^z² = 1`. -/
-private lemma noncommProd_sq_of_pairwise_commute_of_sq_one
-    {ι : Type*} {n : Type*} [Fintype n] [DecidableEq n]
-    (s : Finset ι) (f : ι → Matrix n n ℂ)
-    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
-    (hSq : ∀ a ∈ s, f a * f a = 1) :
-    s.noncommProd f hcomm * s.noncommProd f hcomm = 1 := by
-  classical
-  induction s using Finset.induction_on with
-  | empty =>
-    simp only [Finset.noncommProd_empty]
-    rw [Matrix.one_mul]
-  | @insert a t hat ih =>
-    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
-    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
-      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
-    have hSq_t : ∀ b ∈ t, f b * f b = 1 :=
-      fun b hb => hSq b (Finset.mem_insert_of_mem hb)
-    have hcomm_a : Commute (f a) (t.noncommProd f hcomm_t) := by
-      apply Finset.noncommProd_commute
-      intro b hb
-      have hab : a ≠ b := fun h => hat (h ▸ hb)
-      exact hcomm (Finset.mem_insert_self a t) (Finset.mem_insert_of_mem hb) hab
-    -- (f a · ∏)·(f a · ∏) = f a · (∏ · f a) · ∏ = f a · (f a · ∏) · ∏ = (f a · f a) · ∏²
-    -- = 1 · 1 = 1
-    rw [show f a * t.noncommProd f hcomm_t * (f a * t.noncommProd f hcomm_t)
-          = (f a * f a) * (t.noncommProd f hcomm_t * t.noncommProd f hcomm_t) by
-        rw [Matrix.mul_assoc, ← Matrix.mul_assoc (t.noncommProd f hcomm_t) (f a),
-            ← hcomm_a.eq, Matrix.mul_assoc, Matrix.mul_assoc]]
-    rw [hSq a (Finset.mem_insert_self a t), Matrix.one_mul, ih hcomm_t hSq_t]
-
 /-- `(jwString N i)² = 1`: the JW string squares to the identity, since
 each `σ^z` factor satisfies `(σ^z)² = 1`. -/
 theorem jwString_sq (N : ℕ) (i : Fin (N + 1)) :
     jwString N i * jwString N i = 1 := by
   unfold jwString
-  apply noncommProd_sq_of_pairwise_commute_of_sq_one
+  apply Matrix.noncommProd_sq_of_sq_one
   intro j _
   rw [onSite_mul_onSite_same, pauliZ_mul_self, onSite_one]
 

--- a/LatticeSystem/Math/MatrixAnalysis/HermitianSum.lean
+++ b/LatticeSystem/Math/MatrixAnalysis/HermitianSum.lean
@@ -4,12 +4,18 @@ import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Matrix.Basic
 
 /-!
-# Finite sums of Hermitian matrices are Hermitian
+# Closure of Hermitian-ness under finite sums and commuting products
 
-A small generic linear-algebra fact, `Matrix.isHermitian_sum`, extracted from several physics files
-(`Quantum/IsingChain.lean`, `Quantum/TotalSpin.lean`, `Quantum/SpinS/*`) where it had been re-proved
-as a private helper.  mathlib has `Matrix.conjTranspose_sum` and `Matrix.isHermitian_zero` but no
-packaged `Finset.sum` version.
+Small generic linear-algebra facts extracted from several physics files where they had been
+re-proved as private helpers:
+
+* `Matrix.isHermitian_sum` — a finite sum of Hermitian matrices is Hermitian (extracted from
+  `Quantum/IsingChain.lean`, `Quantum/TotalSpin.lean`, `Quantum/SpinS/*`).
+* `Matrix.IsHermitian.mul_of_commute` — the product of two commuting Hermitian matrices is
+  Hermitian (previously sitting in the widely-imported physics file `Quantum/ManyBody.lean`).
+
+mathlib has `Matrix.conjTranspose_sum`, `Matrix.conjTranspose_mul`, and `Matrix.isHermitian_zero`,
+but no packaged `Finset.sum` version nor the commuting-product corollary.
 -/
 
 namespace Matrix
@@ -22,5 +28,12 @@ theorem isHermitian_sum (s : Finset ι) {f : ι → Matrix n n ℂ}
   classical
   refine Finset.sum_induction _ _ (fun A B hA hB => hA.add hB) Matrix.isHermitian_zero ?_
   exact hf
+
+/-- The product of two commuting Hermitian matrices is Hermitian. -/
+theorem IsHermitian.mul_of_commute [Fintype n]
+    {A B : Matrix n n ℂ} (hA : A.IsHermitian) (hB : B.IsHermitian)
+    (hcomm : A * B = B * A) : (A * B).IsHermitian := by
+  unfold Matrix.IsHermitian
+  rw [Matrix.conjTranspose_mul, hA, hB, hcomm]
 
 end Matrix

--- a/LatticeSystem/Math/MatrixAnalysis/NoncommProd.lean
+++ b/LatticeSystem/Math/MatrixAnalysis/NoncommProd.lean
@@ -1,0 +1,134 @@
+import Mathlib.Data.Finset.NoncommProd
+import Mathlib.Data.Matrix.Mul
+import LatticeSystem.Math.MatrixAnalysis.HermitianSum
+
+/-!
+# Non-commutative products of pairwise-commuting matrices
+
+Generic linear-algebra facts about `Finset.noncommProd` of a family of `Matrix n n ℂ` that is
+*pairwise commuting*.  These were re-proved as private (or near-duplicate public) helpers in several
+fermion / Jordan–Wigner files:
+
+* `Matrix.noncommProd_isHermitian` — a product of pairwise-commuting Hermitian matrices is
+  Hermitian.  Previously copied in `Fermion/JWAbstract.lean`, `Fermion/JordanWigner/Operators.lean`,
+  and `Fermion/JordanWigner/Hubbard/HardcoreProjection.lean` (the last with an explicit
+  "duplicated because of an import cycle" note).
+* `Matrix.noncommProd_sq_of_sq_one` — a product of pairwise-commuting involutions is an
+  involution.  Previously copied in `Fermion/JWAbstract.lean` and
+  `Fermion/JordanWigner/Operators.lean`.
+* `Matrix.noncommProd_mul_self_of_idempotent` — a product of pairwise-commuting idempotents is
+  idempotent.  Previously in `Fermion/JordanWigner/Hubbard/HardcoreProjection.lean`.
+* `Matrix.noncommProd_mulVec_eq_self` — a product of matrices each fixing a vector `ψ` also fixes
+  `ψ`.  Previously in `Fermion/JordanWigner/Hubbard/HardcoreProjection.lean`.
+
+None of these depend on any fermion-specific structure, so they belong in the generic
+matrix-analysis layer.  Hosting them upstream of the Jordan–Wigner files also removes the import
+cycle that forced the `HardcoreProjection` duplication.
+-/
+
+namespace Matrix
+
+variable {ι : Type*} {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- A non-commutative product of pairwise-commuting Hermitian matrices is Hermitian. -/
+theorem noncommProd_isHermitian
+    (s : Finset ι) (f : ι → Matrix n n ℂ)
+    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
+    (hHerm : ∀ a ∈ s, (f a).IsHermitian) :
+    (s.noncommProd f hcomm).IsHermitian := by
+  classical
+  induction s using Finset.induction_on with
+  | empty =>
+    simp only [Finset.noncommProd_empty]
+    exact Matrix.isHermitian_one
+  | @insert a t hat ih =>
+    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
+    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
+      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
+    have hHerm_t : ∀ b ∈ t, (f b).IsHermitian :=
+      fun b hb => hHerm b (Finset.mem_insert_of_mem hb)
+    refine Matrix.IsHermitian.mul_of_commute
+      (hHerm a (Finset.mem_insert_self a t)) (ih hcomm_t hHerm_t) ?_
+    apply Finset.noncommProd_commute
+    intro b hb
+    have hab : a ≠ b := fun h => hat (h ▸ hb)
+    exact hcomm (Finset.mem_insert_self a t) (Finset.mem_insert_of_mem hb) hab
+
+/-- A non-commutative product of pairwise-commuting matrices, each squaring to the identity, itself
+squares to the identity. -/
+theorem noncommProd_sq_of_sq_one
+    (s : Finset ι) (f : ι → Matrix n n ℂ)
+    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
+    (hSq : ∀ a ∈ s, f a * f a = 1) :
+    s.noncommProd f hcomm * s.noncommProd f hcomm = 1 := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simp only [Finset.noncommProd_empty]; rw [Matrix.one_mul]
+  | @insert a t hat ih =>
+    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
+    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
+      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
+    have hSq_t : ∀ b ∈ t, f b * f b = 1 :=
+      fun b hb => hSq b (Finset.mem_insert_of_mem hb)
+    have hcomm_a : Commute (f a) (t.noncommProd f hcomm_t) := by
+      apply Finset.noncommProd_commute
+      intro b hb
+      have hab : a ≠ b := fun h => hat (h ▸ hb)
+      exact hcomm (Finset.mem_insert_self a t) (Finset.mem_insert_of_mem hb) hab
+    rw [show f a * t.noncommProd f hcomm_t * (f a * t.noncommProd f hcomm_t)
+          = (f a * f a) * (t.noncommProd f hcomm_t * t.noncommProd f hcomm_t) by
+        rw [Matrix.mul_assoc,
+          ← Matrix.mul_assoc (t.noncommProd f hcomm_t) (f a),
+          ← hcomm_a.eq, Matrix.mul_assoc, Matrix.mul_assoc]]
+    rw [hSq a (Finset.mem_insert_self a t), Matrix.one_mul,
+      ih hcomm_t hSq_t]
+
+/-- A non-commutative product of pairwise-commuting idempotent matrices is itself idempotent.  This
+is the projection analogue of `noncommProd_sq_of_sq_one`: instead of `f a * f a = 1` we assume
+`f a * f a = f a`. -/
+theorem noncommProd_mul_self_of_idempotent
+    (s : Finset ι) (f : ι → Matrix n n ℂ)
+    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
+    (hId : ∀ a ∈ s, f a * f a = f a) :
+    s.noncommProd f hcomm * s.noncommProd f hcomm = s.noncommProd f hcomm := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simp only [Finset.noncommProd_empty]; rw [Matrix.one_mul]
+  | @insert a t hat ih =>
+    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
+    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
+      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
+    have hId_t : ∀ b ∈ t, f b * f b = f b :=
+      fun b hb => hId b (Finset.mem_insert_of_mem hb)
+    have hcomm_a : Commute (f a) (t.noncommProd f hcomm_t) := by
+      apply Finset.noncommProd_commute
+      intro b hb
+      have hab : a ≠ b := fun h => hat (h ▸ hb)
+      exact hcomm (Finset.mem_insert_self a t) (Finset.mem_insert_of_mem hb) hab
+    rw [show f a * t.noncommProd f hcomm_t * (f a * t.noncommProd f hcomm_t)
+          = (f a * f a) * (t.noncommProd f hcomm_t * t.noncommProd f hcomm_t) by
+        rw [Matrix.mul_assoc,
+          ← Matrix.mul_assoc (t.noncommProd f hcomm_t) (f a),
+          ← hcomm_a.eq, Matrix.mul_assoc, Matrix.mul_assoc]]
+    rw [hId a (Finset.mem_insert_self a t), ih hcomm_t hId_t]
+
+/-- A non-commutative product of matrices, each of which fixes a vector `ψ` under `mulVec`, also
+fixes `ψ`. -/
+theorem noncommProd_mulVec_eq_self
+    (s : Finset ι) (f : ι → Matrix n n ℂ)
+    (hcomm : (s : Set ι).Pairwise (fun a b => Commute (f a) (f b)))
+    (ψ : n → ℂ) (hfix : ∀ a ∈ s, (f a).mulVec ψ = ψ) :
+    (s.noncommProd f hcomm).mulVec ψ = ψ := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simp only [Finset.noncommProd_empty]; rw [Matrix.one_mulVec]
+  | @insert a t hat ih =>
+    rw [Finset.noncommProd_insert_of_notMem _ _ _ _ hat]
+    have hcomm_t : (t : Set ι).Pairwise (fun a b => Commute (f a) (f b)) :=
+      hcomm.mono fun x hx => Finset.mem_insert_of_mem hx
+    have hfix_t : ∀ b ∈ t, (f b).mulVec ψ = ψ :=
+      fun b hb => hfix b (Finset.mem_insert_of_mem hb)
+    rw [← Matrix.mulVec_mulVec, ih hcomm_t hfix_t,
+      hfix a (Finset.mem_insert_self a t)]
+
+end Matrix

--- a/LatticeSystem/Quantum/ManyBody.lean
+++ b/LatticeSystem/Quantum/ManyBody.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.Hermitian
+import LatticeSystem.Math.MatrixAnalysis.HermitianSum
 
 /-!
 # Multi-body operator space and site-embedded operators
@@ -191,14 +192,11 @@ theorem onSite_mul_onSite_of_ne {i j : Λ} (hij : i ≠ j)
   · exact absurd (hcond.mpr h2) h1
   · rfl
 
-/-! ## Products of commuting Hermitian matrices -/
+/-! ## Products of commuting Hermitian matrices
 
-/-- The product of two commuting Hermitian matrices is Hermitian. -/
-theorem Matrix.IsHermitian.mul_of_commute {n : Type*} [Fintype n]
-    {A B : Matrix n n ℂ} (hA : A.IsHermitian) (hB : B.IsHermitian)
-    (hcomm : A * B = B * A) : (A * B).IsHermitian := by
-  unfold Matrix.IsHermitian
-  rw [Matrix.conjTranspose_mul, hA, hB, hcomm]
+The generic fact `Matrix.IsHermitian.mul_of_commute` (the product of two commuting Hermitian
+matrices is Hermitian) now lives in `Math/MatrixAnalysis/HermitianSum.lean` and is re-exported via
+the import above. -/
 
 /-! ## Linearity of the site embedding -/
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -445,7 +445,25 @@ equality; specializing to `Λ = Fin N` recovers an `N`-site chain.
 | `basisVec` / `onSite_mulVec_basisVec` | tensor-product basis states and their action under site operators (Tasaki (2.2.1)/(2.2.4)) | `Quantum/ManyBody.lean` |
 | `onSite_mul_onSite_same` | same-site product `onSite i A · onSite i B = onSite i (A · B)` (Tasaki (2.2.6), `x = y`) | `Quantum/ManyBody.lean` |
 | `onSite_commutator_same` | same-site commutator `[onSite i A, onSite i B] = onSite i [A, B]` | `Quantum/ManyBody.lean` |
-| `Matrix.IsHermitian.mul_of_commute` | commuting Hermitians multiply Hermitian | `Quantum/ManyBody.lean` |
+| `Matrix.IsHermitian.mul_of_commute` | commuting Hermitians multiply Hermitian (generic; relocated to the matrix-analysis layer in PR #4342) | `Math/MatrixAnalysis/HermitianSum.lean` |
+
+### Generic matrix-analysis helpers (`Math/MatrixAnalysis/`)
+
+Topic-organized generic linear-algebra facts extracted from the physics files where they had been
+re-proved as private helpers (Issue [#4339](https://github.com/phasetr/lattice-system/issues/4339)).
+
+| Lean name | Statement | File |
+|---|---|---|
+| `Matrix.isHermitian_sum` | a finite sum of Hermitian matrices is Hermitian | `Math/MatrixAnalysis/HermitianSum.lean` |
+| `Matrix.IsHermitian.mul_of_commute` | the product of two commuting Hermitian matrices is Hermitian | `Math/MatrixAnalysis/HermitianSum.lean` |
+| `Matrix.noncommProd_isHermitian` | a `Finset.noncommProd` of pairwise-commuting Hermitian matrices is Hermitian | `Math/MatrixAnalysis/NoncommProd.lean` |
+| `Matrix.noncommProd_sq_of_sq_one` | a `Finset.noncommProd` of pairwise-commuting involutions is an involution | `Math/MatrixAnalysis/NoncommProd.lean` |
+| `Matrix.noncommProd_mul_self_of_idempotent` | a `Finset.noncommProd` of pairwise-commuting idempotents is idempotent | `Math/MatrixAnalysis/NoncommProd.lean` |
+| `Matrix.noncommProd_mulVec_eq_self` | a `Finset.noncommProd` of matrices each fixing `ψ` also fixes `ψ` | `Math/MatrixAnalysis/NoncommProd.lean` |
+
+These are consumed by the Jordan–Wigner string / Hubbard hard-core projection layers (PR #4342),
+replacing the per-file private copies in `Fermion/JWAbstract.lean`,
+`Fermion/JordanWigner/Operators.lean`, and `Fermion/JordanWigner/Hubbard/HardcoreProjection.lean`.
 
 ### Total spin operator (Tasaki §2.2 eq. (2.2.7), (2.2.8))
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4286,7 +4286,14 @@ The string is a noncomm-product of pairwise-commuting Hermitian
 $\sigma^z_j$ factors.  An induction over the Finset, using
 \texttt{Matrix.IsHermitian.mul\_of\_commute} at each step (the new
 factor commutes with the rest by
-\texttt{Finset.noncommProd\_commute}), establishes the result.
+\texttt{Finset.noncommProd\_commute}), establishes the result.  This
+induction is packaged once as the generic helper
+\texttt{Matrix.noncommProd\_isHermitian} in
+\texttt{Math/MatrixAnalysis/NoncommProd.lean}, together with the
+involution (\texttt{noncommProd\_sq\_of\_sq\_one}), idempotent
+(\texttt{noncommProd\_mul\_self\_of\_idempotent}), and vector-fixing
+(\texttt{noncommProd\_mulVec\_eq\_self}) analogues shared across the
+Jordan--Wigner and Hubbard hard-core layers.
 \end{proof}
 
 \begin{lemma}[\texttt{fermionMultiAnnihilation\_conjTranspose},


### PR DESCRIPTION
Tracked in #4339.

## Summary

Second extraction in the Issue #4339 generic-proposition sweep. Centralizes the
`Finset.noncommProd` algebra helpers (and the commuting-Hermitian-product lemma)
that several Jordan–Wigner / Hubbard files re-proved as private or near-duplicate
public copies.

New `LatticeSystem/Math/MatrixAnalysis/NoncommProd.lean` (all in `namespace Matrix`):

- `noncommProd_isHermitian` — product of pairwise-commuting Hermitian matrices is Hermitian.
- `noncommProd_sq_of_sq_one` — product of pairwise-commuting involutions is an involution.
- `noncommProd_mul_self_of_idempotent` — product of pairwise-commuting idempotents is idempotent.
- `noncommProd_mulVec_eq_self` — product of matrices each fixing `ψ` also fixes `ψ`.

`Matrix.IsHermitian.mul_of_commute` (the product of two commuting Hermitian
matrices is Hermitian) is relocated out of the widely-imported physics file
`Quantum/ManyBody.lean` into `Math/MatrixAnalysis/HermitianSum.lean` and
re-exported via import — all existing call sites keep the same name.

Duplicates removed:

- `Fermion/JWAbstract.lean` — two public copies (`noncommProd_isHermitian`, `noncommProd_sq_of_sq_one`).
- `Fermion/JordanWigner/Operators.lean` — two private variants
  (`noncommProd_isHermitian_of_pairwise_commute_of_isHermitian`,
  `noncommProd_sq_of_pairwise_commute_of_sq_one`).
- `Fermion/JordanWigner/Hubbard/HardcoreProjection.lean` — three privates, one of which carried an
  explicit "duplicated because of an import cycle" comment. Hosting the helpers upstream in the
  `Math` layer removes that cycle workaround entirely.

Net: 6 files, +172 / −217 lines. No new mathematical content; pure deduplication
into the topic-organized matrix-analysis layer.

## Build-speed evaluation

Relocating `mul_of_commute` touches `Quantum/ManyBody.lean`, which is a deep
dependency, so this PR triggers a near-full rebuild. That is a one-time cost of
the relocation; steady-state build cost is unchanged (the lemmas were already
being elaborated, now once instead of up to three times). Full `lake build`
green (3997 jobs).

## Verification

- `lake build` green (3997 jobs), zero linter warnings on the new files.
- `proof-guide.tex` rebuilds (261 pages); docs/index.md gains a Generic
  matrix-analysis helpers section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
