### PR TITLE
Tasaki §9.2.3: Slater state nonvanishing iff linearly independent (Lemma 9.2) — #4485

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/FockSpaceRepresentation.lean
+++ b/LatticeSystem/Fermion/JordanWigner/FockSpaceRepresentation.lean
@@ -1,5 +1,8 @@
 import LatticeSystem.Fermion.JWAbstract
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.LinearAlgebra.Matrix.DotProduct
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import Mathlib.LinearAlgebra.Matrix.ToLin
 
 /-!
 # Fock space representation of tight-binding electrons (Tasaki §9.2.3)
@@ -30,6 +33,9 @@ state of single-electron wave functions `φ⁽¹⁾, …, φ⁽ᴺ⁾` is
   the determinant of the single-particle overlap (Gram) matrix.
 * `lemma_9_1_slater_inner_perm_sum` — the explicit permutation-sum form
   of eq. (9.2.53), derived from `lemma_9_1_slater_inner_det`.
+* `lemma_9_2_slater_ne_zero_iff_linearIndependent` — **Tasaki Lemma 9.2**
+  (p. 320): the Slater determinant state is nonvanishing iff its
+  single-electron wave functions are linearly independent.
 
 ## Status of Lemma 9.1
 
@@ -49,7 +55,7 @@ Lemmas 9.2 and 9.3 are proved from this identity.
 namespace LatticeSystem.Fermion
 
 open Matrix LatticeSystem.Quantum
-open scoped BigOperators
+open scoped BigOperators ComplexOrder
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] [LinearOrder Λ]
 
