### PR TITLE
Refactor PR3: show -> change tactic warnings (56 sites) — #4569

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHardcorePreserve.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHardcorePreserve.lean
@@ -139,7 +139,7 @@ theorem tJKinetic_commute_hubbardHardcoreProjection
       (hubbardHardcoreProjection N * hubbardKineticOnGraph N G 1 * hubbardHardcoreProjection N)
       (hubbardHardcoreProjection N) := by
   have h := hubbardHardcoreProjection_mul_self N
-  show hubbardHardcoreProjection N * hubbardKineticOnGraph N G 1 * hubbardHardcoreProjection N *
+  change hubbardHardcoreProjection N * hubbardKineticOnGraph N G 1 * hubbardHardcoreProjection N *
       hubbardHardcoreProjection N =
     hubbardHardcoreProjection N *
       (hubbardHardcoreProjection N * hubbardKineticOnGraph N G 1 * hubbardHardcoreProjection N)

--- a/LatticeSystem/Math/DoubleSequenceDiagonal.lean
+++ b/LatticeSystem/Math/DoubleSequenceDiagonal.lean
@@ -70,16 +70,16 @@ theorem diagonal_tendsto_zero (f : ℕ → ℕ → ℝ) (g : ℕ → ℝ)
   -- key facts: `T (m L) ≤ L` whenever `T 0 ≤ L`, and `K ≤ m L` whenever `L ≥ T K`.
   have hTmL : ∀ L, T 0 ≤ L → T (m L) ≤ L := by
     intro L hL
-    show T (Nat.findGreatest (fun k => T k ≤ L) L) ≤ L
+    change T (Nat.findGreatest (fun k => T k ≤ L) L) ≤ L
     exact Nat.findGreatest_spec (P := fun k => T k ≤ L) (Nat.zero_le L) hL
   have hmL_ge : ∀ K L, T K ≤ L → K ≤ m L := by
     intro K L hL
-    show K ≤ Nat.findGreatest (fun k => T k ≤ L) L
+    change K ≤ Nat.findGreatest (fun k => T k ≤ L) L
     exact Nat.le_findGreatest (P := fun k => T k ≤ L) (le_trans (hT_ge_self K) hL) hL
   refine ⟨m, ?_, ?_, ?_⟩
   · -- Monotone `m`.
     intro a b hab
-    show Nat.findGreatest (fun k => T k ≤ a) a ≤ Nat.findGreatest (fun k => T k ≤ b) b
+    change Nat.findGreatest (fun k => T k ≤ a) a ≤ Nat.findGreatest (fun k => T k ≤ b) b
     exact Nat.findGreatest_mono (P := fun k => T k ≤ a) (Q := fun k => T k ≤ b)
       (fun k hk => le_trans hk hab) hab
   · -- `m L → ∞`.

--- a/LatticeSystem/Math/HermitianMaxEigenvalueLeOfPF.lean
+++ b/LatticeSystem/Math/HermitianMaxEigenvalueLeOfPF.lean
@@ -60,7 +60,7 @@ theorem norm_mulVec_complex_le_mulVec_norm
   -- LHS = ‖∑ j, (B_real i j : ℂ) * w j‖
   -- ≤ ∑ j, ‖(B_real i j : ℂ) * w j‖ = ∑ j, |B_real i j| * ‖w j‖ = ∑ j, B_real i j * ‖w j‖.
   simp only [Matrix.mulVec, dotProduct, Matrix.map_apply]
-  show ‖∑ j, ((B_real i j : ℂ)) * w j‖ ≤ ∑ j, B_real i j * ‖w j‖
+  change ‖∑ j, ((B_real i j : ℂ)) * w j‖ ≤ ∑ j, B_real i j * ‖w j‖
   refine (norm_sum_le _ _).trans ?_
   apply Finset.sum_le_sum
   intros j _

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorEmbeddingLift.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorEmbeddingLift.lean
@@ -65,7 +65,7 @@ theorem anisotropicHeisenbergS_mulVec_magSectorEmbedding
         (anisotropicHeisenbergS J lam D N).mulVec (magSectorEmbedding Φ) σ =
         (anisotropicHeisenbergS_magSector_submatrix (Λ := Λ) J lam D N M).mulVec Φ
           ⟨σ, hσ⟩ := by
