### PR TITLE
Tasaki §10.2.2: Lieb's theorem for the repulsive Hubbard model (Theorem 10.4) — #4485

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -115,6 +115,7 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandProjectionBlock
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandTheorem1115
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralBasisHN
 import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractive
+import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebRepulsive
 import LatticeSystem.Fermion.JordanWigner.Hubbard.SectorMinEnergy
 import LatticeSystem.Fermion.JordanWigner.Hubbard.NonsingularHubbardModel
 import LatticeSystem.Fermion.JordanWigner.Hubbard.NonsingularLocalStability

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebRepulsive.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebRepulsive.lean
@@ -1,0 +1,148 @@
+import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractive
+import Mathlib.LinearAlgebra.Dimension.Finrank
+
+/-!
+# Lieb's theorem for the repulsive Hubbard model at half-filling (Tasaki §10.2.2, Theorem 10.4)
+
+This file formalizes the statement of **Tasaki Theorem 10.4** (Lieb's
+theorem for the repulsive Hubbard model at half-filling), from Hal Tasaki,
+*Physics and Mathematics of Quantum Many-Body Systems*, 1st ed., Springer
+2020, §10.2.2, p. 350.
+
+For a **bipartite** real symmetric connected hopping matrix `T`
+(`Λ = A ⊔ B`, hopping only across the sublattices) and a repulsive on-site
+interaction — either the uniform form `Ĥint = U Σ_x n̂_{x,↑} n̂_{x,↓}`
+(`U > 0`, eq. (10.2.5)) or the symmetric form
+`Ĥint = Σ_x U_x (n̂_{x,↑} − ½)(n̂_{x,↓} − ½)` (`U_x > 0`, eq. (10.2.6)) — at
+half-filling `N = |Λ|`, every ground state has total spin
+`S_tot = ||A| − |B||/2`, and the ground states are exactly
+`2 S_tot + 1 = |A| − |B| + 1` fold degenerate (the unavoidable SU(2)
+multiplet degeneracy).
+
+## Status
+
+Theorem 10.4 is proved by Lieb's spin-space reflection-positivity method
+(via the Shiba transformation from the attractive case, Theorem 10.2); per
+the project policy this deep result is recorded as a faithful documented
+`axiom`, built on concrete repulsive Hubbard Hamiltonians. The model
+hypotheses are packaged in `IsLiebRepulsiveModel`, reused by the
+correlation theorems (10.5, 10.6) in follow-up files.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Quantum
+open scoped BigOperators ComplexOrder
+
+variable {N : ℕ}
+
+/-- The complement sublattice `B = Aᶜ` of a bipartition `Λ = A ⊔ B`. -/
+def bipartitionComplement (A : Finset (Fin (N + 1))) : Finset (Fin (N + 1)) :=
+  Finset.univ.filter fun x => x ∉ A
+
+/-- The hopping matrix `T` respects the bipartition `A ⊔ Aᶜ`: a nonzero
+amplitude `T x y` connects only sites in different sublattices. -/
+def HoppingRespectsBipartition (A : Finset (Fin (N + 1)))
+    (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ) : Prop :=
+  ∀ ⦃x y⦄, T x y ≠ 0 → (x ∈ A ↔ y ∉ A)
+
+/-- The sublattice imbalance `||A| − |B||` as a natural number. -/
+noncomputable def sublatticeImbalance (A : Finset (Fin (N + 1))) : ℕ :=
+  Int.natAbs ((A.card : ℤ) - ((bipartitionComplement A).card : ℤ))
+
+/-- The Casimir eigenvalue `S₀ (S₀ + 1)` of the total-spin operator at
+`S₀ = ||A| − |B||/2` (Tasaki's ground-state total spin in Theorem 10.4). -/
+noncomputable def liebRepulsiveSpinCasimir (A : Finset (Fin (N + 1))) : ℂ :=
+  ((sublatticeImbalance A : ℂ) / 2) * ((sublatticeImbalance A : ℂ) / 2 + 1)
+
+/-- The trivial SU(2)-multiplet ground-state degeneracy
+`2 S₀ + 1 = |A| − |B| + 1`. -/
+noncomputable def liebRepulsiveGroundMultiplicity (A : Finset (Fin (N + 1))) : ℕ :=
+  sublatticeImbalance A + 1
+
+/-- The **uniform repulsive Hubbard Hamiltonian** `Ĥ = Ĥhop + U Σ_x n̂↑n̂↓`
+(Tasaki eq. (10.2.5)), with `U > 0`. -/
+noncomputable def repulsiveHubbardHamiltonian (N : ℕ)
+    (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ) (U : ℝ) :
+    ManyBodyOp (Fin (2 * N + 2)) :=
+  hubbardKinetic N (fun x y => (T x y : ℂ)) +
+    hubbardOnSiteInteractionSite N (fun _ => (U : ℂ))
+
+/-- The **symmetric repulsive interaction**
+`Σ_x U_x (n̂_{x,↑} − ½)(n̂_{x,↓} − ½)` (Tasaki eq. (10.2.6)). -/
+noncomputable def symmetricRepulsiveHubbardInteraction (N : ℕ)
+    (U : Fin (N + 1) → ℝ) : ManyBodyOp (Fin (2 * N + 2)) :=
+  ∑ x : Fin (N + 1), (U x : ℂ) •
+    ((fermionUpNumber N x - (1 / 2 : ℂ) • (1 : ManyBodyOp (Fin (2 * N + 2)))) *
+      (fermionDownNumber N x - (1 / 2 : ℂ) • (1 : ManyBodyOp (Fin (2 * N + 2)))))
+
+/-- The **symmetric repulsive Hubbard Hamiltonian** `Ĥ = Ĥhop + Ĥint`
+with the symmetric interaction (Tasaki eq. (10.2.6)). -/
+noncomputable def symmetricRepulsiveHubbardHamiltonian (N : ℕ)
+    (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ) (U : Fin (N + 1) → ℝ) :
+    ManyBodyOp (Fin (2 * N + 2)) :=
+  hubbardKinetic N (fun x y => (T x y : ℂ)) +
+    symmetricRepulsiveHubbardInteraction N U
+
+/-- The fixed-electron-number ground subspace of `H` at energy `E`: the
+intersection of the `E`-eigenspace with the `Ne`-electron sector (no
+hard-core constraint — double occupancy is allowed). -/
+noncomputable def hubbardGroundSubmoduleAtElectronNumber
+    (H : ManyBodyOp (Fin (2 * N + 2))) (E : ℂ) (Ne : ℕ) :
+    Submodule ℂ ((Fin (2 * N + 2) → Fin 2) → ℂ) :=
+  Module.End.eigenspace H.mulVecLin E ⊓
+    Module.End.eigenspace (fermionTotalNumber (2 * N + 1)).mulVecLin (Ne : ℂ)
+
+/-- `H` is one of the two repulsive Hubbard Hamiltonians of Theorem 10.4:
+the uniform form (`U > 0`, eq. (10.2.5)) or the symmetric form
+(`U_x > 0`, eq. (10.2.6)). -/
+def IsLiebRepulsiveHamiltonian (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ)
+    (H : ManyBodyOp (Fin (2 * N + 2))) : Prop :=
+  (∃ U : ℝ, 0 < U ∧ H = repulsiveHubbardHamiltonian N T U) ∨
+    (∃ U : Fin (N + 1) → ℝ, (∀ x, 0 < U x) ∧
+      H = symmetricRepulsiveHubbardHamiltonian N T U)
+
+/-- The packaged hypotheses of Tasaki's repulsive-Hubbard theorems
+(10.4/10.5/10.6): a bipartition `A`, a real symmetric hopping matrix `T`
+respecting it whose support graph is connected, and a repulsive
+Hamiltonian `H` (uniform or symmetric form). -/
+structure IsLiebRepulsiveModel (A : Finset (Fin (N + 1)))
+    (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ)
+    (H : ManyBodyOp (Fin (2 * N + 2))) : Prop where
+  /-- `T` is symmetric. -/
+  symm : ∀ x y, T x y = T y x
+  /-- `T` respects the bipartition (hops only across sublattices). -/
+  bipartite : HoppingRespectsBipartition A T
+  /-- The hopping support graph is connected. -/
+  connected : (hoppingSupportGraph T).Preconnected
+  /-- `H` is a repulsive Hubbard Hamiltonian (uniform or symmetric form). -/
+  hamiltonian : IsLiebRepulsiveHamiltonian T H
+
+/-- **Tasaki Theorem 10.4** (Lieb's theorem for the repulsive Hubbard model
+at half-filling, 1st ed., Springer 2020, §10.2.2, p. 350, **AXIOM**). For a
+bipartite real symmetric connected hopping matrix `T` and a repulsive
+Hubbard Hamiltonian `H` (uniform or symmetric form), at half-filling
+`N = |Λ|` (electron number `N + 1` on `Fin (N + 1)` sites), there is a
+ground energy `E₀` whose `(N+1)`-electron ground subspace `G` is nonzero,
+minimal in energy, consists entirely of total-spin `S₀ = ||A| − |B||/2`
+states (Casimir eigenvalue `S₀(S₀+1)`), and has dimension exactly
+`|A| − |B| + 1` (the unavoidable SU(2) multiplet degeneracy).
+
+Proved by Lieb's spin-space reflection-positivity method (via the Shiba
+transformation from the attractive case); recorded as a faithful documented
+axiom. -/
+axiom theorem_10_4_lieb_repulsive_half_filling
+    (A : Finset (Fin (N + 1)))
+    (T : Matrix (Fin (N + 1)) (Fin (N + 1)) ℝ)
+    (H : ManyBodyOp (Fin (2 * N + 2)))
+    (hModel : IsLiebRepulsiveModel A T H) :
+    ∃ E₀ : ℂ,
+      hubbardGroundSubmoduleAtElectronNumber H E₀ (N + 1) ≠ ⊥ ∧
+      (∀ E : ℂ, hubbardGroundSubmoduleAtElectronNumber H E (N + 1) ≠ ⊥ →
+        E₀.re ≤ E.re) ∧
+      (∀ v ∈ hubbardGroundSubmoduleAtElectronNumber H E₀ (N + 1),
+        (fermionTotalSpinSquared N).mulVec v = liebRepulsiveSpinCasimir A • v) ∧
+      Module.finrank ℂ (hubbardGroundSubmoduleAtElectronNumber H E₀ (N + 1))
+        = liebRepulsiveGroundMultiplicity A
+
+end LatticeSystem.Fermion

