### PR TITLE
Refactor (20-PR cadence): post-Chapter-8 build-speed eval + doc long-line fix — #4485

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorInverseLift.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorInverseLift.lean
@@ -7,7 +7,8 @@ import LatticeSystem.Quantum.SpinS.MagSectorEmbedding
 
 Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) first-crossing argument.
 
-The anisotropic analog of `heisenbergHamiltonianSMatrixOnMagSector_mulVec_magSectorRestriction_of_full_eigen`
+The anisotropic analog of
+`heisenbergHamiltonianSMatrixOnMagSector_mulVec_magSectorRestriction_of_full_eigen`
 (in `MagSectorEmbedding.lean`): a full-Hilbert-space eigenvector `Ψ` of
 `Ĥ(λ, D)` at energy `μ` restricts to a sector-`M` eigenvector of the sector
 submatrix `Ĥ_M(λ, D)` at the same `μ`.


### PR DESCRIPTION
Tracked in #4485.

**Mandatory refactoring PR (20-PR cadence)** — inserted after 17 feature PRs since the last refactor (#4525), at the natural **Chapter-7+8-complete** boundary.

## Build-speed evaluation (required)
The 18 new §7/§8 SpinS modules (Chapters 7–8 backfill, PRs #4524–#4542) are all small (67–134 lines, **one file per textbook section**). Timed clean rebuilds:

| Module | Time |
|--------|------|
| `ToricCode` | 8.0s (heaviest — concrete torus lattice + `List.prod` stabilizers) |
| `SPTPhase` | 2.6s |
| `AKLTMatrixProduct` | 2.7s |
| (the rest) | ~2–3s each |

**Conclusion:** no module is a split candidate. The per-section granularity keeps every file fast and independently buildable, so **no build-speed action is needed**.

## Action taken
- Fixed a doc-comment long-line in `AnisotropicHeisenbergMagSectorInverseLift.lean` (the only long-line warning outside the new files; the new §7/§8 files are all warning-free).

## Deferred (own refactor PR)
A full-root build surfaces ~267 pre-existing `show`-tactic-style warnings (plus a couple of long-lines), **concentrated in the older Theorem-2.4 / MagSector proof files** — *not* in the new §7/§8 modules. CI passes with these. Clearing them safely requires a dedicated pass over the old proofs (bulk `show` edits risk breaking proofs), so it is scheduled as its own lint-cleanup refactor PR rather than bundled here.

`lake build` green; the touched file rebuilds warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
