### PR TITLE
Tasaki §10.2.1: Lieb's theorem for the attractive Hubbard model (Theorem 10.2) — #4485

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -114,6 +114,7 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandProjectionBridg
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandProjectionBlock
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandTheorem1115
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralBasisHN
+import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractive
 import LatticeSystem.Fermion.JordanWigner.Hubbard.SectorMinEnergy
 import LatticeSystem.Fermion.JordanWigner.Hubbard.NonsingularHubbardModel
 import LatticeSystem.Fermion.JordanWigner.Hubbard.NonsingularLocalStability

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractive.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractive.lean
@@ -1,0 +1,113 @@
+import LatticeSystem.Fermion.JordanWigner.Hubbard.SaturatedFerromagnetism
+import LatticeSystem.Math.MatrixAnalysis.DegeneratePerturbation
+import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
+import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+
+/-!
+# Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorems 10.2 & 10.3)
+
+This file formalizes the statements of **Tasaki Theorem 10.2** (Lieb's
+theorem for the attractive Hubbard model) and **Theorem 10.3** (Tian's
+pair-correlation positivity), from Hal Tasaki, *Physics and Mathematics of
+Quantum Many-Body Systems*, 1st ed., Springer 2020, §10.2.1, pp. 348–349.
+
+The attractive Hubbard model has Hamiltonian `Ĥ = Ĥhop + Ĥatt-int` with an
+arbitrary real symmetric connected hopping matrix `T` (arbitrary on-site
+energies allowed) and on-site attraction `Ĥatt-int = −Σ_x U_x n̂_{x,↑} n̂_{x,↓}`,
+`U_x > 0` (eqs. (10.2.1)/(10.2.2)).
+
+* **Theorem 10.2**: for even electron number `N` with `0 < N ≤ 2|Λ|`, the
+  ground state is unique and has total spin `S_tot = 0`.
+* **Theorem 10.3**: the pair-transfer correlation
+  `⟨ΦGS| ĉ†_{x,↑} ĉ†_{x,↓} ĉ_{y,↓} ĉ_{y,↑} |ΦGS⟩` is strictly positive
+  (a measure of off-diagonal long-range order).
+
+## Status
+
+Both are proved by Lieb's spin-space reflection-positivity method (and
+Tian's extension); per the project policy these deep reflection-positivity
+results are recorded as faithful documented `axiom`s, built on a concrete
+attractive Hubbard Hamiltonian. The general hopping kinetic term reuses the
+existing `hubbardKinetic`; the unique-ground-state predicate reuses
+`IsUniqueGroundStateOn` from the degenerate-perturbation development.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Quantum LatticeSystem.Math
+open scoped BigOperators ComplexOrder
+
+variable {N : ℕ}
+
+/-- The support graph of a real hopping matrix `T`, with an edge between
+distinct `x, y` whenever `T x y` or `T y x` is nonzero (diagonal on-site
+energies `T x x` are ignored). Connectivity of this graph is Tasaki's
+"`Λ` is connected through nonvanishing `t_{x,y}`" hypothesis. -/
+def hoppingSupportGraph (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ) :
+    SimpleGraph (Fin (N + 1)) :=
+  SimpleGraph.fromRel (fun x y => T x y ≠ 0)
+
+/-- The site-dependent on-site Hubbard interaction
+`Σ_x U_x n̂_{x,↑} n̂_{x,↓}`. -/
+noncomputable def hubbardOnSiteInteractionSite (N : ℕ)
+    (U : Fin (N + 1) → ℂ) : ManyBodyOp (Fin (2 * N + 2)) :=
+  ∑ x : Fin (N + 1), U x • (fermionUpNumber N x * fermionDownNumber N x)
+
+/-- The attractive on-site interaction `−Σ_x U_x n̂_{x,↑} n̂_{x,↓}`
+(Tasaki eq. (10.2.2)), with positive `U_x`. -/
+noncomputable def attractiveHubbardInteraction (N : ℕ)
+    (U : Fin (N + 1) → ℝ) : ManyBodyOp (Fin (2 * N + 2)) :=
+  hubbardOnSiteInteractionSite N (fun x => -(U x : ℂ))
+
+/-- The **attractive Hubbard Hamiltonian** `Ĥ = Ĥhop + Ĥatt-int`
+(Tasaki §10.2.1, eqs. (10.2.1)/(10.2.2)): general real symmetric hopping
+`T` plus site-dependent on-site attraction `−Σ_x U_x n̂_{x,↑} n̂_{x,↓}`. -/
+noncomputable def attractiveHubbardHamiltonian (N : ℕ)
+    (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ) (U : Fin (N + 1) → ℝ) :
+    ManyBodyOp (Fin (2 * N + 2)) :=
+  hubbardKinetic N (fun x y => (T x y : ℂ)) + attractiveHubbardInteraction N U
+
+/-- The fixed electron-number sector `H_N`, as a subspace of the
+`EuclideanSpace` of computational configurations: the `(N : ℂ)`-eigenspace
+of the total number operator. -/
+noncomputable def electronNumberSectorEuclidean (N Ne : ℕ) :
+    Submodule ℂ (EuclideanSpace ℂ (Fin (2 * N + 2) → Fin 2)) :=
+  Module.End.eigenspace
+    (Matrix.toEuclideanLin (fermionTotalNumber (2 * N + 1))) (Ne : ℂ)
+
+/-- The on-site pair-transfer operator
+`ĉ†_{x,↑} ĉ†_{x,↓} ĉ_{y,↓} ĉ_{y,↑}` whose ground-state expectation measures
+off-diagonal long-range order (Tasaki eq. (10.2.4)). -/
+noncomputable def hubbardPairCorrelationOp (N : ℕ) (x y : Fin (N + 1)) :
+    ManyBodyOp (Fin (2 * N + 2)) :=
+  fermionUpCreation N x * fermionDownCreation N x *
+    fermionDownAnnihilation N y * fermionUpAnnihilation N y
+
+/-- The expectation `⟨φ| O |φ⟩` of an observable `O` in a (Euclidean)
+state vector `φ`. -/
+noncomputable def euclideanExpectation {ι : Type*} [Fintype ι]
+    (O : Matrix ι ι ℂ) (φ : EuclideanSpace ℂ ι) : ℂ :=
+  dotProduct (star φ.ofLp) (O.mulVec φ.ofLp)
+
+/-- **Tasaki Theorem 10.2** (Lieb's theorem for the attractive Hubbard
+model, 1st ed., Springer 2020, §10.2.1, p. 348, **AXIOM**). For an
+arbitrary real symmetric hopping matrix `T` whose support graph is
+connected (with arbitrary on-site energies) and site-dependent attraction
+`U_x > 0`, and an even electron number `N` with `0 < N ≤ 2|Λ|`, the ground
+state of `Ĥ = Ĥhop + Ĥatt-int` in the `N`-electron sector is unique and a
+spin singlet (`(Ŝ_tot)² = 0`).
+
+Proved by Lieb's spin-space reflection-positivity method; recorded as a
+faithful documented axiom. -/
+axiom theorem_10_2_lieb_attractive_unique_singlet (N Ne : ℕ)
+    (hNe_even : Even Ne) (hNe_pos : 0 < Ne) (hNe_le : Ne ≤ 2 * (N + 1))
+    (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ)
+    (hT_symm : ∀ x y, T x y = T y x)
+    (hT_conn : (hoppingSupportGraph T).Preconnected)
+    (U : Fin (N + 1) → ℝ) (hU_pos : ∀ x, 0 < U x) :
+    ∃ (E : ℝ) (φ : EuclideanSpace ℂ (Fin (2 * N + 2) → Fin 2)),
+      IsUniqueGroundStateOn (electronNumberSectorEuclidean N Ne)
+          (attractiveHubbardHamiltonian N T U) E φ ∧
+        Matrix.toEuclideanLin (fermionTotalSpinSquared N) φ = 0
+
+end LatticeSystem.Fermion

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractive.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractive.lean
@@ -4,12 +4,12 @@ import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 
 /-!
-# Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorems 10.2 & 10.3)
+# Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorem 10.2)
 
-This file formalizes the statements of **Tasaki Theorem 10.2** (Lieb's
-theorem for the attractive Hubbard model) and **Theorem 10.3** (Tian's
-pair-correlation positivity), from Hal Tasaki, *Physics and Mathematics of
-Quantum Many-Body Systems*, 1st ed., Springer 2020, §10.2.1, pp. 348–349.
+This file formalizes the statement of **Tasaki Theorem 10.2** (Lieb's
+theorem for the attractive Hubbard model), from Hal Tasaki, *Physics and
+Mathematics of Quantum Many-Body Systems*, 1st ed., Springer 2020, §10.2.1,
+p. 348.
 
 The attractive Hubbard model has Hamiltonian `Ĥ = Ĥhop + Ĥatt-int` with an
 arbitrary real symmetric connected hopping matrix `T` (arbitrary on-site
@@ -18,18 +18,20 @@ energies allowed) and on-site attraction `Ĥatt-int = −Σ_x U_x n̂_{x,↑} n�
 
 * **Theorem 10.2**: for even electron number `N` with `0 < N ≤ 2|Λ|`, the
   ground state is unique and has total spin `S_tot = 0`.
-* **Theorem 10.3**: the pair-transfer correlation
-  `⟨ΦGS| ĉ†_{x,↑} ĉ†_{x,↓} ĉ_{y,↓} ĉ_{y,↑} |ΦGS⟩` is strictly positive
-  (a measure of off-diagonal long-range order).
+
+This file also sets up the pair-transfer operator `hubbardPairCorrelationOp`
+and `euclideanExpectation` used to state Theorem 10.3 (Tian's
+pair-correlation positivity); the Theorem 10.3 statement itself is added in
+a follow-up PR.
 
 ## Status
 
-Both are proved by Lieb's spin-space reflection-positivity method (and
-Tian's extension); per the project policy these deep reflection-positivity
-results are recorded as faithful documented `axiom`s, built on a concrete
-attractive Hubbard Hamiltonian. The general hopping kinetic term reuses the
-existing `hubbardKinetic`; the unique-ground-state predicate reuses
-`IsUniqueGroundStateOn` from the degenerate-perturbation development.
+Theorem 10.2 is proved by Lieb's spin-space reflection-positivity method (a
+deep result); per the project policy it is recorded as a faithful documented
+`axiom`, built on a concrete attractive Hubbard Hamiltonian. The general
+hopping kinetic term reuses the existing `hubbardKinetic`; the
+unique-ground-state predicate reuses `IsUniqueGroundStateOn` from the
+degenerate-perturbation development.
 -/
 
 namespace LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2852,6 +2852,14 @@ fermion mode acting on `ℂ²` with computational basis
 | `IsGroundEigenvalueOn` / `IsUniqueGroundStateOn` | ground-eigenvalue and unique-(normalized)-ground-state predicates for a Hermitian matrix restricted to a subspace | `Math/MatrixAnalysis/DegeneratePerturbation.lean` |
 | `tasaki_lemma_10_1_degenerate_perturbation` | **Lemma 10.1** (Tasaki §10.1, p. 346, **AXIOM**): assuming the first-order term vanishes on the degenerate subspace (`P̂₀ V̂ P̂₀ = 0`, so the effective theory is second-order, eq. (10.1.6)), if `Ĥeff` has a unique ground state on `ker Ĥ₀`, then `Ĥ(λ)` has a unique ground state for all sufficiently small `λ > 0`, converging (phase choice) to the effective ground state as `λ → 0⁺`. Analytic degenerate-perturbation theory → faithful documented axiom (companion to the strong-coupling `effectiveHamiltonian_strongCoupling_limit`, Theorem A.12). | `Math/MatrixAnalysis/DegeneratePerturbation.lean` |
 
+#### Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorem 10.2)
+
+| Lean name | Statement | File |
+|---|---|---|
+| `hoppingSupportGraph` / `hubbardOnSiteInteractionSite` / `attractiveHubbardInteraction` / `attractiveHubbardHamiltonian` | the attractive Hubbard model `Ĥ = Ĥhop + Ĥatt-int` (eqs. (10.2.1)/(10.2.2)): general real symmetric hopping `T` (via `hubbardKinetic`) + site-dependent attraction `−Σ_x U_x n̂_{x,↑} n̂_{x,↓}`; the support graph encodes the connectivity hypothesis | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
+| `electronNumberSectorEuclidean` / `hubbardPairCorrelationOp` / `euclideanExpectation` | the `N`-electron sector (number eigenspace), the pair-transfer operator `ĉ†_{x↑}ĉ†_{x↓}ĉ_{y↓}ĉ_{y↑}`, and Euclidean expectation values | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
+| `theorem_10_2_lieb_attractive_unique_singlet` | **Theorem 10.2** (Tasaki §10.2.1, p. 348, **AXIOM**): for an even electron number `N` with `0 < N ≤ 2\|Λ\|`, connected real symmetric hopping, and site-dependent attraction `U_x > 0`, the ground state of `Ĥ` in the `N`-electron sector is unique and a spin singlet (`(Ŝ_tot)² = 0`). Lieb's spin-space reflection positivity → faithful documented axiom. | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
+
 #### Hubbard effective Hamiltonian on the hard-core sector (Tasaki §11.2)
 
 | Lean name | Statement | File |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5269,6 +5269,32 @@ projection $\hat P_0$ is constructed concretely and its
 Hermitian/idempotent properties are proved as consistency guards.
 
 %======================================================================
+\subsection{Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorem 10.2)}
+\label{subsec:lieb-attractive}
+
+\noindent The attractive Hubbard model (Tasaki §10.2.1, eqs.~(10.2.1)/(10.2.2))
+has Hamiltonian $\hat H = \hat H_{\rm hop} + \hat H_{\rm att\text{-}int}$ with an
+arbitrary real symmetric hopping matrix $T$ (whose support graph
+\texttt{hoppingSupportGraph} is connected; arbitrary on-site energies $T_{xx}$
+allowed) and site-dependent on-site attraction
+$\hat H_{\rm att\text{-}int} = -\sum_x U_x\,\hat n_{x\uparrow}\hat n_{x\downarrow}$,
+$U_x > 0$ (\texttt{attractiveHubbardHamiltonian}, reusing the general kinetic
+term \texttt{hubbardKinetic}).
+
+\medskip
+\noindent\textbf{Theorem 10.2} (Lieb's theorem; Tasaki §10.2.1, p.~348). For an
+even electron number $N$ with $0 < N \le 2|\Lambda|$, the ground state of
+$\hat H$ in the $N$-electron sector is unique and a spin singlet,
+$(\hat S_{\rm tot})^2 = 0$
+(\texttt{theorem\_10\_2\_lieb\_attractive\_unique\_singlet}).
+
+\emph{Status.} Proved by Lieb's spin-space reflection-positivity method; per the
+project policy this deep reflection-positivity result is recorded as a faithful
+documented \texttt{axiom}, built on a concrete attractive Hubbard Hamiltonian,
+with the unique-ground-state predicate \texttt{IsUniqueGroundStateOn} reused from
+the degenerate-perturbation development (§10.1).
+
+%======================================================================
 \subsection{Effective Hamiltonian on the hard-core sector (Tasaki §11.2)}
 \label{subsec:hubbard-effective-hamiltonian}
 %======================================================================


### PR DESCRIPTION
Tracked in #4485.

## Summary

Continues **Chapter 10** with **Theorem 10.2** (Lieb's theorem for the attractive Hubbard
model; Tasaki 1st ed., Springer 2020, §10.2.1, p. 348):

> For the attractive Hubbard model `Ĥ = Ĥhop + Ĥatt-int` with arbitrary real symmetric
> connected hopping `T` (arbitrary on-site energies) and site-dependent attraction
> `−Σ_x U_x n̂_{x,↑} n̂_{x,↓}` (`U_x > 0`), at even electron number `N` with `0 < N ≤ 2|Λ|`,
> the `N`-electron ground state is unique and a spin singlet (`(Ŝ_tot)² = 0`).

New file `Hubbard/LiebAttractive.lean`.

## Status: faithful documented axiom

Theorem 10.2 is proved by Lieb's spin-space reflection-positivity method (a deep result);
per the project policy it is recorded as a faithful documented `axiom`
(`theorem_10_2_lieb_attractive_unique_singlet`), built on a **concrete** attractive Hubbard
Hamiltonian:

- `attractiveHubbardHamiltonian` = `hubbardKinetic` (the existing general hopping term,
  `Σ_σ Σ_{i,j} T_{i,j} ĉ†_{iσ}ĉ_{jσ}`) + `attractiveHubbardInteraction` (site-dependent
  `−Σ_x U_x n̂_{x,↑} n̂_{x,↓}`).
- `hoppingSupportGraph` (via `SimpleGraph.fromRel`) encodes the connectivity hypothesis.
- The unique-ground-state predicate `IsUniqueGroundStateOn` is reused from the §10.1
  degenerate-perturbation development (PR #4548); `S_tot = 0` is the Casimir
  `fermionTotalSpinSquared` eigenvalue 0.

`hubbardPairCorrelationOp` / `euclideanExpectation` are also defined here, ready for
Theorem 10.3 (Tian's pair-correlation positivity) in the next PR.

## Verification

- `lake build LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractive` — clean, zero
  warnings; wired into the `JordanWigner` facade.
- `#print axioms theorem_10_2_lieb_attractive_unique_singlet` → `{propext, Classical.choice,
  Quot.sound, theorem_10_2_lieb_attractive_unique_singlet}` (documented axiom).
- `docs/index.md` (new §10.2.1 subsection) + `tex/proof-guide.tex` (new §10.2.1 subsection,
  builds warning-free) synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