--- a/docs/index.md
+++ b/docs/index.md
@@ -2861,6 +2861,15 @@ fermion mode acting on `ℂ²` with computational basis
 | `theorem_10_2_lieb_attractive_unique_singlet` | **Theorem 10.2** (Tasaki §10.2.1, p. 348, **AXIOM**): for an even electron number `N` with `0 < N ≤ 2\|Λ\|`, connected real symmetric hopping, and site-dependent attraction `U_x > 0`, the ground state of `Ĥ` in the `N`-electron sector is unique and a spin singlet (`(Ŝ_tot)² = 0`). Lieb's spin-space reflection positivity → faithful documented axiom. | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
 | `theorem_10_3_tian_pair_correlation_positive` | **Theorem 10.3** (Tian; Tasaki §10.2.1, p. 349, eq. (10.2.4), **AXIOM**): under the Theorem 10.2 hypotheses (with the non-full guard `N < 2\|Λ\|`), the unique ground state has strictly positive on-site pair-transfer correlation `⟨ΦGS\| ĉ†_{x↑}ĉ†_{x↓}ĉ_{y↓}ĉ_{y↑} \|ΦGS⟩ > 0` for all `x, y` (off-diagonal long-range order). Reflection positivity (Tian's extension) → faithful documented axiom. | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
 
+#### Lieb's theorem for the repulsive Hubbard model at half-filling (Tasaki §10.2.2, Theorem 10.4)
+
+| Lean name | Statement | File |
+|---|---|---|
+| `bipartitionComplement` / `HoppingRespectsBipartition` / `sublatticeImbalance` | the bipartition `Λ = A ⊔ Aᶜ`, the "hops only across sublattices" predicate, and `\|\|A\|−\|B\|\|` | `Fermion/JordanWigner/Hubbard/LiebRepulsive.lean` |
+| `repulsiveHubbardHamiltonian` / `symmetricRepulsiveHubbardInteraction` / `symmetricRepulsiveHubbardHamiltonian` | the uniform repulsive model `Ĥhop + U Σ n̂↑n̂↓` (eq. (10.2.5)) and the symmetric form `Σ_x U_x (n̂↑−½)(n̂↓−½)` (eq. (10.2.6)) | `Fermion/JordanWigner/Hubbard/LiebRepulsive.lean` |
+| `hubbardGroundSubmoduleAtElectronNumber` / `IsLiebRepulsiveHamiltonian` / `IsLiebRepulsiveModel` | non-hard-core fixed-`N` ground subspace (energy eigenspace ⊓ number sector); the two allowed interaction forms; the packaged model hypotheses (bipartite + symmetric + connected hopping) | `Fermion/JordanWigner/Hubbard/LiebRepulsive.lean` |
+| `theorem_10_4_lieb_repulsive_half_filling` | **Theorem 10.4** (Tasaki §10.2.2, p. 350, **AXIOM**): at half-filling `N = \|Λ\|`, the ground subspace is nonzero, energy-minimal, consists entirely of total-spin `S₀ = \|\|A\|−\|B\|\|/2` states (Casimir `S₀(S₀+1)`), and has dimension exactly `\|A\|−\|B\|+1` (the unavoidable SU(2) multiplet degeneracy). Lieb's reflection positivity via the Shiba transformation → faithful documented axiom. | `Fermion/JordanWigner/Hubbard/LiebRepulsive.lean` |
+
 #### Hubbard effective Hamiltonian on the hard-core sector (Tasaki §11.2)
 
 | Lean name | Statement | File |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5308,6 +5308,36 @@ the concrete Fock representation). Proved by Tian's extension of Lieb's
 reflection-positivity method; recorded as a faithful documented \texttt{axiom}.
 
 %======================================================================
