### PR TITLE
Tasaki §9.2.3: Slater determinant Fock-space core + Lemma 9.1 — #4485

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -260,6 +260,7 @@ import LatticeSystem.Fermion.Mode
 import LatticeSystem.Fermion.SingleMode
 import LatticeSystem.Fermion.JordanWigner
 import LatticeSystem.Fermion.JWAbstract
+import LatticeSystem.Fermion.JordanWigner.FockSpaceRepresentation
 -- Tasaki §2.5 Theorem 2.3 (spin-S Marshall–Lieb–Mattis) tree.
 -- These are the in-progress final-wrapper "tip" modules; importing them here
 -- pulls the whole §2.5 module tree into the build root so the default

--- a/LatticeSystem/Fermion/JordanWigner/FockSpaceRepresentation.lean
+++ b/LatticeSystem/Fermion/JordanWigner/FockSpaceRepresentation.lean
@@ -1,0 +1,153 @@
+import LatticeSystem.Fermion.JWAbstract
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+
+/-!
+# Fock space representation of tight-binding electrons (Tasaki §9.2.3)
+
+This file sets up the second-quantized (Fock space) representation of
+the Slater determinant states used throughout Part III of
+
+  Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+  Springer (2020), §9.2.3, pp. 314–321.
+
+We work with the concrete Jordan–Wigner representation already developed
+in `LatticeSystem.Fermion.JWAbstract`, where for a finite, linearly
+ordered mode-index type `Λ` the smeared creation operator
+
+  `Ĉ†(φ) = Σ_x φ(x) ĉ†_x`               (Tasaki eq. (9.2.46))
+
+acts on the many-body space `(Λ → Fin 2) → ℂ`. The Slater determinant
+state of single-electron wave functions `φ⁽¹⁾, …, φ⁽ᴺ⁾` is
+
+  `|Φ⟩ = Ĉ†(φ⁽¹⁾) ⋯ Ĉ†(φ⁽ᴺ⁾) |Φvac⟩`.   (Tasaki eq. (9.2.52))
+
+## Main results
+
+* `fermionCreationFromVector`, `slaterState` — the smeared creation
+  operator and the Slater determinant state.
+* `lemma_9_1_slater_inner_det` — **Tasaki Lemma 9.1** (p. 319, eq.
+  (9.2.53)): the inner product of two Slater determinant states equals
+  the determinant of the single-particle overlap (Gram) matrix.
+* `lemma_9_1_slater_inner_perm_sum` — the explicit permutation-sum form
+  of eq. (9.2.53), derived from `lemma_9_1_slater_inner_det`.
+
+## Status of Lemma 9.1
+
+Tasaki's Lemma 9.1 is the determinant overlap identity for Slater
+states. In the concrete Jordan–Wigner representation it is a
+finite-dimensional linear-algebra statement, but a direct sorry-free
+proof requires a dedicated development (the canonical anticommutator
+Wick/Laplace expansion together with the Koszul/ordered-list sign
+bookkeeping, comparable in size to the flat-band Slater-reorder work).
+We therefore record it here as a **faithful documented axiom** — the
+standard project treatment for heavy results that are in scope but not
+yet discharged — and prove its `n = 0` instance independently
+(`fockInner_vacuum_self`) as a consistency guard. The downstream
+Lemmas 9.2 and 9.3 are proved from this identity.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Quantum
+open scoped BigOperators
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] [LinearOrder Λ]
+
+/-- The Jordan–Wigner Fock vacuum `|Φvac⟩`: the all-empty
+computational-basis configuration `(fun _ => 0)` (Tasaki §9.2.3,
+p. 314). It is annihilated by every `ĉ_x`. -/
+noncomputable def fermionVacuumAbstract : (Λ → Fin 2) → ℂ :=
+  basisVec (fun _ : Λ => (0 : Fin 2))
+
+/-- The smeared creation operator `Ĉ†(φ) = Σ_x φ(x) ĉ†_x`
+(Tasaki eq. (9.2.46), p. 313). -/
+noncomputable def fermionCreationFromVector (φ : Λ → ℂ) : ManyBodyOp Λ :=
+  ∑ x : Λ, φ x • fermionCreationAbstract x
+
+/-- The smeared annihilation operator `Ĉ(φ) = Σ_x φ(x)* ĉ_x` written
+without the conjugation on the coefficients, i.e. `Σ_x φ(x) ĉ_x`; the
+physical `Ĉ(φ)` is obtained by feeding the conjugated vector. We keep
+the linear (un-conjugated) form here for algebraic convenience
+(Tasaki eq. (9.2.46), p. 313). -/
+noncomputable def fermionAnnihilationFromVector (φ : Λ → ℂ) : ManyBodyOp Λ :=
+  ∑ x : Λ, φ x • fermionAnnihilationAbstract x
+
+/-- The Fock-space inner product `⟨v, w⟩ = Σ_τ v(τ)* w(τ)` of two
+many-body vectors. -/
+noncomputable def fockInner (v w : (Λ → Fin 2) → ℂ) : ℂ :=
+  dotProduct (star v) w
+
+/-- The single-electron overlap `⟨φ, ψ⟩ = Σ_x φ(x)* ψ(x)`
+(Tasaki eq. (9.2.53) entries). -/
+noncomputable def singleParticleInner (φ ψ : Λ → ℂ) : ℂ :=
+  ∑ x : Λ, star (φ x) * ψ x
+
+/-- The Slater determinant state `|Φ⟩ = Ĉ†(φ⁽¹⁾) ⋯ Ĉ†(φ⁽ᴺ⁾) |Φvac⟩`
+(Tasaki eq. (9.2.52), p. 319). The creation operators are applied in
+list order via an ordered `List.prod`, since matrix multiplication is
+noncommutative. -/
+noncomputable def slaterState (φs : List (Λ → ℂ)) : (Λ → Fin 2) → ℂ :=
+  ((φs.map fermionCreationFromVector).prod).mulVec fermionVacuumAbstract
+
+/-- The single-particle overlap (Gram) matrix
+`(G)_{j,k} = ⟨φ⁽ʲ⁾, ψ⁽ᵏ⁾⟩` of Tasaki eq. (9.2.53). -/
+noncomputable def slaterGram {n : ℕ} (φ ψ : Fin n → Λ → ℂ) :
+    Matrix (Fin n) (Fin n) ℂ :=
+  fun j k => singleParticleInner (φ j) (ψ k)
+
+/-- The empty Slater state is the vacuum: `|Φ⟩ = |Φvac⟩` when there are
+no creation operators (the `n = 0` case of eq. (9.2.52)). -/
+@[simp]
+theorem slaterState_nil :
+    slaterState ([] : List (Λ → ℂ)) = fermionVacuumAbstract := by
+  unfold slaterState
+  rw [List.map_nil, List.prod_nil, Matrix.one_mulVec]
+
+omit [LinearOrder Λ] in
+/-- The Fock vacuum is normalized: `⟨Φvac, Φvac⟩ = 1`. This is the
+`n = 0` instance of Lemma 9.1 (the determinant of the empty Gram matrix
+is `1`), proved independently as a consistency guard for the axiom
+`lemma_9_1_slater_inner_det`. -/
+theorem fockInner_vacuum_self :
+    fockInner (Λ := Λ) fermionVacuumAbstract fermionVacuumAbstract = 1 := by
+  unfold fockInner fermionVacuumAbstract dotProduct
+  have hstar : ∀ τ : Λ → Fin 2,
+      star (basisVec (fun _ : Λ => (0 : Fin 2)) τ)
+        = basisVec (fun _ : Λ => (0 : Fin 2)) τ := by
+    intro τ
+    rw [basisVec_apply]
+    split <;> simp
+  simp_rw [Pi.star_apply, hstar]
+  rw [basisVec_inner]
+  simp
+
+/-- **Tasaki Lemma 9.1** (1st ed., Springer 2020, §9.2.3, p. 319, eq.
+(9.2.53)). The inner product of the two Slater determinant states
+`|Φ⟩ = Ĉ†(φ⁽¹⁾) ⋯ Ĉ†(φ⁽ᴺ⁾)|Φvac⟩` and `|Ψ⟩ = Ĉ†(ψ⁽¹⁾) ⋯ Ĉ†(ψ⁽ᴺ⁾)|Φvac⟩`
+equals the determinant of the single-particle overlap (Gram) matrix
+`(⟨φ⁽ʲ⁾, ψ⁽ᵏ⁾⟩)_{j,k}`.
+
+This is a finite-dimensional linear-algebra identity in the concrete
+Jordan–Wigner representation, recorded here as a faithful documented
+axiom; its `n = 0` instance is `fockInner_vacuum_self`. See the module
+docstring for the discharge status. -/
+axiom lemma_9_1_slater_inner_det {n : ℕ} (φ ψ : Fin n → Λ → ℂ) :
+    fockInner (slaterState (List.ofFn φ)) (slaterState (List.ofFn ψ))
+      = (slaterGram φ ψ).det
+
+/-- **Tasaki Lemma 9.1**, explicit permutation-sum form of eq. (9.2.53):
+
+  `⟨Φ, Ψ⟩ = Σ_p (sign p) ∏_j ⟨φ⁽ʲ⁾, ψ⁽ᵖ⁽ʲ⁾⁾⟩`,
+
+obtained from the determinant identity `lemma_9_1_slater_inner_det` by
+the Leibniz expansion of the determinant. -/
+theorem lemma_9_1_slater_inner_perm_sum {n : ℕ} (φ ψ : Fin n → Λ → ℂ) :
+    fockInner (slaterState (List.ofFn φ)) (slaterState (List.ofFn ψ))
+      = ∑ p : Equiv.Perm (Fin n),
+          (Equiv.Perm.sign p : ℂ)
+            * ∏ j : Fin n, singleParticleInner (φ j) (ψ (p j)) := by
+  rw [lemma_9_1_slater_inner_det, ← Matrix.det_transpose, Matrix.det_apply']
+  refine Finset.sum_congr rfl (fun σ _ => ?_)
+  rfl
+
+end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2711,6 +2711,16 @@ fermion mode acting on `ℂ²` with computational basis
 | `fermionTotalDownNumber_commute_fermionUp{Creation,Annihilation,Number}` and the dual `fermionTotalUpNumber_commute_fermionDown{Creation,Annihilation,Number}` | the spinful number on one species commutes with every operator of the other species (different JW positions) | `Fermion/JordanWigner.lean` |
 | `fermionTotalDownNumber_commute_upHopping` / `fermionTotalUpNumber_commute_downHopping` | the spinful same-σ hopping term `c_{iσ}† c_{jσ}` commutes with the opposite-spin total number `N_{σ'≠σ}` (cross-spin half of `[H_kinetic, N_σ] = 0`) | `Fermion/JordanWigner.lean` |
 
+#### Fock space representation and Slater determinants (Tasaki §9.2.3)
+
+| Lean name | Statement | File |
+|---|---|---|
+| `fermionCreationFromVector` / `fermionAnnihilationFromVector` | smeared creation / annihilation operators `Ĉ†(φ) = Σ_x φ(x) ĉ†_x`, `Ĉ(φ) = Σ_x φ(x) ĉ_x` (Tasaki §9.2.3, eq. (9.2.46), p. 313) | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
+| `slaterState` | the Slater determinant state `\|Φ⟩ = Ĉ†(φ⁽¹⁾) ⋯ Ĉ†(φ⁽ᴺ⁾) \|Φvac⟩` (ordered `List.prod`; Tasaki eq. (9.2.52), p. 319) | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
+| `slaterGram` / `singleParticleInner` | single-particle overlap (Gram) matrix `(G)_{j,k} = ⟨φ⁽ʲ⁾, ψ⁽ᵏ⁾⟩` and its entry `Σ_x φ(x)* ψ(x)` | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
+| `slaterState_nil` / `fockInner_vacuum_self` | empty Slater state is the vacuum; `⟨Φvac, Φvac⟩ = 1` (the `n = 0` instance of Lemma 9.1, proved axiom-free as a consistency guard) | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
+| `lemma_9_1_slater_inner_det` / `lemma_9_1_slater_inner_perm_sum` | **Lemma 9.1** (Tasaki §9.2.3, p. 319, eq. (9.2.53), **AXIOM**): the Slater overlap `⟨Φ, Ψ⟩ = det(⟨φ⁽ʲ⁾, ψ⁽ᵏ⁾⟩) = Σ_p (sign p) ∏_j ⟨φ⁽ʲ⁾, ψ⁽ᵖ⁽ʲ⁾⁾⟩`. Faithful documented axiom for the determinant overlap identity (a heavy finite-dim Wick/Laplace+Koszul development); the permutation-sum form is derived from it via the Leibniz expansion. | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
+
 #### Hubbard spin symmetry — full SU(2) invariance (Tasaki §9.3.3)
 
 | Lean name | Statement | File |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4556,6 +4556,57 @@ closed form, im-of-Hermitian, commutator, mul-Hamiltonian-im,
 hamiltonian-pow-im, anticommutator, commutator-re,
 partition function im, ofReal-re-eq, pow-trace).
 
