### PR TITLE
Use mathlib Matrix.conjTranspose_sum instead of private re-proofs — #4339

### DIFF
--- a/LatticeSystem/Quantum/SpinS/TotalSpin.lean
+++ b/LatticeSystem/Quantum/SpinS/TotalSpin.lean
@@ -102,23 +102,11 @@ theorem onSiteS_conjTranspose (i : Λ)
       h (fun k hk => (hp k hk).symm)
     rw [if_neg h, if_neg h', star_zero]
 
-omit [Fintype Λ] [DecidableEq Λ] in
-/-- Conjugate transpose distributes over finite sums in `ManyBodyOpS Λ N`. -/
-private lemma sum_conjTranspose_manyBodyS {N : ℕ}
-    {s : Finset Λ} (f : Λ → ManyBodyOpS Λ N) :
-    (∑ x ∈ s, f x).conjTranspose = ∑ x ∈ s, (f x).conjTranspose := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simp
-  | @insert a t hns ih =>
-    rw [Finset.sum_insert hns, Finset.sum_insert hns,
-      Matrix.conjTranspose_add, ih]
-
 /-- `(Ŝ_tot^+)† = Ŝ_tot^-`. -/
 theorem totalSpinSOpPlus_conjTranspose :
     (totalSpinSOpPlus Λ N).conjTranspose = totalSpinSOpMinus Λ N := by
   unfold totalSpinSOpPlus totalSpinSOpMinus
-  rw [sum_conjTranspose_manyBodyS]
+  rw [Matrix.conjTranspose_sum]
   refine Finset.sum_congr rfl fun x _ => ?_
   rw [onSiteS_conjTranspose, spinSOpPlus_conjTranspose]
 
@@ -126,7 +114,7 @@ theorem totalSpinSOpPlus_conjTranspose :
 theorem totalSpinSOpMinus_conjTranspose :
     (totalSpinSOpMinus Λ N).conjTranspose = totalSpinSOpPlus Λ N := by
   unfold totalSpinSOpPlus totalSpinSOpMinus
-  rw [sum_conjTranspose_manyBodyS]
+  rw [Matrix.conjTranspose_sum]
   refine Finset.sum_congr rfl fun x _ => ?_
   rw [onSiteS_conjTranspose, spinSOpMinus_conjTranspose]
 

--- a/LatticeSystem/Quantum/TotalSpin.lean
+++ b/LatticeSystem/Quantum/TotalSpin.lean
@@ -470,23 +470,11 @@ theorem onSite_conjTranspose (i : Λ) (A : Matrix (Fin 2) (Fin 2) ℂ) :
       h (fun k hk => (hp k hk).symm)
     rw [if_neg h, if_neg h', star_zero]
 
-omit [Fintype Λ] [DecidableEq Λ] in
-/-- Conjugate transpose distributes over finite sums in `ManyBodyOp Λ`. -/
-private lemma sum_conjTranspose_manyBody
-    {s : Finset Λ} (f : Λ → ManyBodyOp Λ) :
-    (∑ x ∈ s, f x).conjTranspose = ∑ x ∈ s, (f x).conjTranspose := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simp
-  | @insert a t hns ih =>
-    rw [Finset.sum_insert hns, Finset.sum_insert hns,
-      Matrix.conjTranspose_add, ih]
-
 /-- `(Ŝ^+_tot)† = Ŝ^-_tot`. -/
 theorem totalSpinHalfOpPlus_conjTranspose :
     (totalSpinHalfOpPlus Λ).conjTranspose = totalSpinHalfOpMinus Λ := by
   unfold totalSpinHalfOpPlus totalSpinHalfOpMinus
-  rw [sum_conjTranspose_manyBody]
+  rw [Matrix.conjTranspose_sum]
   refine Finset.sum_congr rfl fun x _ => ?_
   rw [onSite_conjTranspose, spinHalfOpPlus_conjTranspose]
 
@@ -494,7 +482,7 @@ theorem totalSpinHalfOpPlus_conjTranspose :
 theorem totalSpinHalfOpMinus_conjTranspose :
     (totalSpinHalfOpMinus Λ).conjTranspose = totalSpinHalfOpPlus Λ := by
   unfold totalSpinHalfOpPlus totalSpinHalfOpMinus
-  rw [sum_conjTranspose_manyBody]
+  rw [Matrix.conjTranspose_sum]
   refine Finset.sum_congr rfl fun x _ => ?_
   rw [onSite_conjTranspose, spinHalfOpMinus_conjTranspose]
 


### PR DESCRIPTION
Tracked in #4339.

## Summary

Third extraction in the Issue #4339 generic-helper sweep, and the simplest:
removes two *reinvented* mathlib lemmas. The private helpers

- `sum_conjTranspose_manyBody` (`Quantum/TotalSpin.lean`)
- `sum_conjTranspose_manyBodyS` (`Quantum/SpinS/TotalSpin.lean`)

were verbatim inductive re-proofs of mathlib's `Matrix.conjTranspose_sum`
(`(∑ i ∈ s, M i)ᴴ = ∑ i ∈ s, (M i)ᴴ`). They are deleted and the four call sites
(`totalSpinHalfOp±_conjTranspose`, `totalSpinSOp±_conjTranspose`) now `rw
[Matrix.conjTranspose_sum]` directly.

No new public declarations (both helpers were `private`); pure removal of
duplicated-from-mathlib code.

## Build-speed evaluation

Neutral-to-positive: two fewer private lemmas to elaborate. Both files are
widely imported, so this triggers a near-full rebuild as a one-time cost; no
steady-state change.

## Verification

- `lake build` green.
- No docs/tex changes required (the deleted lemmas were private and undocumented;
  no new public theorem is introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