-      show ∑ ρ, (anisotropicHeisenbergS J lam D N) σ ρ * magSectorEmbedding Φ ρ =
+      change ∑ ρ, (anisotropicHeisenbergS J lam D N) σ ρ * magSectorEmbedding Φ ρ =
         ∑ ρ' : magConfigS Λ N M,
           anisotropicHeisenbergS_magSector_submatrix (Λ := Λ) J lam D N M ⟨σ, hσ⟩ ρ' *
             Φ ρ'
@@ -101,12 +101,12 @@ theorem anisotropicHeisenbergS_mulVec_magSectorEmbedding
     -- Now apply the sector eigenvalue equation.
     have hμ := congrFun hΦ ⟨σ, hσ⟩
     rw [hμ]
-    show μ * Φ ⟨σ, hσ⟩ = (μ • magSectorEmbedding Φ) σ
+    change μ * Φ ⟨σ, hσ⟩ = (μ • magSectorEmbedding Φ) σ
     rw [Pi.smul_apply, magSectorEmbedding_apply_of_mem Φ hσ, smul_eq_mul]
   · -- σ ∉ sector M. Both sides vanish.
     have hLHS_zero :
         (anisotropicHeisenbergS J lam D N).mulVec (magSectorEmbedding Φ) σ = 0 := by
-      show ∑ ρ, (anisotropicHeisenbergS J lam D N) σ ρ * magSectorEmbedding Φ ρ = 0
+      change ∑ ρ, (anisotropicHeisenbergS J lam D N) σ ρ * magSectorEmbedding Φ ρ = 0
       refine Finset.sum_eq_zero (fun ρ _ => ?_)
       by_cases hρ : magSumS ρ = M
       · -- ρ ∈ sector M, σ ∉ sector M: magSums differ ⟹ matrix element = 0.
@@ -115,7 +115,7 @@ theorem anisotropicHeisenbergS_mulVec_magSectorEmbedding
         rw [anisotropicHeisenbergS_apply_eq_zero_of_magSumS_ne J lam D hne, zero_mul]
       · rw [magSectorEmbedding_apply_of_not_mem Φ hρ, mul_zero]
     rw [hLHS_zero]
-    show (0 : ℂ) = (μ • magSectorEmbedding Φ) σ
+    change (0 : ℂ) = (μ • magSectorEmbedding Φ) σ
     rw [Pi.smul_apply, magSectorEmbedding_apply_of_not_mem Φ hσ, smul_zero]
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorInverseLift.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergMagSectorInverseLift.lean
@@ -51,7 +51,7 @@ theorem anisotropicHeisenbergS_magSector_submatrix_mulVec_magSectorRestriction_o
   -- LHS: (Ĥ_M).mulVec (restrict Ψ) τ = ∑ τ' : magConfigS, Ĥ_M τ τ' * (restrict Ψ) τ'.
   --     = ∑ τ' : magConfigS, Ĥ τ.1 τ'.1 * Ψ τ'.1.
   -- Convert subtype sum to filter sum.