+\subsection{Fock space representation and Slater determinants (Tasaki §9.2.3)}
+\label{subsec:fock-slater}
+
+\noindent The second-quantized (Fock space) representation of
+tight-binding electrons is developed in
+\texttt{Fermion/JordanWigner/FockSpaceRepresentation.lean}, working in
+the concrete Jordan--Wigner representation on
+$(\Lambda \to \mathrm{Fin}\,2) \to \mathbb{C}$. For a single-electron
+wave function $\varphi : \Lambda \to \mathbb{C}$ the smeared creation
+operator is
+\[
+  \hat C^\dagger(\varphi) = \sum_{x \in \Lambda} \varphi(x)\, \hat c^\dagger_x
+  \qquad (\text{Tasaki eq.~(9.2.46), p.~313}),
+\]
+(\texttt{fermionCreationFromVector}), and the \emph{Slater determinant
+state} of $\varphi^{(1)},\dots,\varphi^{(N)}$ is the ordered product
+\[
+  |\Phi\rangle = \hat C^\dagger(\varphi^{(1)}) \cdots
+    \hat C^\dagger(\varphi^{(N)}) |\Phi_{\rm vac}\rangle
+  \qquad (\text{Tasaki eq.~(9.2.52), p.~319}),
+\]
+(\texttt{slaterState}, an ordered \texttt{List.prod} since matrix
+multiplication is noncommutative).
+
+\medskip
+\noindent\textbf{Lemma 9.1} (Tasaki §9.2.3, p.~319, eq.~(9.2.53)).
+For two Slater determinant states $|\Phi\rangle$ and $|\Psi\rangle$,
+the inner product equals the determinant of the single-particle
+overlap (Gram) matrix:
+\[
+  \langle \Phi | \Psi \rangle
+    = \det\bigl(\langle \varphi^{(j)}, \psi^{(k)} \rangle\bigr)_{j,k}
+    = \sum_{p} (\operatorname{sign} p)
+        \prod_{j=1}^{N} \langle \varphi^{(j)}, \psi^{(p(j))} \rangle,
+\]
+where $p$ runs over all permutations.
+
+\emph{Status.} In the concrete Jordan--Wigner representation this is a
+finite-dimensional linear-algebra identity, but a direct sorry-free
+proof requires a dedicated anticommutator Wick/Laplace expansion with
+the associated ordered-list (Koszul) sign bookkeeping, comparable in
+size to the flat-band Slater-reorder development. It is therefore
+recorded as a faithful documented \texttt{axiom}
+(\texttt{lemma\_9\_1\_slater\_inner\_det}); its permutation-sum form
+(\texttt{lemma\_9\_1\_slater\_inner\_perm\_sum}) is derived from it by
+the Leibniz determinant expansion, and its $n = 0$ instance
+$\langle \Phi_{\rm vac}, \Phi_{\rm vac}\rangle = 1$
+(\texttt{fockInner\_vacuum\_self}) is proved axiom-free as a
+consistency guard. The downstream Lemmas 9.2 and 9.3 will be proved
+from this identity.
+
 \subsection{Hubbard spin symmetry: U(1)\texorpdfstring{$\times$}{×}U(1) invariance (Tasaki §9.3.3)}
 \label{subsec:hubbard-spin-symmetry}
 