+\subsection{Lieb's theorem for the repulsive Hubbard model at half-filling (Tasaki §10.2.2, Theorem 10.4)}
+\label{subsec:lieb-repulsive}
+
+\noindent The repulsive Hubbard model (Tasaki §10.2.2) has a \emph{bipartite}
+real symmetric connected hopping matrix $T$ ($\Lambda = A \sqcup B$, hopping
+only across sublattices; \texttt{HoppingRespectsBipartition}) and a repulsive
+on-site interaction, either the uniform form $\hat H_{\rm int} = U \sum_x
+\hat n_{x\uparrow}\hat n_{x\downarrow}$ ($U > 0$, eq.~(10.2.5),
+\texttt{repulsiveHubbardHamiltonian}) or the symmetric form $\sum_x U_x
+(\hat n_{x\uparrow}-\tfrac12)(\hat n_{x\downarrow}-\tfrac12)$ ($U_x > 0$,
+eq.~(10.2.6), \texttt{symmetricRepulsiveHubbardHamiltonian}). These hypotheses
+are packaged in \texttt{IsLiebRepulsiveModel}.
+
+\medskip
+\noindent\textbf{Theorem 10.4} (Lieb's theorem; Tasaki §10.2.2, p.~350). At
+half-filling $N = |\Lambda|$, every ground state has total spin
+$S_{\rm tot} = ||A|-|B||/2$, and the ground states are exactly
+$2 S_{\rm tot}+1 = |A|-|B|+1$ fold degenerate (the unavoidable SU(2) multiplet
+degeneracy). Formally
+(\texttt{theorem\_10\_4\_lieb\_repulsive\_half\_filling}): there is a ground
+energy $E_0$ whose $(N+1)$-electron ground subspace is nonzero, energy-minimal,
+lies in the Casimir eigenspace $S_0(S_0+1)$ with $S_0 = ||A|-|B||/2$, and has
+$\dim = |A|-|B|+1$.
+
+\emph{Status.} Proved by Lieb's spin-space reflection-positivity method (via the
+Shiba transformation from the attractive case, Theorem 10.2); per the project
+policy recorded as a faithful documented \texttt{axiom}, built on concrete
+repulsive Hubbard Hamiltonians.
+
+%======================================================================
 \subsection{Effective Hamiltonian on the hard-core sector (Tasaki §11.2)}
 \label{subsec:hubbard-effective-hamiltonian}
 %======================================================================


### PR DESCRIPTION
Tracked in #4485.

## Summary

Continues **Chapter 10** with **Theorem 10.4** (Lieb's theorem for the repulsive Hubbard
model at half-filling; Tasaki 1st ed., Springer 2020, §10.2.2, p. 350):

> For a bipartite real symmetric connected hopping matrix `T` (`Λ = A ⊔ B`) and a repulsive
> Hubbard interaction — uniform `U Σ_x n̂_{x,↑} n̂_{x,↓}` (`U > 0`, eq. (10.2.5)) or symmetric
> `Σ_x U_x (n̂_{x,↑}−½)(n̂_{x,↓}−½)` (`U_x > 0`, eq. (10.2.6)) — at half-filling `N = |Λ|`,
> every ground state has total spin `S_tot = ||A|−|B||/2`, and the ground states are exactly
> `|A|−|B|+1` fold degenerate (the unavoidable SU(2) multiplet degeneracy).

New file `Hubbard/LiebRepulsive.lean`.

## Status: faithful documented axiom

Proved by Lieb's spin-space reflection-positivity method (via the Shiba transformation from
the attractive case, Theorem 10.2); recorded as a faithful documented `axiom`
(`theorem_10_4_lieb_repulsive_half_filling`), built on **concrete** repulsive Hubbard
Hamiltonians:

