### PR TITLE
Refactor PR6: maxHeartbeat comment + 44 long-line wraps (prose) — #4569

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJDiagonalMatrixElement.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJDiagonalMatrixElement.lean
@@ -6,7 +6,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorBasis
 
 The interaction term `n̂_x n̂_y / 4 − Ŝ_x · Ŝ_y` of the t-J Hamiltonian splits into the ladder part
 `½(Ŝ⁺_xŜ⁻_y + Ŝ⁻_xŜ⁺_y)` (off-diagonal, handled in PR-B5) and the *diagonal* part
-`n̂_x n̂_y / 4 − Ŝ³_x Ŝ³_y`.  The per-site number `n̂_x` and spin-z `Ŝ³_x` are diagonal operators on the
+`n̂_x n̂_y / 4 − Ŝ³_x Ŝ³_y`.  The per-site number `n̂_x` and spin-z `Ŝ³_x` are diagonal operators
+on the
 computational basis (combinations of mode-number operators), so their products act as scalars on
 `|Φ_s⟩`, and hence have **vanishing off-diagonal matrix element** `⟨Φ_{s'} | · | Φ_s⟩ = 0` for
 `s' ≠ s`.  This isolates the off-diagonal part of the effective matrix to the sign-free hopping and

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingRayleighBridge.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingRayleighBridge.lean
@@ -5,7 +5,8 @@ import LatticeSystem.Quantum.SpinS.RayleighUnitarySimilarity
 /-!
 # Tasaki 11.5: the filling embedding is an isometry, and the Rayleigh bridge (Prop 11.24 PR-E2 ≥)
 
-The orthonormal filling embedding `T` satisfies `Tᴴ T = 1` (`tJFillingEmbedding_conjTranspose_mul_self`),
+The orthonormal filling embedding `T` satisfies `Tᴴ T = 1`
+(`tJFillingEmbedding_conjTranspose_mul_self`),
 so it is an isometry: `⟨T c, T c⟩ = ⟨c, c⟩`.  Consequently the operator Rayleigh quotient of `Ĥ_tJ`
 on a lifted filling vector equals the matrix Rayleigh quotient of the compression `Ĥ_W`:
 `rayleighOnVec Ĥ_tJ (tJFillingExpansion c) = rayleighOnVec (tJFillingCompress Ĥ_tJ) c`

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingSpinZDiag.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingSpinZDiag.lean
@@ -4,7 +4,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorSpin
 /-!
 # Tasaki 11.5: `Ŝ³` is diagonal on filling expansions; odd `Ne` has no `Ŝ³ = 0` state (Prop 11.24)
 