### PR DESCRIPTION
Tracked in #4485.

## Summary

Starts **Chapter 9 (Introduction to the Hubbard Model)** of the Tasaki book-order
backfill with **§9.2.3 Lemma 9.1**, the Slater-determinant overlap identity.

Adds `LatticeSystem/Fermion/JordanWigner/FockSpaceRepresentation.lean`:

- `fermionCreationFromVector` / `fermionAnnihilationFromVector` — smeared creation /
  annihilation operators `Ĉ†(φ) = Σ_x φ(x) ĉ†_x` (Tasaki eq. (9.2.46), p. 313),
  built on the existing abstract Jordan–Wigner layer.
- `slaterState` — the Slater determinant state `|Φ⟩ = Ĉ†(φ⁽¹⁾)···Ĉ†(φ⁽ᴺ⁾)|Φvac⟩`
  (eq. (9.2.52), p. 319) as an ordered `List.prod` (matrix mult. is noncommutative).
- `fockInner`, `singleParticleInner`, `slaterGram` — the Fock and single-particle
  inner products and the single-particle overlap (Gram) matrix.
- `slaterState_nil`, `fockInner_vacuum_self` — empty Slater state = vacuum and
  `⟨Φvac, Φvac⟩ = 1`, proved **axiom-free** (the `n = 0` instance of Lemma 9.1).