- `repulsiveHubbardHamiltonian` (uniform) / `symmetricRepulsiveHubbardHamiltonian` (eq. (10.2.6)),
  both reusing the general `hubbardKinetic`.
- `HoppingRespectsBipartition` + `sublatticeImbalance` encode the bipartition `A ⊔ Aᶜ` and `||A|−|B||`.
- `hubbardGroundSubmoduleAtElectronNumber` is the non-hard-core fixed-`N` ground subspace
  (energy eigenspace ⊓ number sector).
- The statement asserts: the ground subspace is nonzero, energy-minimal, lies in the Casimir
  eigenspace `S₀(S₀+1)`, and has `finrank = |A|−|B|+1`.
- Model hypotheses are packaged in `IsLiebRepulsiveModel`, reused by Theorems 10.5/10.6 (follow-ups).

## Verification

- `lake build LatticeSystem.Fermion.JordanWigner.Hubbard.LiebRepulsive` — clean, zero warnings;
  wired into the `JordanWigner` facade.
- `#print axioms theorem_10_4_lieb_repulsive_half_filling` → `{propext, Classical.choice,
  Quot.sound, theorem_10_4_lieb_repulsive_half_filling}` (documented axiom).
- `docs/index.md` (new §10.2.2 subsection) + `tex/proof-guide.tex` (new §10.2.2 subsection,
  builds warning-free) synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