-  show ∑ τ' : magConfigS Λ N M,
+  change ∑ τ' : magConfigS Λ N M,
       anisotropicHeisenbergS_magSector_submatrix J lam D N M τ τ' *
         magSectorRestriction (M := M) Ψ τ' = μ * Ψ τ.1
   have hsec : (∑ τ' : magConfigS Λ N M,

--- a/LatticeSystem/Quantum/SpinS/AnisotropicSectorProjectionEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicSectorProjectionEigenvector.lean
@@ -55,7 +55,7 @@ theorem anisotropicHeisenbergS_magSectorProjection_eigen
     -- The second sum is 0 since H σ τ = 0 when sectors differ (#3898).
     -- So (H·w) σ = (H·v) σ = μ * v σ = μ * w σ.
     have hHwσ : H.mulVec w σ = H.mulVec v σ := by
-      show ∑ τ, H σ τ * w τ = ∑ τ, H σ τ * v τ
+      change ∑ τ, H σ τ * w τ = ∑ τ, H σ τ * v τ
       refine Finset.sum_congr rfl (fun τ _ => ?_)
       by_cases hτM : magSumS τ = M
       · have : w τ = v τ := by
@@ -77,7 +77,7 @@ theorem anisotropicHeisenbergS_magSectorProjection_eigen
     -- (H·w) σ = ∑_τ H σ τ * w τ. For τ in sector M: σ ∉ M ⟹ H σ τ = 0.
     -- For τ not in sector M: w τ = 0. So all terms vanish.
     have hHwσ : H.mulVec w σ = 0 := by
-      show ∑ τ, H σ τ * w τ = 0
+      change ∑ τ, H σ τ * w τ = 0
       refine Finset.sum_eq_zero (fun τ _ => ?_)
       by_cases hτM : magSumS τ = M
       · have hH0 : H σ τ = 0 := by

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -126,14 +126,14 @@ theorem exists_raiseLowerStepS_bipartite_of_over_under_ne_sublattice
     -- σ'' agrees with σ off {x, y}.
     have hagree : ∀ k, k ≠ x → k ≠ y → σ'' k = σ k := by
       intro k hkx hky
-      show (Function.update (Function.update σ x _) y _) k = σ k
+      change (Function.update (Function.update σ x _) y _) k = σ k
       rw [Function.update_of_ne hky, Function.update_of_ne hkx]
     -- σ'' x and σ'' y values.
     have hupd_x : (σ'' x).val = (σ x).val - 1 := by
-      show (Function.update (Function.update σ x _) y _ x).val = _
+      change (Function.update (Function.update σ x _) y _ x).val = _
       rw [Function.update_of_ne hxy, Function.update_self]
     have hupd_y : (σ'' y).val = (σ y).val + 1 := by
-      show (Function.update (Function.update σ x _) y _ y).val = _
+      change (Function.update (Function.update σ x _) y _ y).val = _
       rw [Function.update_self]
     refine ⟨x, y, hadj, Or.inr ⟨?_, ?_⟩, hagree⟩
     · rw [hupd_x]; omega
@@ -181,31 +181,31 @@ theorem exists_raiseLowerReachableS_bipartite_of_over_under_eq_sublattice
       ⟨(σ z).val + 1, hz_raise_bound⟩
   -- σ_1 site values.
   have hσ_1_z : (σ_1 z).val = (σ z).val + 1 := by
-    show (Function.update (Function.update σ x _) z _ z).val = _
+    change (Function.update (Function.update σ x _) z _ z).val = _
     rw [Function.update_self]
   have hσ_1_x : (σ_1 x).val = (σ x).val - 1 := by
-    show (Function.update (Function.update σ x _) z _ x).val = _
+    change (Function.update (Function.update σ x _) z _ x).val = _
     rw [Function.update_of_ne hzx.symm, Function.update_self]
   have hσ_1_y_eq : σ_1 y = σ y := by
-    show Function.update (Function.update σ x _) z _ y = σ y
+    change Function.update (Function.update σ x _) z _ y = σ y
     rw [Function.update_of_ne hzy.symm, Function.update_of_ne hxy.symm]
   have hσ_1_off : ∀ k, k ≠ x → k ≠ z → σ_1 k = σ k := by
     intro k hkx hkz
-    show Function.update (Function.update σ x _) z _ k = σ k
+    change Function.update (Function.update σ x _) z _ k = σ k
     rw [Function.update_of_ne hkz, Function.update_of_ne hkx]
   -- σ_2 site values.
   have hσ_2_x : (σ_2 x).val = (σ x).val - 1 := by
-    show (Function.update (Function.update σ x _) y _ x).val = _
+    change (Function.update (Function.update σ x _) y _ x).val = _
     rw [Function.update_of_ne hxy, Function.update_self]
   have hσ_2_y : (σ_2 y).val = (σ y).val + 1 := by
-    show (Function.update (Function.update σ x _) y _ y).val = _
+    change (Function.update (Function.update σ x _) y _ y).val = _
     rw [Function.update_self]
   have hσ_2_z : σ_2 z = σ z := by
-    show (Function.update (Function.update σ x _) y _) z = σ z
+    change (Function.update (Function.update σ x _) y _) z = σ z
     rw [Function.update_of_ne hzy, Function.update_of_ne hzx]
   have hσ_2_off : ∀ k, k ≠ x → k ≠ y → σ_2 k = σ k := by
     intro k hkx hky
-    show (Function.update (Function.update σ x _) y _) k = σ k
+    change (Function.update (Function.update σ x _) y _) k = σ k
     rw [Function.update_of_ne hky, Function.update_of_ne hkx]
   refine ⟨σ_2, ?_, ?_⟩
   · -- Reachability via 2 steps σ → σ_1 → σ_2.

--- a/LatticeSystem/Quantum/SpinS/ConfigDist.lean
+++ b/LatticeSystem/Quantum/SpinS/ConfigDist.lean
@@ -176,17 +176,17 @@ theorem configDistS_decrease_of_over_under
     -- σ'' k = σ k for k ∉ {x, y}.
     show Nat.dist (σ'' k).val (σ' k).val = Nat.dist (σ k).val (σ' k).val
     have hupd : σ'' k = σ k := by
-      show (Function.update (Function.update σ x _) y _) k = σ k
+      change (Function.update (Function.update σ x _) y _) k = σ k
       rw [Function.update_of_ne hky, Function.update_of_ne hkx]
     rw [hupd]
   rw [Finset.sum_congr rfl hrest]
   -- Compute σ'' x and σ'' y.
   have hupdy_y : σ'' y =
       ⟨(σ y).val + 1, by have := (σ y).isLt; omega⟩ := by
-    show (Function.update (Function.update σ x _) y _) y = _
+    change (Function.update (Function.update σ x _) y _) y = _
     rw [Function.update_self]
   have hupd_x : σ'' x = ⟨(σ x).val - 1, by have := (σ x).isLt; omega⟩ := by
-    show (Function.update (Function.update σ x _) y _) x = _
+    change (Function.update (Function.update σ x _) y _) x = _
     rw [Function.update_of_ne hxy, Function.update_self]
   rw [hupd_x, hupdy_y]
   -- Now distances at x and y change by 1 each.
@@ -257,14 +257,14 @@ theorem raiseLowerReachableS_completeGraph_of_eq_magSumS
       -- σ'' agrees with σ off {x, y}.
       have hagree : ∀ k, k ≠ x → k ≠ y → σ'' k = σ k := by
         intro k hkx hky
-        show (Function.update (Function.update σ x _) y _) k = σ k
+        change (Function.update (Function.update σ x _) y _) k = σ k
         rw [Function.update_of_ne hky, Function.update_of_ne hkx]
       -- σ'' x and σ'' y values.
       have hupd_x : (σ'' x).val = (σ x).val - 1 := by
-        show (Function.update (Function.update σ x _) y _ x).val = _
+        change (Function.update (Function.update σ x _) y _ x).val = _
         rw [Function.update_of_ne hxy, Function.update_self]
       have hupd_y : (σ'' y).val = (σ y).val + 1 := by
-        show (Function.update (Function.update σ x _) y _ y).val = _
+        change (Function.update (Function.update σ x _) y _ y).val = _
         rw [Function.update_self]
       -- Adjacency in ⊤: any distinct pair.
       have hadj : (⊤ : SimpleGraph V).Adj x y := by

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapParityBondStrictPos.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapParityBondStrictPos.lean
@@ -287,7 +287,7 @@ theorem shiftedDressedAxisSwappedReMatrix_apply_pos_of_parityBondStepS_witness_b
   have hneg :=
     dressedAxisSwappedAnisotropicHeisenbergS_apply_re_neg_of_parityBondStepS_witness_bipartite
       A hJim hJnn hJself hJbip hlam hlb hub hDim hDnn hxy hAne hJpos_xy hsh hagree
-  show 0 < -((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N) σ' σ).re
+  change 0 < -((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N) σ' σ).re
   linarith
 
 /-- **Shifted PF strictly positive on a `ParityBondStepS`**.  For a bond-parity move on

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapRaiseLowerStrictNeg.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapRaiseLowerStrictNeg.lean
@@ -176,7 +176,7 @@ theorem shiftedDressedAxisSwappedReMatrix_apply_pos_of_raiseLowerStepS_witness_b
   have hneg :=
     dressedAxisSwappedAnisotropicHeisenbergS_apply_re_neg_of_raiseLowerStepS_witness_bipartite
       A hJim hJnn hJself hJbip hlam hlb hub hDim hDnn hxy hAne hJpos_xy hsh hagree
-  show 0 < -((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N) σ' σ).re
+  change 0 < -((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N) σ' σ).re
   linarith
 
 /-- **Shifted PF matrix entry strictly positive on a transverse step**.  For a

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapSingleIonStrictPos.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapSingleIonStrictPos.lean
@@ -258,7 +258,7 @@ theorem shiftedDressedAxisSwappedReMatrix_apply_pos_of_singleIonStepS_witness
   have hneg :=
     dressedAxisSwappedAnisotropicHeisenbergS_apply_re_neg_of_singleIonStepS_witness
       (lam := lam) A hJself hDim hDpos hsx hagree
-  show 0 < -((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N) σ' σ).re
+  change 0 < -((dressedAxisSwappedAnisotropicHeisenbergS A J lam D N) σ' σ).re
   linarith
 
 /-- **Shifted PF strict positive on a `SingleIonStepS`** (case (i.2), `D.re > 0`). -/

--- a/LatticeSystem/Quantum/SpinS/DressedHeisenbergRaiseLower.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedHeisenbergRaiseLower.lean
@@ -198,7 +198,7 @@ theorem neg_dressedHeisenbergSReMatrix_apply_pos_of_raiseLowerStepS_witness
     0 < (-dressedHeisenbergSReMatrix A J N) σ' σ := by
   have hneg := dressedHeisenbergSReMatrix_apply_neg_of_raiseLowerStepS_witness
     A N hadj hAne hJ_real hJ_pos hJ_sym hsh hagree
-  show 0 < -dressedHeisenbergSReMatrix A J N σ' σ
+  change 0 < -dressedHeisenbergSReMatrix A J N σ' σ
   linarith
 
 /-- For a `RaiseLowerStepS` in the bipartite complete graph

--- a/LatticeSystem/Quantum/SpinS/ParityReachConcentrate.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachConcentrate.lean
@@ -56,7 +56,7 @@ theorem parityReachableS_drainSetInto
       by_cases hka : k = a₀
       · rw [hka, if_pos rfl]
         ext
-        show (σ a₀).val + ∑ s ∈ (∅ : Finset V), (σ s).val = (σ a₀).val
+        change (σ a₀).val + ∑ s ∈ (∅ : Finset V), (σ s).val = (σ a₀).val
         simp
       · rw [if_neg hka]
         simp
@@ -98,7 +98,7 @@ theorem parityReachableS_drainSetInto
       rw [hsig_drain_off s hsa hsa₀]
     have hbound_ih : (σ_drain_a a₀).val + ∑ s ∈ S, (σ_drain_a s).val ≤ N := by
       rw [hsig_drain_a₀, hSum_eq]
-      show (σ a₀).val + (σ a).val + ∑ s ∈ S, (σ s).val ≤ N
+      change (σ a₀).val + (σ a).val + ∑ s ∈ S, (σ s).val ≤ N
       have := hbound; rw [hSum_insert] at this; omega
     have hkb_ih : (σ_drain_a b).val + 1 ≤ N := by
       rw [hsig_drain_off b ha_adj.ne.symm ha₀b.ne.symm]
@@ -113,10 +113,10 @@ theorem parityReachableS_drainSetInto
       by_cases hka₀ : k = a₀
       · rw [hka₀, if_pos rfl, if_pos rfl]
         ext
-        show (σ_drain_a a₀).val + ∑ s ∈ S, (σ_drain_a s).val =
+        change (σ_drain_a a₀).val + ∑ s ∈ S, (σ_drain_a s).val =
           (σ a₀).val + ∑ s ∈ (insert a S), (σ s).val
         rw [hsig_drain_a₀, hSum_eq, hSum_insert]
-        show (σ a₀).val + (σ a).val + ∑ s ∈ S, (σ s).val =
+        change (σ a₀).val + (σ a).val + ∑ s ∈ S, (σ s).val =
           (σ a₀).val + ((σ a).val + ∑ s ∈ S, (σ s).val)
         ring
       · rw [if_neg hka₀, if_neg hka₀]

--- a/LatticeSystem/Quantum/SpinS/ParityReachConcentrateAB.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachConcentrateAB.lean
@@ -101,7 +101,7 @@ theorem parityReachableS_concentrate_AB
   · -- σ_AB b₀ = (σ_A b₀ + Σ bSitesExcept σ_A) = (σ b₀ + Σ σ_A b) = (σ b₀ + Σ σ b).
     rw [hsig_AB]; unfold drainSetInto; rw [if_pos rfl]
     ext
-    show (σ_A b₀).val + ∑ s ∈ bSitesExcept A b₀, (σ_A s).val =
+    change (σ_A b₀).val + ∑ s ∈ bSitesExcept A b₀, (σ_A s).val =
       (σ b₀).val + ∑ s ∈ bSitesExcept A b₀, (σ s).val
     rw [hsig_A_bSite b₀ hb₀]
     congr 1

--- a/LatticeSystem/Quantum/SpinS/ParityReachDrainOne.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachDrainOne.lean
@@ -49,7 +49,7 @@ theorem parityReachableS_drain_a_into_a0
     by_cases hja : j = a
     · rw [hja, if_pos rfl, if_pos rfl]
       ext
-      show (σ a).val - (σ a).val = 0
+      change (σ a).val - (σ a).val = 0
       omega
     · rw [if_neg hja, if_neg hja]
   rw [htarget_eq] at hreach

--- a/LatticeSystem/Quantum/SpinS/ParityReachShuffle.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachShuffle.lean
@@ -58,7 +58,7 @@ theorem parityReachableS_shuffle_a_to_aprime_via_b
     rw [hsig_mid]; exact configUpdateTwo_agree _ _ _ _ _ a' ha'a ha'b_ne
   -- Step 2: σ_mid → σ_final where σ_final = σ_mid with σ_mid a' += 1, σ_mid b -= 1.
   have hka'_mid : (σ_mid a').val + 1 ≤ N := by rw [hsig_mid_a']; exact hka'
-  have hkb_mid : 1 ≤ (σ_mid b).val := by rw [hsig_mid_b]; show 1 ≤ (σ b).val + 1; omega
+  have hkb_mid : 1 ≤ (σ_mid b).val := by rw [hsig_mid_b]; change 1 ≤ (σ b).val + 1; omega
   have hstep2 := raiseLowerStepS_pair_shift_raise_a_lower_b (N := N) A ha'b hka'_mid hkb_mid
   -- Show the final config equals our target.
   have hfinal_eq :
@@ -79,16 +79,16 @@ theorem parityReachableS_shuffle_a_to_aprime_via_b
         have h_kb : k ≠ b := hka'_k ▸ ha'b_ne
         simp only [configUpdateTwo, if_neg h_ka, if_pos hka'_k]
         ext
-        show (σ_mid a').val + 1 = (σ a').val + 1
+        change (σ_mid a').val + 1 = (σ a').val + 1
         rw [hsig_mid_a']
       · by_cases hkb_k : k = b
         · have h_ka : k ≠ a := hkb_k ▸ fun h => hab_ne h.symm
           have h_ka' : k ≠ a' := hkb_k ▸ fun h => ha'b_ne h.symm
           simp only [configUpdateTwo, if_neg h_ka, if_neg h_ka', if_pos hkb_k]
           ext
-          show (σ_mid b).val - 1 = (σ k).val
+          change (σ_mid b).val - 1 = (σ k).val
           rw [hkb_k, hsig_mid_b]
-          show (σ b).val + 1 - 1 = (σ b).val
+          change (σ b).val + 1 - 1 = (σ b).val
           omega
         · simp only [configUpdateTwo, if_neg hka_k, if_neg hka'_k, if_neg hkb_k]
           rw [hsig_mid]

--- a/LatticeSystem/Quantum/SpinS/ParityReachShuffleIter.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachShuffleIter.lean
@@ -46,13 +46,13 @@ theorem parityReachableS_shuffle_n_units
       · rw [hja]
         unfold configUpdateTwo
         rw [if_pos rfl]
-        ext; show (σ a).val - 0 = (σ a).val; omega
+        ext; change (σ a).val - 0 = (σ a).val; omega
       · unfold configUpdateTwo
         rw [if_neg hja]
         by_cases hja' : j = a'
         · rw [hja']
           rw [if_pos rfl]
-          ext; show (σ a').val + 0 = (σ a').val; omega
+          ext; change (σ a').val + 0 = (σ a').val; omega
         · rw [if_neg hja']
     rw [hself]
     exact ParityReachableS.refl _ _
@@ -92,14 +92,14 @@ theorem parityReachableS_shuffle_n_units
       by_cases hja : j = a
       · rw [hja, if_pos rfl, if_pos rfl]
         ext
-        show (σ_one a).val - k = (σ a).val - (k + 1)
+        change (σ_one a).val - k = (σ a).val - (k + 1)
         rw [hsig_one_a_val]
         omega
       · rw [if_neg hja, if_neg hja]
         by_cases hja' : j = a'
         · rw [hja', if_pos rfl, if_pos rfl]
           ext
-          show (σ_one a').val + k = (σ a').val + (k + 1)
+          change (σ_one a').val + k = (σ a').val + (k + 1)
           rw [hsig_one_a'_val]
           omega
         · rw [if_neg hja', if_neg hja']

--- a/LatticeSystem/Quantum/SpinS/ParityReachTransferIter.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachTransferIter.lean
@@ -46,12 +46,12 @@ theorem parityReachableS_transfer_n_units
       · rw [hja]
         unfold configUpdateTwo
         rw [if_pos rfl]
-        ext; show (σ a).val - 0 = (σ a).val; omega
+        ext; change (σ a).val - 0 = (σ a).val; omega
       · unfold configUpdateTwo
         rw [if_neg hja]
         by_cases hjb : j = b
         · rw [hjb, if_pos rfl]
-          ext; show (σ b).val + 0 = (σ b).val; omega
+          ext; change (σ b).val + 0 = (σ b).val; omega
         · rw [if_neg hjb]
     rw [hself]
     exact ParityReachableS.refl _ _
@@ -87,14 +87,14 @@ theorem parityReachableS_transfer_n_units
       by_cases hja : j = a
       · rw [hja, if_pos rfl, if_pos rfl]
         ext
-        show (σ_one a).val - k = (σ a).val - (k + 1)
+        change (σ_one a).val - k = (σ a).val - (k + 1)
         rw [hsig_one_a_val]
         omega
       · rw [if_neg hja, if_neg hja]
         by_cases hjb : j = b
         · rw [hjb, if_pos rfl, if_pos rfl]
           ext
-          show (σ_one b).val + k = (σ b).val + (k + 1)
+          change (σ_one b).val + k = (σ b).val + (k + 1)
           rw [hsig_one_b_val]
           omega
         · rw [if_neg hjb, if_neg hjb]

--- a/LatticeSystem/Quantum/SpinS/ParityReachWitness.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachWitness.lean
@@ -72,7 +72,7 @@ theorem raiseLowerStepS_pair_shift_lower_a_raise_b
   refine ⟨a, b, hadj, ?_, ?_⟩
   · right
     refine ⟨?_, ?_⟩
-    · rw [configUpdateTwo_at_a]; show (σ a).val - 1 + 1 = (σ a).val; omega
+    · rw [configUpdateTwo_at_a]; change (σ a).val - 1 + 1 = (σ a).val; omega
     · rw [configUpdateTwo_at_b _ hadj.ne]
   · exact configUpdateTwo_agree _ _ _ _ _
 
@@ -90,7 +90,7 @@ theorem raiseLowerStepS_pair_shift_raise_a_lower_b
   · left
     refine ⟨?_, ?_⟩
     · rw [configUpdateTwo_at_a]
-    · rw [configUpdateTwo_at_b _ hadj.ne]; show (σ b).val - 1 + 1 = (σ b).val; omega
+    · rw [configUpdateTwo_at_b _ hadj.ne]; change (σ b).val - 1 + 1 = (σ b).val; omega
   · exact configUpdateTwo_agree _ _ _ _ _
 
 omit [Fintype V] in
@@ -121,8 +121,8 @@ theorem parityBondStepS_pair_lower
   refine ⟨a, b, hadj, ?_, ?_⟩
   · right
     refine ⟨?_, ?_⟩
-    · rw [configUpdateTwo_at_a]; show (σ a).val - 1 + 1 = (σ a).val; omega
-    · rw [configUpdateTwo_at_b _ hadj.ne]; show (σ b).val - 1 + 1 = (σ b).val; omega
+    · rw [configUpdateTwo_at_a]; change (σ a).val - 1 + 1 = (σ a).val; omega
+    · rw [configUpdateTwo_at_b _ hadj.ne]; change (σ b).val - 1 + 1 = (σ b).val; omega
   · exact configUpdateTwo_agree _ _ _ _ _
 
 /-- Update at a single site. -/
@@ -160,7 +160,7 @@ theorem singleIonStepS_lower
     SingleIonStepS σ (configUpdateOne σ a ⟨(σ a).val - 2, by have := (σ a).isLt; omega⟩) := by
   refine ⟨a, ?_, ?_⟩
   · right
-    rw [configUpdateOne_at]; show (σ a).val - 2 + 2 = (σ a).val; omega
+    rw [configUpdateOne_at]; change (σ a).val - 2 + 2 = (σ a).val; omega
   · exact configUpdateOne_agree _ _ _
 
 end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #4569.

## Summary

Replaces `show` with `change` at every site flagged by the style linter
(*"The `show` tactic should only be used to indicate intermediate goal states …
this tactic invocation changed the goal. Please use `change` instead."*). 56
sites across 19 files. `change` performs the same definitional goal change, so the
proofs are unaffected.

## Build-speed evaluation

Format-only (`show` → `change`); no import-DAG or elaboration-time change.
Verdict: no regression.

## Verification

- `lake build` (full root) green, no errors.
- All 56 flagged sites now use `change`.

Remaining: flexible-simp, unused hypothesis, long-line, deprecated `_legacy`
(later PRs of #4569).