@@ -149,5 +155,66 @@ theorem lemma_9_1_slater_inner_perm_sum {n : ℕ} (φ ψ : Fin n → Λ → ℂ)
   rw [lemma_9_1_slater_inner_det, ← Matrix.det_transpose, Matrix.det_apply']
   refine Finset.sum_congr rfl (fun σ _ => ?_)
   rfl
+
+/-- The `Λ × Fin n` coefficient matrix whose `j`-th column is the
+single-electron wave function `φ⁽ʲ⁾`:
+`(slaterCoeffMatrix φ) x j = φ⁽ʲ⁾(x)`. -/
+noncomputable def slaterCoeffMatrix {n : ℕ} (φ : Fin n → Λ → ℂ) :
+    Matrix Λ (Fin n) ℂ :=
+  Matrix.of (fun x j => φ j x)
+
+omit [DecidableEq Λ] [LinearOrder Λ] in
+/-- The single-particle overlap (Gram) matrix of a family with itself is
+the conjugate-transpose square `Aᴴ A` of its coefficient matrix
+`A = slaterCoeffMatrix φ`: `(G)_{j,k} = ⟨φ⁽ʲ⁾, φ⁽ᵏ⁾⟩ = (Aᴴ A)_{j,k}`. -/
+theorem slaterGram_self_eq_conjTranspose_mul_self {n : ℕ} (φ : Fin n → Λ → ℂ) :
+    slaterGram φ φ = (slaterCoeffMatrix φ)ᴴ * slaterCoeffMatrix φ := by
+  ext j k
+  simp only [slaterGram, singleParticleInner, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, slaterCoeffMatrix, Matrix.of_apply]
+
+omit [DecidableEq Λ] [LinearOrder Λ] in
+/-- The Gram determinant of a family with itself is nonzero iff the family
+is linearly independent. This is the linear-algebra core behind Lemma 9.2:
+`det(⟨φ⁽ʲ⁾, φ⁽ᵏ⁾⟩) ≠ 0 ↔ φ` are linearly independent, via `G = Aᴴ A`,
+`ker(Aᴴ A) = ker A`, and the column-injectivity criterion. -/
+theorem slaterGram_self_det_ne_zero_iff {n : ℕ} (φ : Fin n → Λ → ℂ) :
+    (slaterGram φ φ).det ≠ 0 ↔ LinearIndependent ℂ φ := by
+  have hcol : (slaterCoeffMatrix φ).col = φ := by
+    funext j; funext x; rfl
+  have hLI : LinearIndependent ℂ φ ↔
+      Function.Injective (slaterCoeffMatrix φ).mulVec := by
+    rw [Matrix.mulVec_injective_iff, hcol]
+  have hker :
+      Function.Injective ((slaterCoeffMatrix φ)ᴴ * slaterCoeffMatrix φ).mulVec ↔
+        Function.Injective (slaterCoeffMatrix φ).mulVec := by
+    rw [← Matrix.coe_mulVecLin, ← Matrix.coe_mulVecLin,
+      ← LinearMap.ker_eq_bot, ← LinearMap.ker_eq_bot,
+      Matrix.ker_mulVecLin_eq_bot_iff, Matrix.ker_mulVecLin_eq_bot_iff]
+    constructor
+    · intro h v hv
+      exact h v ((Matrix.conjTranspose_mul_self_mulVec_eq_zero _ v).mpr hv)
+    · intro h v hv
+      exact h v ((Matrix.conjTranspose_mul_self_mulVec_eq_zero _ v).mp hv)
+  rw [slaterGram_self_eq_conjTranspose_mul_self, ← isUnit_iff_ne_zero,
+    ← Matrix.isUnit_iff_isUnit_det, ← Matrix.mulVec_injective_iff_isUnit,
+    hker, ← hLI]
+
+/-- **Tasaki Lemma 9.2** (1st ed., Springer 2020, §9.2.3, p. 320). The
+Slater determinant state `|Φ⟩ = Ĉ†(φ⁽¹⁾) ⋯ Ĉ†(φ⁽ᴺ⁾)|Φvac⟩` is
+nonvanishing if and only if the `N` single-electron wave functions
+`φ⁽¹⁾, …, φ⁽ᴺ⁾` are linearly independent.
+
+Proof: by Lemma 9.1 (with `ψ = φ`) the squared norm `⟨Φ, Φ⟩` equals the
+Gram determinant `det(⟨φ⁽ʲ⁾, φ⁽ᵏ⁾⟩)`; the Fock inner product is positive
+definite, so `Φ = 0` iff `⟨Φ, Φ⟩ = 0`, and the Gram determinant vanishes
+iff the family is linearly dependent. -/
+theorem lemma_9_2_slater_ne_zero_iff_linearIndependent {n : ℕ}
+    (φ : Fin n → Λ → ℂ) :
+    slaterState (List.ofFn φ) ≠ 0 ↔ LinearIndependent ℂ φ := by
+  rw [← slaterGram_self_det_ne_zero_iff, ← lemma_9_1_slater_inner_det,
+    ne_eq, ne_eq, not_iff_not]
+  unfold fockInner
+  exact dotProduct_star_self_eq_zero.symm
 
 end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2720,6 +2720,8 @@ fermion mode acting on `ℂ²` with computational basis
 | `slaterGram` / `singleParticleInner` | single-particle overlap (Gram) matrix `(G)_{j,k} = ⟨φ⁽ʲ⁾, ψ⁽ᵏ⁾⟩` and its entry `Σ_x φ(x)* ψ(x)` | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
 | `slaterState_nil` / `fockInner_vacuum_self` | empty Slater state is the vacuum; `⟨Φvac, Φvac⟩ = 1` (the `n = 0` instance of Lemma 9.1, proved axiom-free as a consistency guard) | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
 | `lemma_9_1_slater_inner_det` / `lemma_9_1_slater_inner_perm_sum` | **Lemma 9.1** (Tasaki §9.2.3, p. 319, eq. (9.2.53), **AXIOM**): the Slater overlap `⟨Φ, Ψ⟩ = det(⟨φ⁽ʲ⁾, ψ⁽ᵏ⁾⟩) = Σ_p (sign p) ∏_j ⟨φ⁽ʲ⁾, ψ⁽ᵖ⁽ʲ⁾⁾⟩`. Faithful documented axiom for the determinant overlap identity (a heavy finite-dim Wick/Laplace+Koszul development); the permutation-sum form is derived from it via the Leibniz expansion. | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
+| `slaterCoeffMatrix` / `slaterGram_self_eq_conjTranspose_mul_self` / `slaterGram_self_det_ne_zero_iff` | coefficient matrix `A` (columns = wave functions), `G = AᴴA`, and the linear-algebra core `det G ≠ 0 ↔ LinearIndependent ℂ φ` (axiom-free, via `ker(AᴴA)=ker A` + column-injectivity criterion) | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
+| `lemma_9_2_slater_ne_zero_iff_linearIndependent` | **Lemma 9.2** (Tasaki §9.2.3, p. 320): the Slater determinant state `slaterState (List.ofFn φ) ≠ 0 ↔ LinearIndependent ℂ φ`. Proved from Lemma 9.1 (`⟨Φ,Φ⟩ = det Gram`) + positive-definiteness of the Fock inner product. Depends only on the Lemma 9.1 axiom. | `Fermion/JordanWigner/FockSpaceRepresentation.lean` |
 
 #### Hubbard spin symmetry — full SU(2) invariance (Tasaki §9.3.3)
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4607,6 +4607,25 @@ $\langle \Phi_{\rm vac}, \Phi_{\rm vac}\rangle = 1$
 consistency guard. The downstream Lemmas 9.2 and 9.3 will be proved
 from this identity.
 
+\medskip
+\noindent\textbf{Lemma 9.2} (Tasaki §9.2.3, p.~320). The Slater
+determinant state $|\Phi\rangle$ is nonvanishing if and only if the
+single-electron wave functions $\varphi^{(1)},\dots,\varphi^{(N)}$ are
+linearly independent
+(\texttt{lemma\_9\_2\_slater\_ne\_zero\_iff\_linearIndependent}).
+
+\emph{Proof.} By Lemma 9.1 (with $\psi = \varphi$) the squared norm
+$\langle \Phi, \Phi\rangle$ equals the Gram determinant
+$\det(\langle \varphi^{(j)}, \varphi^{(k)}\rangle)$. The Fock inner
+product is positive definite, so $\Phi = 0$ iff
+$\langle \Phi, \Phi\rangle = 0$. Writing the coefficient matrix
+$A$ with columns $\varphi^{(j)}$ (so $A_{x,j} = \varphi^{(j)}(x)$), the
+Gram matrix is $G = A^{\mathsf H} A$, and $\ker(A^{\mathsf H} A) = \ker A$
+over $\mathbb{C}$; hence $\det G \neq 0$ iff the columns of $A$ are
+linearly independent, i.e.\ iff the $\varphi^{(j)}$ are. This part
+(\texttt{slaterGram\_self\_det\_ne\_zero\_iff}) is proved axiom-free; the
+full lemma depends only on the Lemma 9.1 axiom.
+
 \subsection{Hubbard spin symmetry: U(1)\texorpdfstring{$\times$}{×}U(1) invariance (Tasaki §9.3.3)}
 \label{subsec:hubbard-spin-symmetry}
 


### PR DESCRIPTION
Tracked in #4485.

## Summary

Continues **Chapter 9 §9.2.3** with **Lemma 9.2** (Tasaki 1st ed., Springer 2020, p. 320):

> The Slater determinant state is nonvanishing iff its single-electron wave functions
> are linearly independent.

`lemma_9_2_slater_ne_zero_iff_linearIndependent`:
`slaterState (List.ofFn φ) ≠ 0 ↔ LinearIndependent ℂ φ`.

## Proof

- By Lemma 9.1 (with `ψ = φ`), `⟨Φ, Φ⟩ = det(slaterGram φ φ)`.
- The Fock inner product is positive definite (`dotProduct_star_self_eq_zero`), so
  `Φ = 0 ↔ ⟨Φ, Φ⟩ = 0`.
- The Gram-determinant core `slaterGram_self_det_ne_zero_iff`
  (`det(AᴴA) ≠ 0 ↔ LinearIndependent ℂ φ`) is proved **axiom-free**: writing the
  coefficient matrix `A` with columns `φ⁽ʲ⁾` gives `G = AᴴA`, and `ker(AᴴA) = ker A`
  over ℂ (`conjTranspose_mul_self_mulVec_eq_zero`), reducing to the column-injectivity
  criterion (`mulVec_injective_iff`).

New helpers: `slaterCoeffMatrix`, `slaterGram_self_eq_conjTranspose_mul_self`,
`slaterGram_self_det_ne_zero_iff`.

## Verification

- `lake build LatticeSystem.Fermion.JordanWigner.FockSpaceRepresentation` — clean,
  zero warnings in the file.
- `#print axioms`: `lemma_9_2_slater_ne_zero_iff_linearIndependent` depends only on
  `{propext, Classical.choice, Quot.sound, lemma_9_1_slater_inner_det}`;
  `slaterGram_self_det_ne_zero_iff` uses only the standard three (axiom-free).
- `docs/index.md` + `tex/proof-guide.tex` (§9.2.3 subsection, builds warning-free) synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