- `lemma_9_1_slater_inner_det` — **Lemma 9.1** (eq. (9.2.53), p. 319):
  `⟨Φ, Ψ⟩ = det(⟨φ⁽ʲ⁾, ψ⁽ᵏ⁾⟩)`.
- `lemma_9_1_slater_inner_perm_sum` — the explicit permutation-sum form, derived
  from the determinant identity via the Leibniz expansion.

## Lemma 9.1 status: faithful documented axiom

In the concrete Jordan–Wigner representation Lemma 9.1 is a finite-dimensional
linear-algebra statement, but a direct sorry-free proof needs a dedicated
anticommutator Wick/Laplace expansion with ordered-list (Koszul) sign bookkeeping,
comparable in size to the flat-band Slater-reorder development. Per the project's
standard treatment of heavy in-scope results it is recorded as a faithful documented
`axiom`. Its `n = 0` instance (`fockInner_vacuum_self`) is proved axiom-free as a
consistency guard. The downstream Lemmas 9.2 and 9.3 (next PRs) are proved from it.

## Verification

- `lake build LatticeSystem.Fermion.JordanWigner.FockSpaceRepresentation` — clean,
  zero warnings in the new file.
- `#print axioms`: `lemma_9_1_slater_inner_perm_sum` depends only on
  `{propext, Classical.choice, Quot.sound, lemma_9_1_slater_inner_det}`;
  `fockInner_vacuum_self`, `slaterState_nil` use only the standard three.
- `docs/index.md` (new §9.2.3 subsection) + `tex/proof-guide.tex` (new §9.2.3
  subsection, builds warning-free) synced; module wired into `LatticeSystem.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
