### PR TITLE
Refactor PR2: no-op / unnecessary-seq tactic warnings — #4569

### DIFF
--- a/LatticeSystem/Fermion/NumberSpinSBridge.lean
+++ b/LatticeSystem/Fermion/NumberSpinSBridge.lean
@@ -31,6 +31,6 @@ theorem fermionNumber_eq_half_smul_one_sub_spinSOp3_one :
   unfold fermionNumber LatticeSystem.Quantum.spinSOp3
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [Matrix.diagonal] <;> norm_num
+    simp [Matrix.diagonal]
 
 end LatticeSystem.Fermion

--- a/LatticeSystem/Quantum/MarshallLiebMattis/EqMagnetizationReachable.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/EqMagnetizationReachable.lean
@@ -95,8 +95,9 @@ theorem exists_swap_pair_of_eq_magnetization
            else if x ∈ D10 then (-2 : ℤ) else 0) := by
         intro x
         simp only [hD01_def, hD10_def, Finset.mem_filter, Finset.mem_univ, true_and]
-        rcases h_σx : σ x with ⟨kx, _⟩ <;> rcases h_σ'x : σ' x with ⟨k'x, _⟩ <;>
-          interval_cases kx <;> interval_cases k'x <;> simp [spinSign]
+        rcases h_σx : σ x with ⟨kx, _⟩
+        rcases h_σ'x : σ' x with ⟨k'x, _⟩
+        interval_cases kx <;> interval_cases k'x <;> simp [spinSign]
       have hpoint_pair : ∀ x : Λ,
           spinSign (σ x) - spinSign (σ' x) =
           (if x ∈ D01 then (2 : ℤ) else 0) +

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
@@ -484,7 +484,6 @@ theorem magnetization_neelConfigOf (A : Λ → Bool) :
   rw [Finset.sum_add_distrib]
   rw [← Finset.sum_filter, Finset.sum_const]
   rw [← Finset.sum_filter, Finset.sum_const]
-  push_cast
   ring
 
 /-- **Sublattice-swap symmetry** of the spin-`1/2` Néel magnetization:

--- a/LatticeSystem/Quantum/SpinS/MagSubspaceExtremalDim.lean
+++ b/LatticeSystem/Quantum/SpinS/MagSubspaceExtremalDim.lean
@@ -62,7 +62,7 @@ theorem magEigenvalueS_eq_mMax_iff_allAlignedConfigS_zero
   · intro h
     rw [h, magEigenvalueS_allAlignedConfigS]
     rw [show ((0 : Fin (N + 1)).val : ℂ) = 0 from by simp]
-    push_cast; ring
+    ring
 
 set_option linter.unusedSectionVars false in
 /-- `magEigenvalueS σ = −m_max` iff `σ = allAlignedConfigS V N (Fin.last N)`. -/
@@ -94,7 +94,7 @@ theorem magEigenvalueS_eq_neg_mMax_iff_allAlignedConfigS_last
   · intro h
     rw [h, magEigenvalueS_allAlignedConfigS]
     rw [show ((Fin.last N).val : ℂ) = (N : ℂ) from by simp [Fin.last]]
-    push_cast; ring
+    ring
 
 /-! ## Magnetization subspace at the extremal eigenvalues -/
 
@@ -153,7 +153,7 @@ theorem span_allAlignedStateS_zero_le_magSubspaceS_mMax :
   rw [SetLike.mem_coe, mem_magSubspaceS_iff]
   rw [totalSpinSOp3_mulVec_allAlignedStateS, magEigenvalueS_allAlignedConfigS]
   rw [show ((0 : Fin (N + 1)).val : ℂ) = 0 from by simp]
-  push_cast; ring_nf
+  ring_nf
 
 /-- **`magSubspaceS V N m_max` is exactly the line through `|σ_⊤⟩`**. -/
 theorem magSubspaceS_mMax_eq_span_allAlignedStateS_zero :
@@ -216,7 +216,7 @@ theorem span_allAlignedStateS_last_le_magSubspaceS_neg_mMax :
   rw [SetLike.mem_coe, mem_magSubspaceS_iff]
   rw [totalSpinSOp3_mulVec_allAlignedStateS, magEigenvalueS_allAlignedConfigS]
   rw [show ((Fin.last N).val : ℂ) = (N : ℂ) from by simp [Fin.last]]
-  push_cast; ring_nf
+  ring_nf
 
 /-- **`magSubspaceS V N (-m_max)` is exactly the line through `|σ_⊥⟩`**. -/
 theorem magSubspaceS_neg_mMax_eq_span_allAlignedStateS_last :

--- a/LatticeSystem/Quantum/SpinS/SpinHalfSpecialization.lean
+++ b/LatticeSystem/Quantum/SpinS/SpinHalfSpecialization.lean
@@ -30,7 +30,7 @@ theorem spinSOpPlus_one_eq_spinHalfOpPlus :
     spinSOpPlus 1 = spinHalfOpPlus := by
   unfold spinSOpPlus spinHalfOpPlus
   ext i j
-  fin_cases i <;> fin_cases j <;> simp <;> norm_num
+  fin_cases i <;> fin_cases j <;> simp
 
 /-- `spinSOpMinus 1 = spinHalfOpMinus`: the spin-`S` lowering
 operator at `N = 1` is the standard spin-`1/2` lowering matrix
@@ -39,7 +39,7 @@ theorem spinSOpMinus_one_eq_spinHalfOpMinus :
     spinSOpMinus 1 = spinHalfOpMinus := by
   unfold spinSOpMinus spinHalfOpMinus
   ext i j
-  fin_cases i <;> fin_cases j <;> simp <;> norm_num
+  fin_cases i <;> fin_cases j <;> simp
 
 /-- `spinSOp3 1 = spinHalfOp3`: the spin-`S` `Ŝ^{(3)}` operator at
 `N = 1` is the standard spin-`1/2` operator `(1/2) • σ^z`. -/
@@ -47,7 +47,8 @@ theorem spinSOp3_one_eq_spinHalfOp3 :
     spinSOp3 1 = spinHalfOp3 := by
   unfold spinSOp3 spinHalfOp3 pauliZ
   ext i j
-  fin_cases i <;> fin_cases j <;> simp <;> norm_num
+  fin_cases i <;> fin_cases j <;> simp
+  norm_num
 
 /-- `spinSOp1 1 = spinHalfOp1`: the spin-`S` `Ŝ^{(1)}` operator at
 `N = 1` is the standard spin-`1/2` operator `(1/2) • σ^x`. -/
@@ -66,7 +67,6 @@ theorem spinSOp2_one_eq_spinHalfOp2 :
   rw [spinSOpPlus_one_eq_spinHalfOpPlus, spinSOpMinus_one_eq_spinHalfOpMinus]
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [spinHalfOpPlus, spinHalfOpMinus, Complex.ext_iff] <;>
-    field_simp <;> ring
+    simp [spinHalfOpPlus, spinHalfOpMinus, Complex.ext_iff]
 
 end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #4569.

## Summary

Clears the **tactic-does-nothing / never-executed / unnecessary-`<;>`** warning
categories (no proof-content change; each fix verified by build):

- `SpinHalfSpecialization`: drop dead `<;> norm_num` (spinSOpPlus/Minus);
  newline-sequence `norm_num` for spinSOp3; drop dead `<;> field_simp <;> ring`
  (spinSOp1).
- `NumberSpinSBridge`: drop dead `<;> norm_num`.
- `MagSubspaceExtremalDim`: drop no-op `push_cast` before `ring`/`ring_nf` (×4).
- `MarshallLiebMattis/SublatticeCasimirNeel`: drop no-op `push_cast`.
- `MarshallLiebMattis/EqMagnetizationReachable`: newline-sequence the two
  single-goal `rcases` (fixes unnecessary-`<;>`).

## Build-speed evaluation

Tactic-only cleanup (dropped tactics were no-ops); no import-DAG change, no
measurable elaboration-time change. Verdict: no regression.

## Verification

- `lake build` (full root) green, no errors.
- Touched files confirmed clear of the handled categories via `lake env lean`.

Remaining: flexible-simp, show→change, unused hypothesis, long-line, deprecated
`_legacy` (later PRs of #4569).