### PR TITLE
Refactor (20-PR cadence): clear unused-variable/simp linter warnings + build-speed eval — #4485

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedBelowFromArgmin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedBelowFromArgmin.lean
@@ -40,7 +40,7 @@ theorem balanced_GS_below_sInf_of_argmin
     (hne_chosen :
       (perMCrossingSet (Λ := Λ) hJ N M_balanced M_chosen lam' D' ∩ Icc (0 : ℝ) 1).Nonempty)
     -- Argmin property: M_chosen minimises per-M first crossings across M ≠ M_balanced.
-    (h_argmin :
+    (_h_argmin :
       ∀ M' : ℕ, ∀ _ : Nonempty (magConfigS Λ N M'), M' ≠ M_balanced →
         (perMCrossingSet (Λ := Λ) hJ N M_balanced M' lam' D' ∩ Icc (0 : ℝ) 1).Nonempty →
         sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M_chosen lam' D' ∩ Icc (0 : ℝ) 1) ≤

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricPathStaysInRegion.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergParametricPathStaysInRegion.lean
@@ -30,7 +30,7 @@ namespace LatticeSystem.Quantum
 
 /-- `γ(t).1 < 1` for `t ∈ (0, 1]` and `λ' < 1`. -/
 theorem anisotropicHeisenbergParametricPath_fst_lt_one
-    {lam' D' : ℝ} (hlam' : lam' < 1) {t : ℝ} (ht_pos : 0 < t) (ht_le : t ≤ 1) :
+    {lam' D' : ℝ} (hlam' : lam' < 1) {t : ℝ} (ht_pos : 0 < t) (_ht_le : t ≤ 1) :
     (anisotropicHeisenbergParametricPath lam' D' t).1 < 1 := by
   unfold anisotropicHeisenbergParametricPath
   change (1 - t) + t * lam' < 1

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMCrossingSInfMem.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMCrossingSInfMem.lean
@@ -42,7 +42,7 @@ theorem bddBelow_perMCrossingSet_inter_Icc
     [Nonempty (magConfigS Λ N M_balanced)] [Nonempty (magConfigS Λ N M)]
     (lam' D' : ℝ) :
     BddBelow (perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' ∩ Icc (0 : ℝ) 1) :=
-  ⟨0, fun t ht => ht.2.1⟩
+  ⟨0, fun _t ht => ht.2.1⟩
 
 /-- **`sInf` of the per-`M` crossing set ∩ `Icc 0 1` lies in the set**: given
 non-emptiness, the closed + bounded-below set achieves its infimum. -/

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMStrictGapBelowFirstCrossing.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergPerMStrictGapBelowFirstCrossing.lean
@@ -31,7 +31,7 @@ theorem strict_per_M_gap_of_lt_sInf_perMCrossingSet
     (N M_balanced M : ℕ)
     [Nonempty (magConfigS Λ N M_balanced)] [Nonempty (magConfigS Λ N M)]
     (lam' D' : ℝ)
-    (hne : (perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' ∩ Icc (0 : ℝ) 1).Nonempty)
+    (_hne : (perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' ∩ Icc (0 : ℝ) 1).Nonempty)
     {t : ℝ} (ht_mem : t ∈ Icc (0 : ℝ) 1)
     (ht_lt : t < sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' ∩ Icc (0 : ℝ) 1)) :
     anisotropicHeisenbergS_magSector_minEigenvalue_alongParametricPath
@@ -41,7 +41,7 @@ theorem strict_per_M_gap_of_lt_sInf_perMCrossingSet
   -- Suppose by contradiction the gap fails: E_M(γ(t)) ≤ E_balanced(γ(t)).
   -- Then t ∈ perMCrossingSet, contradicting t < sInf.
   by_contra h_neg
-  push_neg at h_neg
+  push Not at h_neg
   -- h_neg : E_M(γ(t)) ≤ E_balanced(γ(t))? Wait, the negation of `<` is `≥`.
   -- Strict gap goal: E_balanced < E_M. Negation: E_M ≤ E_balanced.
   have h_in_perM : t ∈ perMCrossingSet (Λ := Λ) hJ N M_balanced M lam' D' :=

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergStrictGapAllMFromArgmin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergStrictGapAllMFromArgmin.lean
@@ -31,7 +31,7 @@ theorem strict_gap_all_M_below_sInf_of_argmin
     [Nonempty (magConfigS Λ N M_balanced)] [Nonempty (magConfigS Λ N M_chosen)]
     [Nonempty (Λ → Fin (N + 1))]
     (lam' D' : ℝ)
-    (hne_chosen :
+    (_hne_chosen :
       (perMCrossingSet (Λ := Λ) hJ N M_balanced M_chosen lam' D' ∩ Icc (0 : ℝ) 1).Nonempty)
     (h_argmin :
       ∀ M' : ℕ, ∀ _ : Nonempty (magConfigS Λ N M'), M' ≠ M_balanced →
@@ -58,7 +58,7 @@ theorem strict_gap_all_M_below_sInf_of_argmin
     -- t' ∈ Icc 0 1. If E_M'(γ(t')) ≤ E_balanced(γ(t')), then t' ∈ perMCrossingSet ∩ Icc 0 1
     -- = ∅. Contradiction.
     by_contra h_not_strict
-    push_neg at h_not_strict
+    push Not at h_not_strict
     have h_t'_in : t' ∈ perMCrossingSet (Λ := Λ) hJ N M_balanced M' lam' D' ∩ Icc (0 : ℝ) 1 :=
       ⟨h_not_strict, ht'_in_Icc⟩
     rw [h_M'_ne] at h_t'_in

--- a/LatticeSystem/Quantum/SpinS/HermitianMinEigenvalueViaRayleigh.lean
+++ b/LatticeSystem/Quantum/SpinS/HermitianMinEigenvalueViaRayleigh.lean
@@ -30,6 +30,7 @@ theorem exists_index_eigenvalue_eq_hermitianMinEigenvalue
   obtain ⟨i, _, hi⟩ := h
   exact ⟨i, hi⟩
 
+omit [Nonempty n] in
 /-- For each index `i`, the unit-eigenvector `(hM.eigenvectorBasis i).ofLp` has
 `dotProduct (star v) v = 1`. This is the matrix-side unit normalisation of the
 orthonormal eigenvector basis. -/

--- a/LatticeSystem/Quantum/SpinS/HermitianVariationalLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/HermitianVariationalLowerBound.lean
@@ -25,6 +25,7 @@ open Matrix
 
 variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
 
+omit [Nonempty n] in
 /-- Sum of squared component norms of `Uᴴ v` equals `(dotProduct (star v) v).re`
 when `U` is the Hermitian eigenvectorUnitary. -/
 theorem sum_normSq_conjTranspose_eigenvectorUnitary_mulVec_eq

--- a/LatticeSystem/Quantum/SpinS/RayleighInfMatrixLe.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighInfMatrixLe.lean
@@ -35,6 +35,7 @@ theorem rayleighInfMatrix_le_hermitianMinEigenvalue
   rayleighInfMatrix_le_hermitianMinEigenvalue_of_bddBelow hM
     (rayleighOnVec_bddBelow_on_unit_sphere M)
 
+omit [DecidableEq n] [Nonempty n] in
 /-- **Unconditional upper bound at a unit vector**: for Hermitian `M` and any unit `v`,
 `rayleighInfMatrix M ≤ rayleighOnVec M v`. -/
 theorem rayleighInfMatrix_le_rayleighOnVec

--- a/LatticeSystem/Quantum/SpinS/RayleighInfMatrixLeConditional.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighInfMatrixLeConditional.lean
@@ -25,6 +25,7 @@ open Matrix
 
 variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
 
+omit [DecidableEq n] [Nonempty n] in
 /-- Conditional upper bound: `rayleighInfMatrix M ≤ rayleighOnVec M v` for any unit `v`,
 provided the function is bounded below over the matrix-side unit sphere. -/
 theorem rayleighInfMatrix_le_rayleighOnVec_of_bddBelow

--- a/LatticeSystem/Quantum/SpinS/RayleighOnDiagonal.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighOnDiagonal.lean
@@ -60,6 +60,7 @@ theorem rayleighOnVec_diagonal_real (lam : n → ℝ) (v : n → ℂ) :
 
 variable [Nonempty n]
 
+omit [DecidableEq n] in
 /-- Finite-sum lower bound: `Σ_i (‖v_i‖² · lam_i) ≥ (min_i lam_i) · Σ_i ‖v_i‖²`. -/
 theorem sum_normSq_mul_real_ge_min_mul_sum (lam : n → ℝ) (v : n → ℂ) :
     (Finset.univ.image lam).min' (Finset.image_nonempty.mpr Finset.univ_nonempty) *

--- a/LatticeSystem/Quantum/SpinS/RayleighOnVecBddBelow.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighOnVecBddBelow.lean
@@ -43,6 +43,7 @@ theorem norm_unit_vec_component_le_one
   have hsq_le : ‖v i‖ ^ 2 ≤ 1 := by rw [← hsum]; exact hge
   nlinarith [sq_nonneg (‖v i‖ - 1), sq_nonneg (‖v i‖ + 1), norm_nonneg (v i)]
 
+omit [Nonempty n] in
 /-- For any unit vector `v` (matrix-side `dotProduct (star v) v = 1`) and any matrix `M`,
 the absolute value of the Rayleigh quotient is bounded by the sum of matrix entry magnitudes:
 `|rayleighOnVec M v| ≤ Σ_{i,j} ‖M i j‖`. -/
@@ -79,6 +80,7 @@ theorem abs_rayleighOnVec_le_sum_entryNorms_of_unit
           (norm_unit_vec_component_le_one hunit j) (norm_nonneg _)
     _ = ∑ i, ∑ j, ‖M i j‖ := by simp
 
+omit [Nonempty n] in
 /-- `rayleighOnVec M` on the matrix-side unit sphere is bounded below by `-Σ_{i,j} ‖M i j‖`. -/
 theorem rayleighOnVec_bddBelow_on_unit_sphere (M : Matrix n n ℂ) :
     BddBelow (Set.range

--- a/LatticeSystem/Quantum/SpinS/RayleighOnVecBddBelow.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighOnVecBddBelow.lean
@@ -21,6 +21,7 @@ open Matrix
 
 variable {n : Type*} [Fintype n] [Nonempty n]
 
+omit [Nonempty n] in
 /-- For a unit vector `v` (matrix-side: `dotProduct (star v) v = 1`), each component
 satisfies `‖v_i‖ ≤ 1`. -/
 theorem norm_unit_vec_component_le_one

--- a/LatticeSystem/Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean
@@ -29,6 +29,7 @@ open Matrix Module
 
 variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
 
+omit [DecidableEq n] in
 /-- The Hermitian eigenvectorUnitary `U` is unitary: `U * Uᴴ = 1`. -/
 theorem eigenvectorUnitary_mul_conjTranspose_eq_one
     {M : Matrix n n ℂ} (hM : M.IsHermitian) :
@@ -40,6 +41,7 @@ theorem eigenvectorUnitary_mul_conjTranspose_eq_one
         Matrix n n ℂ) from rfl]
   exact h.2
 
+omit [DecidableEq n] in
 /-- The Hermitian eigenvectorUnitary `U` is unitary: `Uᴴ * U = 1`. -/
 theorem eigenvectorUnitary_conjTranspose_mul_eq_one
     {M : Matrix n n ℂ} (hM : M.IsHermitian) :

--- a/LatticeSystem/Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean
@@ -29,7 +29,7 @@ open Matrix Module
 
 variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
 
-omit [DecidableEq n] in
+omit [Nonempty n] in
 /-- The Hermitian eigenvectorUnitary `U` is unitary: `U * Uᴴ = 1`. -/
 theorem eigenvectorUnitary_mul_conjTranspose_eq_one
     {M : Matrix n n ℂ} (hM : M.IsHermitian) :
@@ -41,7 +41,7 @@ theorem eigenvectorUnitary_mul_conjTranspose_eq_one
         Matrix n n ℂ) from rfl]
   exact h.2
 
-omit [DecidableEq n] in
+omit [Nonempty n] in
 /-- The Hermitian eigenvectorUnitary `U` is unitary: `Uᴴ * U = 1`. -/
 theorem eigenvectorUnitary_conjTranspose_mul_eq_one
     {M : Matrix n n ℂ} (hM : M.IsHermitian) :

--- a/LatticeSystem/Quantum/SpinS/RayleighUnitarySimilarity.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighUnitarySimilarity.lean
@@ -23,6 +23,7 @@ open Matrix
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
+omit [DecidableEq n] in
 /-- Matrix-side adjoint identity for vecMul: `star v ᵥ* U = star (Uᴴ *ᵥ v)`. -/
 theorem star_vecMul (U : Matrix n n ℂ) (v : n → ℂ) :
     star v ᵥ* U = star (U.conjTranspose.mulVec v) := by
@@ -30,7 +31,7 @@ theorem star_vecMul (U : Matrix n n ℂ) (v : n → ℂ) :
   simp only [Matrix.vecMul, Matrix.mulVec, dotProduct, Pi.star_apply, RCLike.star_def,
              star_sum, star_mul', Matrix.conjTranspose_apply]
   refine Finset.sum_congr rfl (fun j _ => ?_)
-  simp [star_star]
+  simp
   ring
 
 /-- `rayleighOnVec` under unitary similarity: for any matrix `U`,

--- a/LatticeSystem/Quantum/SpinS/RayleighUnitarySimilarity.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighUnitarySimilarity.lean
@@ -34,6 +34,7 @@ theorem star_vecMul (U : Matrix n n ℂ) (v : n → ℂ) :
   simp
   ring
 
+omit [DecidableEq n] in
 /-- `rayleighOnVec` under unitary similarity: for any matrix `U`,
 `rayleighOnVec (U * M * Uᴴ) v = rayleighOnVec M (Uᴴ.mulVec v)`. -/
 theorem rayleighOnVec_unitary_conj (U M : Matrix n n ℂ) (v : n → ℂ) :


### PR DESCRIPTION
Tracked in #4485 (book-order backfill umbrella; the 20-PR-cadence refactor for the Chapter 9/10 thread).

## Summary

Refactoring PR (20-PR cadence; 12 feature PRs since the previous refactor #4543). **Fully clears the
unused-variable / unusedSectionVars / unused-simp-argument linter-warning category** from the root
build and includes the mandatory build-speed evaluation.

### Lint cleanup (unused category → zero)

- **`unusedSectionVars`** (unused `[DecidableEq n]` / `[Nonempty n]` section instances): added
  `omit [...] in` to the `Rayleigh*` eigenvalue helpers and their call-chain (the omits propagate
  "unused" up to callers, so the full transitive closure is fixed):
  `RayleighOnDiagonal`, `RayleighUnitarySimilarity`, `RayleighOnVecBddBelow` (×2),
  `RayleighOnVecHermitianLowerBound` (×2), `HermitianMinEigenvalueViaRayleigh`,
  `RayleighInfMatrixLeConditional`, `HermitianVariationalLowerBound`, `RayleighInfMatrixLe`.
- **`unused variable`** (local proof binders): underscore-prefixed 5 unused hypotheses in
  `AnisotropicHeisenberg*` (kept in the signature, only suppresses the warning).
- **unused `simp` argument**: removed `[star_star]` from a `simp` in `RayleighUnitarySimilarity`.
- Replaced 2 deprecated `push_neg` with `push Not` in the two touched `AnisotropicHeisenberg*` files.

Full root build: **0 unused-variable / unusedSectionVars / simp warnings** remain (514 → 494 total).
Each touched file verified warning-free with `lake env lean` (cache-independent, authoritative).

### Build-speed evaluation (mandatory)

Incremental compile times of the new Chapter 9/10 modules: `LiebShenQiu` 4.4s, `BipartiteSpectrum`
2.7s, `DegeneratePerturbation` 3.0s, `FockSpaceRepresentation` 15.1s (heaviest — Lemma 9.1 axiom +
9.2/9.3 Gram/det proofs). None is a split candidate; the lint cleanup is build-speed-neutral.

### Deferred (documented for future refactor PRs)

The root build still has ~266 **long-line** warnings (154 in the `JordanWigner.lean` module-overview
doc-comment table, the rest scattered code lines) and ~55 **deprecated-`_legacy`-variant** warnings
(internal call sites of deprecated `h_intermediate`-free spin-S lemmas). Both are larger, tedious
sweeps left for dedicated follow-up refactors.

## Notes

The first commit had a wrong omit instance (caught by codex P1: the `eigenvectorUnitary` unitary
lemmas need `[DecidableEq n]`; `[Nonempty n]` is the unused one — `lake build` had falsely reported
clean from cache, `lake env lean` is authoritative) and missed the call-chain propagation (P2); both
fixed in the follow-up commit, with a full root build confirming convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
