### PR TITLE
Tasaki §10.2.1: Tian pair-correlation positivity (Theorem 10.3) — #4485

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractive.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractive.lean
@@ -4,12 +4,12 @@ import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 
 /-!
-# Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorem 10.2)
+# Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorems 10.2 & 10.3)
 
-This file formalizes the statement of **Tasaki Theorem 10.2** (Lieb's
-theorem for the attractive Hubbard model), from Hal Tasaki, *Physics and
-Mathematics of Quantum Many-Body Systems*, 1st ed., Springer 2020, §10.2.1,
-p. 348.
+This file formalizes the statements of **Tasaki Theorem 10.2** (Lieb's
+theorem for the attractive Hubbard model) and **Theorem 10.3** (Tian's
+pair-correlation positivity), from Hal Tasaki, *Physics and Mathematics of
+Quantum Many-Body Systems*, 1st ed., Springer 2020, §10.2.1, pp. 348–349.
 
 The attractive Hubbard model has Hamiltonian `Ĥ = Ĥhop + Ĥatt-int` with an
 arbitrary real symmetric connected hopping matrix `T` (arbitrary on-site
@@ -18,20 +18,18 @@ energies allowed) and on-site attraction `Ĥatt-int = −Σ_x U_x n̂_{x,↑} n�
 
 * **Theorem 10.2**: for even electron number `N` with `0 < N ≤ 2|Λ|`, the
   ground state is unique and has total spin `S_tot = 0`.
-
-This file also sets up the pair-transfer operator `hubbardPairCorrelationOp`
-and `euclideanExpectation` used to state Theorem 10.3 (Tian's
-pair-correlation positivity); the Theorem 10.3 statement itself is added in
-a follow-up PR.
+* **Theorem 10.3**: the pair-transfer correlation
+  `⟨ΦGS| ĉ†_{x,↑} ĉ†_{x,↓} ĉ_{y,↓} ĉ_{y,↑} |ΦGS⟩` is strictly positive
+  (a measure of off-diagonal long-range order).
 
 ## Status
 
-Theorem 10.2 is proved by Lieb's spin-space reflection-positivity method (a
-deep result); per the project policy it is recorded as a faithful documented
-`axiom`, built on a concrete attractive Hubbard Hamiltonian. The general
-hopping kinetic term reuses the existing `hubbardKinetic`; the
-unique-ground-state predicate reuses `IsUniqueGroundStateOn` from the
-degenerate-perturbation development.
+Both are proved by Lieb's spin-space reflection-positivity method (and
+Tian's extension); per the project policy these deep reflection-positivity
+results are recorded as faithful documented `axiom`s, built on a concrete
+attractive Hubbard Hamiltonian. The general hopping kinetic term reuses the
+existing `hubbardKinetic`; the unique-ground-state predicate reuses
+`IsUniqueGroundStateOn` from the degenerate-perturbation development.
 -/
 
 namespace LatticeSystem.Fermion
@@ -111,5 +109,32 @@ axiom theorem_10_2_lieb_attractive_unique_singlet (N Ne : ℕ)
       IsUniqueGroundStateOn (electronNumberSectorEuclidean N Ne)
           (attractiveHubbardHamiltonian N T U) E φ ∧
         Matrix.toEuclideanLin (fermionTotalSpinSquared N) φ = 0
+
+/-- **Tasaki Theorem 10.3** (Tian's pair-correlation positivity, 1st ed.,
+Springer 2020, §10.2.1, p. 349, eq. (10.2.4), **AXIOM**). Under the
+hypotheses of Theorem 10.2, the unique ground state `|ΦGS⟩` of the
+attractive Hubbard model has strictly positive on-site pair-transfer
+correlation for all sites `x, y`:
+`⟨ΦGS| ĉ†_{x,↑} ĉ†_{x,↓} ĉ_{y,↓} ĉ_{y,↑} |ΦGS⟩ > 0` (a measure of
+off-diagonal long-range order).
+
+The textbook states the bound for `0 < N ≤ 2|Λ|`; in the concrete finite
+Fock representation the fully-filled endpoint `N = 2|Λ|` makes off-site
+pair transfer vanish, so the Lean statement uses the non-full guard
+`N < 2|Λ|` (the book endpoint is noted here). Proved by Lieb's
+reflection-positivity method extended by Tian; recorded as a faithful
+documented axiom. -/
+axiom theorem_10_3_tian_pair_correlation_positive (N Ne : ℕ)
+    (hNe_even : Even Ne) (hNe_pos : 0 < Ne) (hNe_lt : Ne < 2 * (N + 1))
+    (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ)
+    (hT_symm : ∀ x y, T x y = T y x)
+    (hT_conn : (hoppingSupportGraph T).Preconnected)
+    (U : Fin (N + 1) → ℝ) (hU_pos : ∀ x, 0 < U x)
+    {E : ℝ} {φ : EuclideanSpace ℂ (Fin (2 * N + 2) → Fin 2)}
+    (hGS : IsUniqueGroundStateOn (electronNumberSectorEuclidean N Ne)
+      (attractiveHubbardHamiltonian N T U) E φ) :
+    ∀ x y : Fin (N + 1),
+      0 < (euclideanExpectation (hubbardPairCorrelationOp N x y) φ).re ∧
+        (euclideanExpectation (hubbardPairCorrelationOp N x y) φ).im = 0
 
 end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2852,13 +2852,14 @@ fermion mode acting on `ℂ²` with computational basis
 | `IsGroundEigenvalueOn` / `IsUniqueGroundStateOn` | ground-eigenvalue and unique-(normalized)-ground-state predicates for a Hermitian matrix restricted to a subspace | `Math/MatrixAnalysis/DegeneratePerturbation.lean` |
 | `tasaki_lemma_10_1_degenerate_perturbation` | **Lemma 10.1** (Tasaki §10.1, p. 346, **AXIOM**): assuming the first-order term vanishes on the degenerate subspace (`P̂₀ V̂ P̂₀ = 0`, so the effective theory is second-order, eq. (10.1.6)), if `Ĥeff` has a unique ground state on `ker Ĥ₀`, then `Ĥ(λ)` has a unique ground state for all sufficiently small `λ > 0`, converging (phase choice) to the effective ground state as `λ → 0⁺`. Analytic degenerate-perturbation theory → faithful documented axiom (companion to the strong-coupling `effectiveHamiltonian_strongCoupling_limit`, Theorem A.12). | `Math/MatrixAnalysis/DegeneratePerturbation.lean` |
 
-#### Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorem 10.2)
+#### Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorems 10.2 & 10.3)
 
 | Lean name | Statement | File |
 |---|---|---|
 | `hoppingSupportGraph` / `hubbardOnSiteInteractionSite` / `attractiveHubbardInteraction` / `attractiveHubbardHamiltonian` | the attractive Hubbard model `Ĥ = Ĥhop + Ĥatt-int` (eqs. (10.2.1)/(10.2.2)): general real symmetric hopping `T` (via `hubbardKinetic`) + site-dependent attraction `−Σ_x U_x n̂_{x,↑} n̂_{x,↓}`; the support graph encodes the connectivity hypothesis | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
 | `electronNumberSectorEuclidean` / `hubbardPairCorrelationOp` / `euclideanExpectation` | the `N`-electron sector (number eigenspace), the pair-transfer operator `ĉ†_{x↑}ĉ†_{x↓}ĉ_{y↓}ĉ_{y↑}`, and Euclidean expectation values | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
 | `theorem_10_2_lieb_attractive_unique_singlet` | **Theorem 10.2** (Tasaki §10.2.1, p. 348, **AXIOM**): for an even electron number `N` with `0 < N ≤ 2\|Λ\|`, connected real symmetric hopping, and site-dependent attraction `U_x > 0`, the ground state of `Ĥ` in the `N`-electron sector is unique and a spin singlet (`(Ŝ_tot)² = 0`). Lieb's spin-space reflection positivity → faithful documented axiom. | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
+| `theorem_10_3_tian_pair_correlation_positive` | **Theorem 10.3** (Tian; Tasaki §10.2.1, p. 349, eq. (10.2.4), **AXIOM**): under the Theorem 10.2 hypotheses (with the non-full guard `N < 2\|Λ\|`), the unique ground state has strictly positive on-site pair-transfer correlation `⟨ΦGS\| ĉ†_{x↑}ĉ†_{x↓}ĉ_{y↓}ĉ_{y↑} \|ΦGS⟩ > 0` for all `x, y` (off-diagonal long-range order). Reflection positivity (Tian's extension) → faithful documented axiom. | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
 
 #### Hubbard effective Hamiltonian on the hard-core sector (Tasaki §11.2)
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5269,7 +5269,7 @@ projection $\hat P_0$ is constructed concretely and its
 Hermitian/idempotent properties are proved as consistency guards.
 
 %======================================================================
-\subsection{Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorem 10.2)}
+\subsection{Lieb's theorem for the attractive Hubbard model (Tasaki §10.2.1, Theorems 10.2 \& 10.3)}
 \label{subsec:lieb-attractive}
 
 \noindent The attractive Hubbard model (Tasaki §10.2.1, eqs.~(10.2.1)/(10.2.2))
@@ -5293,6 +5293,19 @@ project policy this deep reflection-positivity result is recorded as a faithful
 documented \texttt{axiom}, built on a concrete attractive Hubbard Hamiltonian,
 with the unique-ground-state predicate \texttt{IsUniqueGroundStateOn} reused from
 the degenerate-perturbation development (§10.1).
+
+\medskip
+\noindent\textbf{Theorem 10.3} (Tian; Tasaki §10.2.1, p.~349, eq.~(10.2.4)).
+Under the hypotheses of Theorem 10.2, the unique ground state has strictly
+positive on-site pair-transfer correlation
+$\langle\Phi_{\rm GS}|\,\hat c^\dagger_{x\uparrow}\hat c^\dagger_{x\downarrow}
+\hat c_{y\downarrow}\hat c_{y\uparrow}\,|\Phi_{\rm GS}\rangle > 0$ for all
+$x, y \in \Lambda$, a measure of off-diagonal long-range order
+(\texttt{theorem\_10\_3\_tian\_pair\_correlation\_positive}). The textbook states
+$0 < N \le 2|\Lambda|$; the Lean statement uses the non-full guard
+$N < 2|\Lambda|$ (the fully-filled endpoint makes off-site pair transfer vanish in
+the concrete Fock representation). Proved by Tian's extension of Lieb's
+reflection-positivity method; recorded as a faithful documented \texttt{axiom}.
 
 %======================================================================
 \subsection{Effective Hamiltonian on the hard-core sector (Tasaki §11.2)}


### PR DESCRIPTION
Tracked in #4485.

## Summary

Continues **Chapter 10 §10.2.1** with **Theorem 10.3** (Tian's pair-correlation positivity;
Tasaki 1st ed., Springer 2020, §10.2.1, p. 349, eq. (10.2.4)):

> Under the hypotheses of Theorem 10.2, the unique ground state of the attractive Hubbard
> model has strictly positive on-site pair-transfer correlation
> `⟨ΦGS| ĉ†_{x,↑} ĉ†_{x,↓} ĉ_{y,↓} ĉ_{y,↑} |ΦGS⟩ > 0` for all `x, y` (off-diagonal long-range order).

Adds `theorem_10_3_tian_pair_correlation_positive` to `Hubbard/LiebAttractive.lean`, reusing
the `hubbardPairCorrelationOp`, `euclideanExpectation`, and `IsUniqueGroundStateOn` vocabulary
already set up for Theorem 10.2.

## Status: faithful documented axiom

Proved by Tian's extension of Lieb's reflection-positivity method (deep); recorded as a
faithful documented `axiom`.

**Soundness note:** the textbook states the bound for `0 < N ≤ 2|Λ|`, but in the concrete
finite Fock representation the fully-filled endpoint `N = 2|Λ|` makes off-site pair transfer
vanish, so the Lean statement uses the non-full guard `N < 2|Λ|` (the book endpoint is noted
in the docstring).

## Verification

- `lake build LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractive` — clean, zero warnings.
- `#print axioms theorem_10_3_tian_pair_correlation_positive` → `{propext, Classical.choice,
  Quot.sound, theorem_10_3_tian_pair_correlation_positive}` (documented axiom).
- `docs/index.md` + `tex/proof-guide.tex` (§10.2.1 subsection, builds warning-free) synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