-`Ŝ³_tot` acts diagonally on the filling basis: on `tJFillingExpansion Φ` it scales each coefficient by
+`Ŝ³_tot` acts diagonally on the filling basis: on `tJFillingExpansion Φ` it scales each coefficient
+by
 `½(#↑ − #↓)` (`fermionTotalSpinZ_mulVec_tJFillingExpansion`).  For **odd** `Ne` every filling
 site-state has `#↑ ≠ #↓` (since `#↑ + #↓ = Ne` is odd), so the scale is nonzero — hence the only
 `Ŝ³ = 0` filling state is the zero vector (`tJFillingExpansion_eq_zero_of_spinZ_mulVec_eq_zero`).

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergy.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergy.lean
@@ -8,7 +8,8 @@ hard-core variational problem (it is a no-double-occupancy `N̂ = Ne` eigenvecto
 energy `μ` (the lowest sector-matrix eigenvalue) bounds the ground energy from above:
 `groundEnergyAtFilling Ĥ_tJ Ne ≤ μ` (`tJHamiltonian_groundEnergyAtFilling_le_of_sectorEigen`).
 
-This is the easy half of the E2 ground-energy identification `groundEnergyAtFilling = μ`; the reverse
+This is the easy half of the E2 ground-energy identification `groundEnergyAtFilling = μ`; the
+reverse
 `μ ≤ groundEnergyAtFilling` (the global minimum sits in the `Ŝ³ = ½` block, via A.17 and odd `Ne`)
 follows next.  Together they make the lifted PF eigenvector a genuine ground state.
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergyGe.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergyGe.lean
@@ -82,7 +82,8 @@ theorem tJ_perronFrobeniusMin_le_hermitianMinEigenvalue (hpos : 0 < N) (Ne : ℕ
 
 /-- **`μ ≤ groundEnergyAtFilling`.** Every admissible `(N̂=Ne, hard-core)` unit state has energy at
 least `hermitianMinEigenvalue Ĥ_W ≥ μ`: its energy equals the matrix Rayleigh quotient of its
-coefficient vector (Rayleigh bridge + isometry), bounded below by `hermitianMinEigenvalue Ĥ_W` by the
+coefficient vector (Rayleigh bridge + isometry), bounded below by `hermitianMinEigenvalue Ĥ_W` by
+the
 variational principle, and `μ ≤ hermitianMinEigenvalue Ĥ_W`. -/
 theorem tJ_groundEnergyAtFilling_ge_of_sectorMin (hpos : 0 < N) (Ne : ℕ) (hNeLt : Ne < N + 1)
     (hodd : Odd Ne) (τ J : ℝ) (hτ : 0 ≤ τ) (hJ : 0 ≤ J) {μ : ℝ}
@@ -129,14 +130,15 @@ theorem tJ_groundEnergyAtFilling_ge_of_sectorMin (hpos : 0 < N) (Ne : ℕ) (hNeL
           (φ : EuclideanSpace ℂ _).ofLp := by
         rw [rayleighOnVec_tJFillingCompress, ← hcompl]
 
+set_option maxHeartbeats 1000000 in
 -- Raised heartbeat budget: this E2 capstone chains several heavy facts (the lifted
 -- PF eigenvector admissibility and the W-restricted A.17 lower bound) whose combined
 -- elaboration exceeds the default limit.
-set_option maxHeartbeats 1000000 in
 /-- **E2 capstone: `groundEnergyAtFilling = μ`.** The ground energy of the d=1 ferromagnetic t-J
 model at odd filling `Ne` equals the Perron–Frobenius sector minimum `μ`: `≤` from the lifted PF
 eigenvector being admissible (`tJHamiltonian_groundEnergyAtFilling_le_of_sectorEigen`), `≥` from the
-W-restricted A.17 (`tJ_groundEnergyAtFilling_ge_of_sectorMin`).  Packaged with the PF eigenvector `v`
+W-restricted A.17 (`tJ_groundEnergyAtFilling_ge_of_sectorMin`).  Packaged with the PF eigenvector
+`v`
 (strictly positive) at `μ`, the unique positive spin-charge-separated ground state. -/
 theorem tJHamiltonian_groundEnergyAtFilling_eq_perronFrobeniusMin (hpos : 0 < N) (Ne : ℕ)
     (hNeLt : Ne < N + 1) (hodd : Odd Ne) (τ J : ℝ) (hτ : 0 < τ) (hJ : 0 < J) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergyReverse.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergyReverse.lean
@@ -4,7 +4,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJGroundEnergy
 # Tasaki 11.5: spin-½ `W`-eigenvalues are sector-matrix eigenvalues (Prop 11.24 PR-E2, `≥` crux)
 
 The crux bridge for the reverse ground-energy bound `μ ≤ groundEnergyAtFilling`: a `Ŝ³ = ½`,
-`N̂ = Ne`, hard-core (`W`) eigenvector of `Ĥ_tJ` at a real eigenvalue `E` produces a nonzero **real**
+`N̂ = Ne`, hard-core (`W`) eigenvector of `Ĥ_tJ` at a real eigenvalue `E` produces a nonzero
+**real**
 eigenvector of the sector matrix `tJEffReMatrixOnSector` at `E`
 (`tJ_spinHalf_W_eigenvector_to_sector`).  Combined with the Perron–Frobenius minimality, this gives
 `μ ≤ E` for every such `E` (`tJ_perronFrobenius_min_le_of_spinHalf_W_eigenvalue`).

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundSpinHalfFinrank.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundSpinHalfFinrank.lean
@@ -7,7 +7,8 @@ import LatticeSystem.Quantum.SpinS.RealComplexEigenspaceBridge
 `finrank ℂ (groundSubmoduleAtFilling Ĥ_tJ Ne ⊓ (Ŝ³ = ½)) ≤ 1`: the ground states in the `Ŝ³ = ½`
 sector form a space of dimension at most one.  A ground state in that block is sector-supported, so
 its coefficient vector is a complex eigenvector of the sector matrix at the ground energy
-`μ = groundEnergyAtFilling`; the map `Φ ↦ tJExpansionCoeff Φ` is an injective `ℂ`-linear embedding of
+`μ = groundEnergyAtFilling`; the map `Φ ↦ tJExpansionCoeff Φ` is an injective `ℂ`-linear embedding
+of
 the block into that eigenspace, whose dimension is `≤ 1` by Perron–Frobenius
 (`matrix_complex_eigenspace_finrank_le_one_of_real`).
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHalfFillingBondAction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHalfFillingBondAction.lean
@@ -4,7 +4,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJExchangeBondSum
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJStepRelation
 
 /-!
-# Tasaki 11.5.3: the exchange bond acts as a half spin-swap on the filled sector (Theorem 11.26 PR3i)
+# Tasaki 11.5.3: the exchange bond acts as a half spin-swap on the filled sector (Theorem 11.26
+PR3i)
 
 On a fully occupied hard-core configuration `|Φ_s⟩` (`∀ k, s k ≠ 0`) the per-bond exchange operator
 `¼ n̂_x n̂_y − Ŝ_x·Ŝ_y` of `tJExchange` acts as a half difference between `|Φ_s⟩` and the
@@ -84,7 +85,8 @@ theorem fermionSpinPlusMinus_mulVec_tJConfigOf_eq_zero_of_target (N : ℕ)
   · exact fermionSpinPlusMinus_mulVec_tJConfigOf_eq_zero_of_source N s i j hj
 
 /-- **The reversed ladder `Ŝ⁻_x Ŝ⁺_y` as a sign-free swap.**  For an antiparallel pair `s x = ↑`,
-`s y = ↓` (`x ≠ y`), `Ŝ⁻_x Ŝ⁺_y |Φ_s⟩ = |Φ_{tJSpinSwap s x y}⟩` (commute to `Ŝ⁺_y Ŝ⁻_x` at `(y,x)`). -/
+`s y = ↓` (`x ≠ y`), `Ŝ⁻_x Ŝ⁺_y |Φ_s⟩ = |Φ_{tJSpinSwap s x y}⟩` (commute to `Ŝ⁺_y Ŝ⁻_x` at
+`(y,x)`). -/
 theorem fermionSpinMinusPlus_mulVec_tJConfigOf (N : ℕ) (s : Fin (N + 1) → Fin 3) (x y : Fin (N + 1))
     (hxy : x ≠ y) (hx : s x = 1) (hy : s y = 2) :
     (fermionSiteSpinMinus N x * fermionSiteSpinPlus N y).mulVec (basisVec (tJConfigOf N s)) =

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHalfFillingBondGround.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHalfFillingBondGround.lean
@@ -6,7 +6,8 @@ import Mathlib.LinearAlgebra.Matrix.PosDef
 # Tasaki 11.5.3: a half-filling ground state is annihilated by every bond (Theorem 11.26 PR3i-2)
 
 A ground state `v` of the half-filling t-J model is annihilated by `tJExchange` (the ground energy
-is `0` and `Ĥ_tJ = J·tJExchange` on the filling sector), and `tJExchange = Σ_{⟨x,y⟩} bond_xy` is a sum
+is `0` and `Ĥ_tJ = J·tJExchange` on the filling sector), and `tJExchange = Σ_{⟨x,y⟩} bond_xy` is a
+sum
 of positive-semidefinite singlet projectors `bond_xy = ½ Δ_xy† Δ_xy`.  Hence `⟨v, tJExchange v⟩ = 0`
 forces `⟨v, bond_xy v⟩ = 0` on every bond, so `Δ_xy v = 0` and `bond_xy v = 0`:
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHalfFillingUpCount.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHalfFillingUpCount.lean
@@ -5,7 +5,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSwapReachable
 # Tasaki 11.5.3: half-filling ground amplitudes depend only on the up-count (Theorem 11.26 PR3i-3b)
 
 The per-bond spin-swap invariance (`tJ_ground_amplitude_swap_invariant`, PR3i-3a) propagates
-along the connected chain: any two half-filling configs with the same number of up-spins are connected
+along the connected chain: any two half-filling configs with the same number of up-spins are
+connected
 by adjacent value-swaps (`adjacentSwapReachable_of_same_counts`, from the Prop 11.24 route), each of
 which is an adjacent bond swap.  Hence:
 
@@ -80,7 +81,8 @@ theorem tJ_ground_amplitude_eq_of_reachable (τ J : ℝ) (hJ : 0 < J)
     exact ih.trans (tJ_ground_amplitude_eq_of_adjacentSwapStep τ J hJ hv hbfull hst)
 
 /-- **Adjacent-swap reachability from equal value-counts, for all `N`.**  The `N = 0` case (a single
-site) is degenerate: equal value-counts force the configs to be equal, so reachability is reflexive. -/
+site) is degenerate: equal value-counts force the configs to be equal, so reachability is
+reflexive. -/
 theorem adjacentSwapReachable_of_same_counts_general (s s' : Fin (N + 1) → Fin 3)
     (hcount : ∀ v, (Finset.univ.filter (fun k => s k = v)).card
         = (Finset.univ.filter (fun k => s' k = v)).card) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticMatrixElement.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticMatrixElement.lean
@@ -5,7 +5,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopWrap
 
 The per-term hopping matrix element `⟨Φ_{s'} | ĉ†_{bσ}ĉ_{aσ} | Φ_s⟩` for a *forward* allowed
 nearest-neighbour or wrap hop equals `1` exactly when `s'` is the hopped site-state
-`tJSiteHop s a b`, and `0` otherwise.  This combines the sign-free hop actions (`tJ_uphop_nn_mulVec`,
+`tJSiteHop s a b`, and `0` otherwise.  This combines the sign-free hop actions
+(`tJ_uphop_nn_mulVec`,
 the wrap variants) with the orthonormality of the sector basis (`tJConfigOf_basisVec_inner`); it is
 the off-diagonal `−τ` kinetic entry of the t-J effective matrix.
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticNonneg.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticNonneg.lean
@@ -3,7 +3,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorBasis
 /-!
 # Tasaki 11.5: the general single-hop matrix element on the sector basis (Prop 11.24 PR-B7-3d)
 
-The per-term hopping matrix element `⟨Φ_{s'} | ĉ†_{iσ}ĉ_{jσ} | Φ_s⟩` for *arbitrary* sites `i, j` and
+The per-term hopping matrix element `⟨Φ_{s'} | ĉ†_{iσ}ĉ_{jσ} | Φ_s⟩` for *arbitrary* sites `i, j`
+and
 spin `σ`, before any adjacency or allowed-hop assumption.  Reading off the single-hop action
 (`fermionMultiCreation_mul_Annihilation_mulVec_basisVec`) at the bra configuration `tJConfigOf s'`,
 the element vanishes unless the source orbital `(j,σ)` is occupied and the target orbital `(i,σ)` is
@@ -23,7 +24,8 @@ open scoped BigOperators
 variable {N : ℕ}
 
 /-- **General single-hop matrix element.**  `⟨Φ_{s'} | ĉ†_{iσ}ĉ_{jσ} | Φ_s⟩` equals, when the source
-`(j,σ)` is occupied and the target `(i,σ)` is empty after removing the source, the product of the two
+`(j,σ)` is occupied and the target `(i,σ)` is empty after removing the source, the product of the
+two
 string signs times `[tJConfigOf s' = hopped config]`, and `0` otherwise. -/
 theorem tJ_hop_matrixElement_apply (N : ℕ) (s s' : Fin (N + 1) → Fin 3) (i j : Fin (N + 1))
     (σ : Fin 2) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSector.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSector.lean
@@ -6,7 +6,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorBasis
 
 The kinetic part of the t-J Hamiltonian is the graph hopping sandwiched by the hard-core projection,
 `P̂hc · K · P̂hc`.  On a hard-core sector basis state `|Φ_s⟩ = basisVec (tJConfigOf s)` the *inner*
-projection acts as the identity (`tJConfigOf` is hard-core), so the sandwich reduces to the projected
+projection acts as the identity (`tJConfigOf` is hard-core), so the sandwich reduces to the
+projected
 hopping `P̂hc (K |Φ_s⟩)`, which still lands in the hard-core subspace.  This isolates the hopping
 matrix elements (computed sign-free in the hop lemmas) from the projection bookkeeping.
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSummand.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSummand.lean
@@ -7,11 +7,14 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopBackwardWrap
 # Tasaki 11.5: each cyclic kinetic summand is `0` or `1` (Prop 11.24 PR-B7-3f)
 
 The off-diagonal kinetic matrix element expands over spins and ordered site pairs as
-`⟨Φ_{s'}|K|Φ_s⟩ = Σ_σ Σ_i Σ_j couplingOf(cycleGraph) i j · ⟨Φ_{s'}|ĉ†_{iσ}ĉ_{jσ}|Φ_s⟩`.  Each summand
+`⟨Φ_{s'}|K|Φ_s⟩ = Σ_σ Σ_i Σ_j couplingOf(cycleGraph) i j · ⟨Φ_{s'}|ĉ†_{iσ}ĉ_{jσ}|Φ_s⟩`.  Each
+summand
 is either `0` or `1`: non-adjacent pairs are killed by the graph coupling; for an adjacent pair the
-single-hop element vanishes unless the source carries spin `σ` and the target site is empty, in which
+single-hop element vanishes unless the source carries spin `σ` and the target site is empty, in
+which
 case the directional (rightward / leftward nearest-neighbour, or wrap) hop matrix element gives the
-sign-free indicator `[s' = tJSiteHop …] ∈ {0,1}`.  Hence the kinetic matrix element is a non-negative
+sign-free indicator `[s' = tJSiteHop …] ∈ {0,1}`.  Hence the kinetic matrix element is a
+non-negative
 real, the input to the Perron–Frobenius step.
 
 Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*
@@ -142,7 +145,8 @@ theorem tJ_kinetic_summand_zero_or_one (N : ℕ) (hpos : 0 < N) (s s' : Fin (N +
 
 /-- **The cyclic kinetic matrix element is a non-negative real.**  `⟨Φ_{s'}|K|Φ_s⟩ ≥ 0` (real part
 non-negative, imaginary part zero), since it is the sum of `{0,1}`-valued summands.  Hence the
-kinetic off-diagonal entry `−τ·⟨Φ_{s'}|K|Φ_s⟩ ≤ 0` for `τ ≥ 0`, feeding the Perron–Frobenius step. -/
+kinetic off-diagonal entry `−τ·⟨Φ_{s'}|K|Φ_s⟩ ≤ 0` for `τ ≥ 0`, feeding the Perron–Frobenius step.
+-/
 theorem tJKinetic_matrixElement_nonneg (N : ℕ) (hpos : 0 < N) (s s' : Fin (N + 1) → Fin 3)
     (Ne : ℕ) (hNe : (Finset.univ.filter (fun k => s k = 1)).card
         + (Finset.univ.filter (fun k => s k = 2)).card = Ne) (hodd : Odd Ne) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJMaximalSpinUnified.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJMaximalSpinUnified.lean
@@ -23,7 +23,8 @@ namespace LatticeSystem.Fermion
 open LatticeSystem.Quantum LatticeSystem.Lattice SimpleGraph
 
 /-- **The d=1 ferromagnetic t-J ground subspace is the maximal-spin multiplet for all `Ne ≤ K+1`.**
-For odd `Ne ≤ K+1` and `τ, J > 0`, the ground subspace of `tJHamiltonian K (cycleGraph (K+1)) τ J` at
+For odd `Ne ≤ K+1` and `τ, J > 0`, the ground subspace of `tJHamiltonian K (cycleGraph (K+1)) τ J`
+at
 filling `Ne` is `IsMaximalSpinMultipletSubmodule K · Ne` — the metallic case `Ne < K+1`
 (`proposition_11_24`) and the half-filling case `Ne = K+1` (`tJ_halfFilling_isMaximalSpinMultiplet`)
 combined. -/

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJOffDiagonal.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJOffDiagonal.lean
@@ -21,7 +21,8 @@ open Matrix LatticeSystem.Quantum
 variable {N : ℕ}
 
 /-- **The hard-core projection drops on a sector configuration.**  Evaluating `P̂hc u` at the
-hard-core config `tJConfigOf s'` returns `u` there: the row of `P̂hc` at a hard-core configuration is
+hard-core config `tJConfigOf s'` returns `u` there: the row of `P̂hc` at a hard-core configuration
+is
 the unit vector. -/
 theorem tJ_hardcore_proj_apply (N : ℕ) (s' : Fin (N + 1) → Fin 3)
     (u : (Fin (2 * N + 2) → Fin 2) → ℂ) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopAction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopAction.lean
@@ -9,7 +9,8 @@ Composing the operator-level single-hop action (`HopBasisVec.lean`), the config 
 computes the action of a single same-spin hopping term `ĉ†_{bσ}ĉ_{aσ}` on a t-J sector basis state
 for a *forward* allowed hop (`a.val < b.val`, source occupied with spin σ, target empty):
 
-  `ĉ†_{bσ}ĉ_{aσ} |Φ_s⟩ = (-1)^(#occupied modes strictly between (a,σ) and (b,σ)) · |Φ_{tJSiteHop s a b}⟩`.
+  `ĉ†_{bσ}ĉ_{aσ} |Φ_s⟩ = (-1)^(#occupied modes strictly between (a,σ) and (b,σ)) · |Φ_{tJSiteHop s
+  a b}⟩`.
 
 The sign is `(-1)` to the occupied modes strictly between source and target in Jordan–Wigner order;
 for the d=1 cycle's nearest-neighbour hops this exponent is `0` (the single intervening orbital is

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackward.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackward.lean
@@ -5,7 +5,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopNN
 
 The cyclic kinetic operator `K = Σ_σ Σ_i Σ_j (adj i j) ĉ†_{iσ}ĉ_{jσ}` contains, for each oriented
 adjacent pair, both the *rightward* hop `ĉ†_{(a+1)σ}ĉ_{aσ}` (`tJ_uphop_nn_mulVec` etc.) and the
-*leftward* hop `ĉ†_{aσ}ĉ_{(a+1)σ}`.  This file computes the leftward nearest-neighbour hop action and
+*leftward* hop `ĉ†_{aσ}ĉ_{(a+1)σ}`.  This file computes the leftward nearest-neighbour hop action
+and
 matrix element, which are again **sign-free** (`+1`): the single intervening Jordan–Wigner mode is
 empty, so the backward sign parity (`jwSign_mul_jwSign_update_backward`) collapses to `0`.
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackwardWrap.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackwardWrap.lean
@@ -5,7 +5,8 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopBackward
 # Tasaki 11.5: the leftward wrap hop is sign-free for odd `Ne` (Prop 11.24 PR-B7-3c)
 
 The cycle's wrap bond `{0, N}` also carries the *leftward* hop `ĉ†_{0σ}ĉ_{Nσ}` (the electron hops
-from the last site `N` to the first site `0`).  Like the rightward wrap hop, it is sign-free `+1` for
+from the last site `N` to the first site `0`).  Like the rightward wrap hop, it is sign-free `+1`
+for
 **odd** `Ne`: the strictly-between Jordan–Wigner occupation is `Ne − 1` (the empty target `0`
 contributes nothing below, the occupied source `N` contributes one above), so the backward sign
 parity collapses to `(-1)^(Ne-1) = +1`.

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiFlatBandClassification.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiFlatBandClassification.lean
@@ -201,8 +201,10 @@ theorem flatBand_groundSubmodule_eq_multipletSpan_of_blocks (K : ℕ) (ν t U : 
 /-- **Tasaki Theorem 11.11 (flat-band ferromagnetism, half-filled ground space) — axiom-free.**
 The zero-energy `N_e = K+1` ground subspace of the flat-band Hubbard model is *exactly* the
 ferromagnetic lowering multiplet of `|Φα,all↑⟩` (the maximal-spin `(2 S_max + 1)`-dimensional
-multiplet).  `⊇` is the existence side; `⊆` is the classification, discharged here: every `Ŝ^z`-weight
-block is one-dimensional (`flatBand_block_finrank_le_one`, the swap-invariant coordinate argument), so
+multiplet).  `⊇` is the existence side; `⊆` is the classification, discharged here: every
+`Ŝ^z`-weight
+block is one-dimensional (`flatBand_block_finrank_le_one`, the swap-invariant coordinate argument),
+so
 the ground subspace has dimension `≤ K+2 = dim` of the multiplet. -/
 theorem flatBand_theorem_11_11_groundSubmodule_eq_multipletSpan (K : ℕ) (ν t U : ℝ)
     (hν : 0 < ν) (ht : 0 < t) (hU : 0 < U) :

--- a/LatticeSystem/Math/DoubleSequenceDiagonal.lean
+++ b/LatticeSystem/Math/DoubleSequenceDiagonal.lean
@@ -6,7 +6,8 @@ import Mathlib.Order.Filter.AtTopBot.Basic
 # Diagonal extraction from an iterated limit (Tasaki Lemma 4.16)
 
 A double sequence `f : ℕ → ℕ → ℝ` (`f L m`) whose iterated limit vanishes,
-`lim_{m→∞} lim_{L→∞} f L m = 0`, admits a *diagonal* slow-diverging index `m(L)` along which it still
+`lim_{m→∞} lim_{L→∞} f L m = 0`, admits a *diagonal* slow-diverging index `m(L)` along which it
+still
 vanishes: there is a nondecreasing `m : ℕ → ℕ` with `m(L) → ∞` and `lim_{L→∞} f L (m L) = 0`.
 
 This is the elementary real-analysis lemma Tasaki uses to choose the slowly diverging tower size
@@ -15,7 +16,8 @@ It is purely analytic — no operators or physics — so we **discharge it axiom
 
 Construction (Tasaki's proof): with `g m = lim_L f L m → 0` and `ε m = 1/(m+1)`, pick a strictly
 increasing threshold `T m` with `T m ≥ N m` (where `|f L m − g m| < ε m` for `L ≥ N m`); set
-`m(L) = `the largest `k ≤ L` with `T k ≤ L` (`Nat.findGreatest`).  Then `m` is monotone, diverges, and
+`m(L) = `the largest `k ≤ L` with `T k ≤ L` (`Nat.findGreatest`).  Then `m` is monotone, diverges,
+and
 `|f L (m L)| ≤ |f L (m L) − g (m L)| + |g (m L)| → 0`.
 
 Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems* (1st ed., Springer,

--- a/LatticeSystem/Math/ReflectionPositivityAveraging.lean
+++ b/LatticeSystem/Math/ReflectionPositivityAveraging.lean
@@ -14,13 +14,15 @@ range over an arbitrary type `V`).
 If `F` is invariant under the cyclic shift (cyclicity, eq. (4.1.55)) and satisfies the *reflection
 bound* (eq. (4.1.56))
 `F(f) ≥ ½ (F(reflect_left f) + F(reflect_right f))`,
-where `reflect_left f` mirrors the second half onto the first and `reflect_right f` mirrors the first
+where `reflect_left f` mirrors the second half onto the first and `reflect_right f` mirrors the
+first
 half onto the second, then `F` is bounded below by the average of its values on the `2n` constant
 strings (eq. (4.1.57)):
 `F(f) ≥ (1 / 2n) Σ_j F(j ↦ f j)`.
 
 Tasaki's proof is the elegant "`G_min = 0`" argument: subtract the constant-string average, restrict
-to the finite set of strings built from the entries of `f`, and show the minimum is `0` by collapsing
+to the finite set of strings built from the entries of `f`, and show the minimum is `0` by
+collapsing
 a minimizer to a constant string via repeated use of the reflection bound and cyclicity.  The proof
 is elementary but intricate (a doubling induction on the number of leading equal entries); we record
 the lemma as a documented axiom and mark it a **finite-dimensional discharge candidate**.
@@ -52,7 +54,8 @@ def reflectRight {V : Type*} (n : ℕ) (f : Fin (2 * n) → V) : Fin (2 * n) →
 `F : (Fin (2n) → V) → ℝ` be a real-valued function of a cyclic string of `2n` arguments in an
 arbitrary type `V`.  Assume `F` is invariant under the cyclic shift (`hcyc`, eq. (4.1.55)) and
 satisfies the reflection bound (`hrefl`, eq. (4.1.56)):
-`F f ≥ ½ (F (reflectLeft n f) + F (reflectRight n f))` for all `f`.  Then `F` is bounded below by the
+`F f ≥ ½ (F (reflectLeft n f) + F (reflectRight n f))` for all `f`.  Then `F` is bounded below by
+the
 average of its values on the `2n` constant strings (eq. (4.1.57)):
 `F f ≥ (1 / 2n) Σ_j F (fun _ => f j)`.
 

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedGSSetClosed.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedGSSetClosed.lean
@@ -7,7 +7,8 @@ import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergParametricMinEigenvalue
 Issue #3739 — Tasaki §2.5 Theorem 2.4 obligation (2) first-crossing argument.
 
 Defines the set
-`balancedGSSet J hJ N M_balanced lam' D' := { t : ℝ | hermitianMinEigenvalue (Ĥ_M_balanced(γ(t))) = hermitianMinEigenvalue (Ĥ(γ(t))) }`
+`balancedGSSet J hJ N M_balanced lam' D' := { t : ℝ | hermitianMinEigenvalue (Ĥ_M_balanced(γ(t))) =
+hermitianMinEigenvalue (Ĥ(γ(t))) }`
 and proves it is closed in `ℝ`.
 
 This is a building block for the first-crossing argument: `t* := sSup balancedGSSet`

--- a/LatticeSystem/Quantum/SpinS/AxisSwapBondReStrictPos.lean
+++ b/LatticeSystem/Quantum/SpinS/AxisSwapBondReStrictPos.lean
@@ -6,7 +6,8 @@ set_option linter.unusedSimpArgs false
 set_option linter.unusedVariables false
 
 /-!
-# Strict positivity of the axis-swapped bond off-diagonal entry on a transverse step (case (i) strict)
+# Strict positivity of the axis-swapped bond off-diagonal entry on a transverse step (case (i)
+strict)
 
 Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
 

--- a/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
@@ -7,7 +7,8 @@ set_option linter.unusedSimpArgs false
 set_option linter.unusedVariables false
 
 /-!
-# Structural (j.13.h.3) bare submatrix `finrank ≤ 1` at `hermitianMinEigenvalue` (no `h_intermediate`)
+# Structural (j.13.h.3) bare submatrix `finrank ≤ 1` at `hermitianMinEigenvalue` (no
+`h_intermediate`)
 
 Issue #3887 (Tasaki §2.5 Theorem 2.4, `h_intermediate` vacuous-at-N=1 fix).
 

--- a/LatticeSystem/Quantum/SpinS/FerrimagneticLRO.lean
+++ b/LatticeSystem/Quantum/SpinS/FerrimagneticLRO.lean
@@ -17,7 +17,8 @@ with `a > 0` (e.g. the Lieb lattice, `a = 1/3`), eq. (4.1.13) gives
 Unlike the existence theorems 4.1–4.3, Theorem 4.4 has a complete *finite-volume* proof in Tasaki
 (the chain (4.1.16): the cross-term positivity (4.1.15) from Problem 2.5.d, the Lieb–Mattis total
 spin `S_tot = (|A| − |B|) S` from Theorem 2.3, and `⟨(Ŝ_tot)²⟩ = S_tot(S_tot + 1) ≥ S_tot²`).  It is
-therefore a **discharge candidate**; here we record it as a faithful, sound documented axiom over the
+therefore a **discharge candidate**; here we record it as a faithful, sound documented axiom over
+the
 concrete connected bipartite antiferromagnetic family (same hypotheses as Theorem 2.3), to be
 discharged once the §2.5 Theorem 2.3 total-spin API and the (4.1.15) cross-term inequality are
 assembled.

--- a/LatticeSystem/Quantum/SpinS/InvolutionEigenspaceDecompEq.lean
+++ b/LatticeSystem/Quantum/SpinS/InvolutionEigenspaceDecompEq.lean
@@ -50,7 +50,8 @@ private theorem eigenspace_one_inf_neg_one_eq_bot
 /-- **Eigenspace finrank EQUALITY under a commuting involution** (strengthens #3776 from `≤` to `=`):
 for finite-dimensional `T, P` with `T ∘ P = P ∘ T` and `P ∘ P = id`, every `T`-eigenspace
 **splits as a direct sum** across the two `P`-eigenspaces `±1`, giving
-`finrank (eigenspace T μ) = finrank (eigenspace T μ ⊓ eigenspace P 1) + finrank (eigenspace T μ ⊓ eigenspace P (−1))`. -/
+`finrank (eigenspace T μ) = finrank (eigenspace T μ ⊓ eigenspace P 1) + finrank (eigenspace T μ ⊓
+eigenspace P (−1))`. -/
 theorem eigenspace_finrank_eq_of_commuting_involution
     {V : Type*} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
     (T P : V →ₗ[ℂ] V) (hcomm : T ∘ₗ P = P ∘ₗ T) (hP : P ∘ₗ P = LinearMap.id) (μ : ℂ) :

--- a/LatticeSystem/Quantum/SpinS/MultiSiteDotOffDiag.lean
+++ b/LatticeSystem/Quantum/SpinS/MultiSiteDotOffDiag.lean
@@ -69,7 +69,8 @@ theorem spinSDot_apply_re_nonneg_of_raising_lowering_x
       Matrix.diagonal_apply_ne _ hσ'x]
     ring
   rw [h3eq]
-  simp only [one_div, Complex.zero_re, add_zero, inv_pos, Nat.ofNat_pos, mul_nonneg_iff_of_pos_left, ge_iff_le]
+  simp only [one_div, Complex.zero_re, add_zero, inv_pos, Nat.ofNat_pos,
+    mul_nonneg_iff_of_pos_left, ge_iff_le]
   positivity
 
 /-- For `x ≠ y` and configurations `σ', σ` agreeing off `{x, y}` with
@@ -203,7 +204,8 @@ theorem spinSDot_apply_re_nonneg_of_raising_lowering_y
       Matrix.diagonal_apply_ne _ hσ'x]
     ring
   rw [h3eq]
-  simp only [one_div, Complex.zero_re, add_zero, inv_pos, Nat.ofNat_pos, mul_nonneg_iff_of_pos_left, ge_iff_le]
+  simp only [one_div, Complex.zero_re, add_zero, inv_pos, Nat.ofNat_pos,
+    mul_nonneg_iff_of_pos_left, ge_iff_le]
   positivity
 
 

--- a/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
@@ -28,7 +28,8 @@ open Module Matrix
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-- **Parity-block Perron eigenspace `finrank ≤ 1`**: under case (i.2) strict (plus the
-intermediate-site and sublattice non-emptyness hypotheses needed by `parityReachableS_total_legacy`),
+intermediate-site and sublattice non-emptyness hypotheses needed by
+`parityReachableS_total_legacy`),
 the Perron eigenspace of the shifted parity-block PF matrix is at most one-dimensional. -/
 theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_perron_eigenspace_finrank_le_one
     (A : Λ → Bool) {J : Λ → Λ → ℂ}

--- a/LatticeSystem/Quantum/SpinS/ParityReachToMinMagSum.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachToMinMagSum.lean
@@ -10,7 +10,8 @@ every configuration reaches some `σ_min` with `magSumS σ_min < 2` — i.e. eit
 config (for even parity) or a single-1-site config (for odd parity).
 
 Combined with the within-sector reachability lift (#3817) and `ParityReachableS` symmetry
-(#3816), this is the penultimate step before the full `parityReachableS_total_legacy` discharging the
+(#3816), this is the penultimate step before the full `parityReachableS_total_legacy` discharging
+the
 parity-block matrix irreducibility theorem (#3797).
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, Springer 2020,

--- a/LatticeSystem/Quantum/SpinS/ParityReachTotal.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachTotal.lean
@@ -8,7 +8,8 @@ import LatticeSystem.Quantum.SpinS.ParityReachableMagSum
 
 Issue #3739 (Tasaki §2.5 Theorem 2.4, Mattis–Nishimori).
 
-`parityReachableS_total_legacy`: for any two configurations sharing the same total-magnetization parity
+`parityReachableS_total_legacy`: for any two configurations sharing the same total-magnetization
+parity
 (`magSumS σ ≡ magSumS σ' (mod 2)`), `ParityReachableS` connects them.
 
 This closes the (d.3) reachability totality plan by chaining:

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
@@ -16,7 +16,8 @@ coupling — truly unconditional (no `h_intermediate`)
 non-negative bipartite couplings positive on the complete bipartite graph.
 
 Combines Step 3 (common ground-state energy) + Step 2 of PR #3891 (structural sector
-existence) + already-`h_intermediate`-free `tasaki23_general_hOutside` / `tasaki23_eigenvalue_ge_common`
+existence) + already-`h_intermediate`-free `tasaki23_general_hOutside` /
+`tasaki23_eigenvalue_ge_common`
 to close `tasaki_2_5_theorem_2_3 A N J c` for general bipartite J at any N ≥ 1.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,


### PR DESCRIPTION
Tracked in #4569.

## Summary

- **maxHeartbeat**: move the explanatory comment to the trailing position the
  `linter.style.maxHeartbeats` linter requires (after `set_option … in`, before
  the declaration). The PR1 placement before `set_option` did not satisfy it —
  only visible under `lake build`, not `lake env lean`.
- **2 `simp only [...]`** argument lists wrapped across two lines
  (MultiSiteDotOffDiag, the sets introduced in PR4).
- **42 doc-comment prose** long-lines wrapped at word boundaries (block-comment
  content only; code long-lines deferred).

## Build-speed evaluation

Comment/formatting only; no code, import-DAG, or elaboration-time change. Full
rebuild clean, 0 errors. Long-line warnings 114 → 70; total 257 → 212.

## Note

The mathlib **style** linters (long-line, maxHeartbeat, extra-space) are NOT run
by `lake env lean` (they need the lakefile `mathlibStandardSet` option, applied
only by `lake build`). Verify these categories with `lake build`.

Remaining: 70 code long-lines, 83 unused-hypothesis, 57 deprecated `_legacy`.