### PR TITLE
Refactor PR4: flexible simp -> simp only (7 sites) — #4569

### DIFF
--- a/LatticeSystem/Math/RayleighAtEigenvector.lean
+++ b/LatticeSystem/Math/RayleighAtEigenvector.lean
@@ -45,7 +45,7 @@ theorem rayleigh_quotient_at_eigenvector
   have h_num : (∑ i, v i * (M.mulVec v) i) = μ * (∑ i, v i * v i) := by
     have : ∀ i, v i * (M.mulVec v) i = μ * (v i * v i) := fun i => by
       have := congrFun hv i
-      simp [Pi.smul_apply, smul_eq_mul] at this
+      simp only [Pi.smul_apply, smul_eq_mul] at this
       rw [this]; ring
     rw [show (∑ i, v i * (M.mulVec v) i) = ∑ i, μ * (v i * v i) from
       Finset.sum_congr rfl (fun i _ => this i)]

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
@@ -823,14 +823,14 @@ theorem neelStateOf_complement_pair_independent
     have := congrArg (dotProduct (star (neelStateOf A))) h
     rw [dotProduct_add, dotProduct_smul, dotProduct_smul,
         neelStateOf_inner_self, horth_AcA, dotProduct_zero] at this
-    simp at this
+    simp only [smul_eq_mul, mul_one, mul_zero, add_zero] at this
     exact this
   have hc2 : c2 = 0 := by
     have := congrArg
       (dotProduct (star (neelStateOf (fun x : Λ => ! A x)))) h
     rw [dotProduct_add, dotProduct_smul, dotProduct_smul,
         neelStateOf_inner_self, horth_cAA, dotProduct_zero] at this
-    simp at this
+    simp only [smul_eq_mul, mul_zero, mul_one, zero_add] at this
     exact this
   exact ⟨hc1, hc2⟩
 

--- a/LatticeSystem/Quantum/SpinS/MultiSiteDotOffDiag.lean
+++ b/LatticeSystem/Quantum/SpinS/MultiSiteDotOffDiag.lean
@@ -69,7 +69,7 @@ theorem spinSDot_apply_re_nonneg_of_raising_lowering_x
       Matrix.diagonal_apply_ne _ hσ'x]
     ring
   rw [h3eq]
-  simp
+  simp only [one_div, Complex.zero_re, add_zero, inv_pos, Nat.ofNat_pos, mul_nonneg_iff_of_pos_left, ge_iff_le]
   positivity
 
 /-- For `x ≠ y` and configurations `σ', σ` agreeing off `{x, y}` with
@@ -203,7 +203,7 @@ theorem spinSDot_apply_re_nonneg_of_raising_lowering_y
       Matrix.diagonal_apply_ne _ hσ'x]
     ring
   rw [h3eq]
-  simp
+  simp only [one_div, Complex.zero_re, add_zero, inv_pos, Nat.ofNat_pos, mul_nonneg_iff_of_pos_left, ge_iff_le]
   positivity
 
 

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelExpectations.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelExpectations.lean
@@ -272,14 +272,14 @@ theorem neelStateOfS_complement_pair_independent
     have := congrArg (dotProduct (star (neelStateOfS A N))) h
     rw [dotProduct_add, dotProduct_smul, dotProduct_smul,
         neelStateOfS_inner_self, horth_AcA, dotProduct_zero] at this
-    simp at this
+    simp only [smul_eq_mul, mul_one, mul_zero, add_zero] at this
     exact this
   have hc2 : c2 = 0 := by
     have := congrArg
       (dotProduct (star (neelStateOfS (fun x : Λ => ! A x) N))) h
     rw [dotProduct_add, dotProduct_smul, dotProduct_smul,
         neelStateOfS_inner_self, horth_cAA, dotProduct_zero] at this
-    simp at this
+    simp only [smul_eq_mul, mul_zero, mul_one, zero_add] at this
     exact this
   exact ⟨hc1, hc2⟩
 


### PR DESCRIPTION
Tracked in #4569.

## Summary

Replaces the goal/hypothesis-modifying `simp` flagged by the **flexible-tactic**
linter with the explicit `simp only [...]` sets from `simp?` (same simplification,
no longer flexible). 7 sites: `Math/RayleighAtEigenvector`, `MultiSiteDotOffDiag`
(×2), `MarshallLiebMattis/SublatticeCasimirNeelExpectations` (×2),
`MarshallLiebMattis/SublatticeCasimirNeel` (×2).

## Build-speed evaluation

Explicit `simp only` sets are neutral-to-slightly-faster than full `simp`; no
import-DAG change. Verdict: no regression.

## Verification

- `lake build` (full root) green, no errors.
- All 7 flagged sites confirmed clear via `lake env lean`.

Remaining: unused hypothesis (83), long-line (266), deprecated `_legacy` (57).