### PR TITLE
Refactor PR5: clear 154 long-line warnings in JordanWigner.lean (table) — #4569

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -263,6 +263,11 @@ import LatticeSystem.Fermion.JordanWigner.NumberCommutePauliOfNe
 set_option linter.unusedSectionVars false
 set_option linter.unusedSimpArgs false
 set_option linter.unusedVariables false
+-- This module is a pure re-export hub: imports + a large module-overview markdown
+-- table (one row per sub-module) + an empty namespace, with no proofs.  The table
+-- rows are single lines by markdown syntax and cannot be wrapped, so the long-line
+-- style linter is disabled file-wide here.
+set_option linter.style.longLine false
 
 /-!
 # Multi-mode fermion via Jordan–Wigner mapping


### PR DESCRIPTION
Tracked in #4569.

## Summary

`Fermion/JordanWigner.lean` is a pure re-export hub — imports + a large
module-overview markdown table (one row per sub-module) + an empty namespace,
**no proofs**. Its 154 long-line warnings are all table rows, which are single
lines by markdown syntax and cannot be wrapped without breaking the table.

Disable the long-line style linter file-wide
(`set_option linter.style.longLine false`) with an explanatory comment,
consistent with the file's existing file-wide `set_option` block. Clears 154 of
the 266 long-line warnings.

## Build-speed evaluation

Linter-option only; no code / import-DAG / elaboration-time change. No regression.

## Verification

- `lake build LatticeSystem.Fermion.JordanWigner`: 0 long-line warnings remain in
  `JordanWigner.lean` (down from 154), no errors.

Remaining 112 long-line warnings are real code lines (follow-up PRs of #4569).