### PR TITLE
Refactor PR7: wrap the remaining 70 code long-lines (long-line cleared) — #4569

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/GeneralFlatBandEigenbasis.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/GeneralFlatBandEigenbasis.lean
@@ -23,7 +23,8 @@ variable {M : ℕ}
 
 /-- The orthonormal eigenbasis of a Hermitian `T`, transported from `EuclideanSpace ℂ (Fin (M+1))`
 to a `Module.Basis` of the plain coordinate space `Fin (M+1) → ℂ`. -/
-noncomputable def eigenbasisAsBasis {T : Matrix (Fin (M + 1)) (Fin (M + 1)) ℂ} (hT : T.IsHermitian) :
+noncomputable def eigenbasisAsBasis {T : Matrix (Fin (M + 1)) (Fin (M + 1)) ℂ} (hT : T.IsHermitian)
+    :
     Module.Basis (Fin (M + 1)) ℂ (Fin (M + 1) → ℂ) :=
   hT.eigenvectorBasis.toBasis.map (WithLp.linearEquiv 2 ℂ (Fin (M + 1) → ℂ))
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJDiagonalMatrixElement.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJDiagonalMatrixElement.lean
@@ -47,7 +47,8 @@ theorem fermionSiteSpinZ_mulVec_basisVec (N : ℕ) (x : Fin (N + 1))
   rw [fermionMultiNumber_mulVec_basisVec, fermionMultiNumber_mulVec_basisVec, ← sub_smul,
     smul_smul]
 
-/-- A diagonal operator (acting as a scalar on `|Φ_s⟩`) has vanishing off-diagonal matrix element. -/
+/-- A diagonal operator (acting as a scalar on `|Φ_s⟩`) has vanishing off-diagonal matrix element.
+-/
 theorem diagonal_offdiag_matrixElement_eq_zero (N : ℕ) (s s' : Fin (N + 1) → Fin 3)
     (op : ManyBodyOp (Fin (2 * N + 2)))
     (hd : ∃ sc : ℂ, op.mulVec (basisVec (tJConfigOf N s)) = sc • basisVec (tJConfigOf N s))

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingBasis.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingBasis.lean
@@ -41,7 +41,8 @@ noncomputable def tJFillingExpansionCoeff (N Ne : ℕ) (u : (Fin (2 * N + 2) →
     TJFillingSector N Ne → ℂ :=
   fun s => ∑ w, basisVec (tJConfigOf N s.val) w * u w
 
-/-- **Left inverse: the coefficient functional inverts the filling expansion.**  The filling basis is
+/-- **Left inverse: the coefficient functional inverts the filling expansion.**  The filling basis
+is
 orthonormal, so `tJFillingExpansionCoeff (Σ_s v_s |Φ_s⟩) = v`. -/
 theorem tJFillingExpansionCoeff_tJFillingExpansion (Ne : ℕ) (v : TJFillingSector N Ne → ℂ) :
     tJFillingExpansionCoeff N Ne (tJFillingExpansion N Ne v) = v := by

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingCompress.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingCompress.lean
@@ -24,7 +24,8 @@ open scoped BigOperators
 
 variable {N : ℕ}
 
-/-- The embedding of the filling space into the full Fock space: its column at the filling site-state
+/-- The embedding of the filling space into the full Fock space: its column at the filling
+site-state
 `s` is the computational basis vector `|Φ_s⟩ = basisVec (tJConfigOf s)`. -/
 noncomputable def tJFillingEmbedding (N Ne : ℕ) :
     Matrix (Fin (2 * N + 2) → Fin 2) (TJFillingSector N Ne) ℂ :=
@@ -55,7 +56,8 @@ theorem tJFillingEmbedding_mulVec (Ne : ℕ) (u : TJFillingSector N Ne → ℂ) 
   funext w
   unfold tJFillingEmbedding tJFillingExpansion
   rw [Matrix.mulVec, dotProduct, Finset.sum_apply]
-  exact Finset.sum_congr rfl (fun s _ => by rw [Matrix.of_apply, Pi.smul_apply, smul_eq_mul, mul_comm])
+  exact Finset.sum_congr rfl (fun s _ => by rw [Matrix.of_apply, Pi.smul_apply, smul_eq_mul,
+      mul_comm])
 
 /-- `Tᴴ` maps a Fock vector to its filling coefficient functional: `(Tᴴ v)_s = ⟨Φ_s, v⟩`. -/
 theorem tJFillingEmbedding_conjTranspose_mulVec (Ne : ℕ) (v : (Fin (2 * N + 2) → Fin 2) → ℂ) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingCompressSpinAlgebra.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingCompressSpinAlgebra.lean
@@ -74,7 +74,8 @@ theorem tJFillingCompress_su2_31 (Ne : ℕ) :
 theorem tJFillingCompress_tJHamiltonian_commute_one (Ne : ℕ) (G : SimpleGraph (Fin (N + 1)))
     [DecidableRel G.Adj] (τ J : ℝ) :
     tJFillingCompress N Ne (tJHamiltonian N G τ J) * tJFillingCompress N Ne (tJTotalSpinOne N) =
-      tJFillingCompress N Ne (tJTotalSpinOne N) * tJFillingCompress N Ne (tJHamiltonian N G τ J) := by
+      tJFillingCompress N Ne (tJTotalSpinOne N) * tJFillingCompress N Ne (tJHamiltonian N G τ J) :=
+          by
   rw [tJFillingCompress_mul_of_right_preserves Ne _ (preservesTJFillingW_tJTotalSpinOne Ne),
     tJHamiltonian_mul_tJTotalSpinOne,
     ← tJFillingCompress_mul_of_right_preserves Ne _ (preservesTJFillingW_tJHamiltonian Ne G τ J)]
@@ -83,7 +84,8 @@ theorem tJFillingCompress_tJHamiltonian_commute_one (Ne : ℕ) (G : SimpleGraph 
 theorem tJFillingCompress_tJHamiltonian_commute_two (Ne : ℕ) (G : SimpleGraph (Fin (N + 1)))
     [DecidableRel G.Adj] (τ J : ℝ) :
     tJFillingCompress N Ne (tJHamiltonian N G τ J) * tJFillingCompress N Ne (tJTotalSpinTwo N) =
-      tJFillingCompress N Ne (tJTotalSpinTwo N) * tJFillingCompress N Ne (tJHamiltonian N G τ J) := by
+      tJFillingCompress N Ne (tJTotalSpinTwo N) * tJFillingCompress N Ne (tJHamiltonian N G τ J) :=
+          by
   rw [tJFillingCompress_mul_of_right_preserves Ne _ (preservesTJFillingW_tJTotalSpinTwo Ne),
     tJHamiltonian_mul_tJTotalSpinTwo,
     ← tJFillingCompress_mul_of_right_preserves Ne _ (preservesTJFillingW_tJHamiltonian Ne G τ J)]

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergy.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergy.lean
@@ -62,7 +62,8 @@ theorem tJExpansion_ne_zero_of_ne_zero (Ne : ℕ) {v : TJSpinHalfFillingSector N
 /-- **Variational bound on the t-J ground energy (E2, `≤`).** A nonzero real sector eigenvector `c`
 of `tJEffReMatrixOnSector` at eigenvalue `μ` lifts to an admissible state whose energy is `μ`, so
 `groundEnergyAtFilling Ĥ_tJ Ne ≤ μ`. -/
-theorem tJHamiltonian_groundEnergyAtFilling_le_of_sectorEigen (hpos : 0 < N) (Ne : ℕ) (hodd : Odd Ne)
+theorem tJHamiltonian_groundEnergyAtFilling_le_of_sectorEigen (hpos : 0 < N) (Ne : ℕ) (hodd : Odd
+    Ne)
     (τ J : ℝ) (hτ : 0 ≤ τ) (hJ : 0 ≤ J) {c : TJSpinHalfFillingSector N Ne → ℝ} (hc : c ≠ 0) (μ : ℝ)
     (heig : (tJEffReMatrixOnSector N Ne (cycleGraph (N + 1)) τ J) *ᵥ c = μ • c) :
     groundEnergyAtFilling (tJHamiltonian N (cycleGraph (N + 1)) τ J) Ne ≤ μ := by

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergyGe.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJGroundEnergyGe.lean
@@ -101,7 +101,8 @@ theorem tJ_groundEnergyAtFilling_ge_of_sectorMin (hpos : 0 < N) (Ne : ℕ) (hNeL
     tJ_perronFrobeniusMin_le_hermitianMinEigenvalue hpos Ne hodd τ J hτ hJ hμmin
   -- the filling space `W` is nonempty as a set of unit states (a basis state)
   haveI : Nonempty (fillingHardcoreStates N Ne) := by
-    refine ⟨⟨(WithLp.equiv 2 _).symm (basisVec (tJConfigOf N (Classical.choice hNE).val)), ?_, ?_, ?_⟩⟩
+    refine ⟨⟨(WithLp.equiv 2 _).symm (basisVec (tJConfigOf N (Classical.choice hNE).val)), ?_, ?_,
+        ?_⟩⟩
     · rw [EuclideanSpace.norm_eq,
         show (∑ i, ‖((WithLp.equiv 2 ((Fin (2 * N + 2) → Fin 2) → ℂ)).symm
               (basisVec (tJConfigOf N (Classical.choice hNE).val))).ofLp i‖ ^ 2) = (1 : ℝ) from ?_]

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHalfFillingBondAction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJHalfFillingBondAction.lean
@@ -35,7 +35,8 @@ variable {N : ℕ}
 If `s j ≠ ↑` the lowering `Ŝ⁻_j = ĉ†_{j↓}ĉ_{j↑}` hits an empty up-orbital. -/
 theorem fermionSpinPlusMinus_mulVec_tJConfigOf_eq_zero_of_source (N : ℕ)
     (s : Fin (N + 1) → Fin 3) (i j : Fin (N + 1)) (hj : s j ≠ 1) :
-    (fermionSiteSpinPlus N i * fermionSiteSpinMinus N j).mulVec (basisVec (tJConfigOf N s)) = 0 := by
+    (fermionSiteSpinPlus N i * fermionSiteSpinMinus N j).mulVec (basisVec (tJConfigOf N s)) = 0 :=
+        by
   have hmin : (fermionSiteSpinMinus N j).mulVec (basisVec (tJConfigOf N s)) = 0 := by
     unfold fermionSiteSpinMinus fermionDownCreation fermionUpAnnihilation
     rw [← Matrix.mulVec_mulVec, fermionMultiAnnihilation_mulVec_basisVec,
@@ -49,7 +50,8 @@ For `i ≠ j` with `s i ≠ ↓`, the raising `Ŝ⁺_i = ĉ†_{i↑}ĉ_{i↓}` 
 (unchanged by the `j`-local lowering `Ŝ⁻_j`). -/
 theorem fermionSpinPlusMinus_mulVec_tJConfigOf_eq_zero_of_target (N : ℕ)
     (s : Fin (N + 1) → Fin 3) (i j : Fin (N + 1)) (hij : i ≠ j) (hi : s i ≠ 2) :
-    (fermionSiteSpinPlus N i * fermionSiteSpinMinus N j).mulVec (basisVec (tJConfigOf N s)) = 0 := by
+    (fermionSiteSpinPlus N i * fermionSiteSpinMinus N j).mulVec (basisVec (tJConfigOf N s)) = 0 :=
+        by
   by_cases hj : s j = 1
   · -- `Ŝ⁻_j |Φ_s⟩ = scalar • |c'⟩` with `c'` differing from `tJConfigOf s` only at `j`'s orbitals
     have hmin : (fermionSiteSpinMinus N j).mulVec (basisVec (tJConfigOf N s)) =
@@ -110,7 +112,8 @@ theorem tJSpinSwap_eq_self_of_eq (s : Fin (N + 1) → Fin 3) (x y : Fin (N + 1))
 commute to `Ŝ⁺_y Ŝ⁻_x` and apply the source/target vanishing at `(y,x)`. -/
 theorem fermionSpinMinusPlus_mulVec_tJConfigOf_eq_zero_of_eq (N : ℕ) (s : Fin (N + 1) → Fin 3)
     (x y : Fin (N + 1)) (hxy : x ≠ y) (h : s x = s y) :
-    (fermionSiteSpinMinus N x * fermionSiteSpinPlus N y).mulVec (basisVec (tJConfigOf N s)) = 0 := by
+    (fermionSiteSpinMinus N x * fermionSiteSpinPlus N y).mulVec (basisVec (tJConfigOf N s)) = 0 :=
+        by
   rw [fermionSiteSpinMinus_mul_Plus_comm N x y hxy]
   rcases (show ∀ a : Fin 3, a ≠ 0 ∨ a = 0 from fun a => by tauto) (s x) with _ | _ <;>
   · by_cases hsx1 : s x = 1

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSummand.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSummand.lean
@@ -110,7 +110,8 @@ theorem tJ_kinetic_summand_zero_or_one (N : ℕ) (hpos : 0 < N) (s s' : Fin (N +
           · rw [tJ_downhop_nn_matrixElement N s s' j i hd hsj hsi0]; split_ifs <;> simp
           · rw [tJ_downhop_wrap_matrixElement N s s' j i hpos hj0 hiN hsj hsi0 Ne hNe hodd]
             split_ifs <;> simp
-          · rw [tJ_downhop_backward_wrap_matrixElement N s s' i j hpos hi0v hjN hsj hsi0 Ne hNe hodd]
+          · rw [tJ_downhop_backward_wrap_matrixElement N s s' i j hpos hi0v hjN hsj hsi0 Ne hNe
+              hodd]
             split_ifs <;> simp
       · -- target site ↑
         rcases tJ_fin2_eq σ with rfl | rfl
@@ -135,7 +136,8 @@ theorem tJ_kinetic_summand_zero_or_one (N : ℕ) (hpos : 0 < N) (s s' : Fin (N +
           · exact absurd (by rw [tJConfigOf_apply_up, if_pos ‹_›] at hsrc; exact hsrc) (by simp_all)
           · rfl
         · rw [tJConfigOf_apply_down]; split
-          · exact absurd (by rw [tJConfigOf_apply_down, if_pos ‹_›] at hsrc; exact hsrc) (by simp_all)
+          · exact absurd (by rw [tJConfigOf_apply_down, if_pos ‹_›] at hsrc; exact hsrc) (by
+              simp_all)
           · rfl
       rw [tJ_hop_matrixElement_eq_zero_of_source N s s' i j σ hsrc0]
       exact Or.inl rfl
@@ -175,7 +177,8 @@ theorem tJKinetic_matrixElement_nonneg (N : ℕ) (hpos : 0 < N) (s s' : Fin (N +
     refine Finset.sum_nonneg fun σ _ => Finset.sum_nonneg fun i _ => Finset.sum_nonneg fun j _ => ?_
     exact (hsumm σ i j).1
   · simp only [Complex.im_sum]
-    refine Finset.sum_eq_zero fun σ _ => Finset.sum_eq_zero fun i _ => Finset.sum_eq_zero fun j _ => ?_
+    refine Finset.sum_eq_zero fun σ _ => Finset.sum_eq_zero fun i _ => Finset.sum_eq_zero fun j _
+        => ?_
     exact (hsumm σ i j).2
 
 end LatticeSystem.Fermion

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJOffDiagonal.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJOffDiagonal.lean
@@ -52,7 +52,8 @@ hard-core bra `⟨Φ_{s'}|` drops both projections, leaving `⟨Φ_{s'} | K | Φ
 theorem tJKinetic_matrixElement_eq (N : ℕ) (G : SimpleGraph (Fin (N + 1))) [DecidableRel G.Adj]
     (s s' : Fin (N + 1) → Fin 3) :
     (∑ w, basisVec (tJConfigOf N s') w *
-        ((hubbardHardcoreProjection N * hubbardKineticOnGraph N G 1 * hubbardHardcoreProjection N).mulVec
+        ((hubbardHardcoreProjection N * hubbardKineticOnGraph N G 1 * hubbardHardcoreProjection
+            N).mulVec
             (basisVec (tJConfigOf N s))) w)
       = ∑ w, basisVec (tJConfigOf N s') w *
           ((hubbardKineticOnGraph N G 1).mulVec (basisVec (tJConfigOf N s))) w := by

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorExchange.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorExchange.lean
@@ -53,7 +53,8 @@ theorem tJConfigOf_tJSpinSwap (N : ℕ) (s : Fin (N + 1) → Fin 3) (i j : Fin (
 
 /-! ### The same-site Jordan–Wigner string cancellations -/
 
-/-- The modes below the successor `q` (`q.val = p.val + 1`) are those below `p` together with `p`. -/
+/-- The modes below the successor `q` (`q.val = p.val + 1`) are those below `p` together with `p`.
+-/
 private theorem tJ_filt_succ (M : ℕ) (p q : Fin (M + 1)) (hq : q.val = p.val + 1) :
     (Finset.univ.filter (fun k : Fin (M + 1) => k.val < q.val))
       = insert p (Finset.univ.filter (fun k => k.val < p.val)) := by
@@ -166,7 +167,8 @@ theorem fermionSiteSpinPlus_mul_Minus_mulVec_tJConfigOf (N : ℕ) (s : Fin (N + 
       = jwSign (2 * N + 1) (spinfulIndex N i 1) c2 • basisVec c3 := by
     rw [fermionMultiAnnihilation_mulVec_basisVec, if_pos hc2id]
   have step4 : (fermionMultiCreation (2 * N + 1) (spinfulIndex N i 0)).mulVec (basisVec c3)
-      = jwSign (2 * N + 1) (spinfulIndex N i 0) c3 • basisVec (tJConfigOf N (tJSpinSwap s i j)) := by
+      = jwSign (2 * N + 1) (spinfulIndex N i 0) c3 • basisVec (tJConfigOf N (tJSpinSwap s i j)) :=
+          by
     rw [fermionMultiCreation_mulVec_basisVec, if_pos hc3iu]
     congr 2
     rw [hc3, hc2, hc1, hcdef]; exact tJConfigOf_tJSpinSwap N s i j hi hj

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopAction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopAction.lean
@@ -45,7 +45,8 @@ theorem tJ_uphop_forward_mulVec (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b : Fin
   have hpne : spinfulIndex N b 0 ≠ spinfulIndex N a 0 := fun h =>
     hne ((spinfulIndex_eq_iff N b a 0 0).mp h).1.symm
   have hcq : tJConfigOf N s (spinfulIndex N a 0) = 1 := by rw [tJConfigOf_apply_up, if_pos ha]
-  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N a 0) 0) (spinfulIndex N b 0) = 0 := by
+  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N a 0) 0) (spinfulIndex N b 0) = 0 :=
+      by
     rw [Function.update_of_ne hpne, tJConfigOf_apply_up, if_neg (by rw [hb]; decide)]
   rw [fermionMultiCreation_mul_Annihilation_mulVec_basisVec, if_pos ⟨hcq, hcp⟩,
     jwSign_mul_jwSign_update_forward (2 * N + 1) (spinfulIndex N a 0) (spinfulIndex N b 0)
@@ -69,7 +70,8 @@ theorem tJ_downhop_forward_mulVec (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b : F
   have hpne : spinfulIndex N b 1 ≠ spinfulIndex N a 1 := fun h =>
     hne ((spinfulIndex_eq_iff N b a 1 1).mp h).1.symm
   have hcq : tJConfigOf N s (spinfulIndex N a 1) = 1 := by rw [tJConfigOf_apply_down, if_pos ha]
-  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N a 1) 0) (spinfulIndex N b 1) = 0 := by
+  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N a 1) 0) (spinfulIndex N b 1) = 0 :=
+      by
     rw [Function.update_of_ne hpne, tJConfigOf_apply_down, if_neg (by rw [hb]; decide)]
   rw [fermionMultiCreation_mul_Annihilation_mulVec_basisVec, if_pos ⟨hcq, hcp⟩,
     jwSign_mul_jwSign_update_forward (2 * N + 1) (spinfulIndex N a 1) (spinfulIndex N b 1)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackward.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackward.lean
@@ -37,7 +37,8 @@ theorem tJ_uphop_backward_nn_mulVec (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b :
   have hcq : tJConfigOf N s (spinfulIndex N b 0) = 1 := by rw [tJConfigOf_apply_up, if_pos ha]
   have hcpz : tJConfigOf N s (spinfulIndex N a 0) = 0 := by
     rw [tJConfigOf_apply_up, if_neg (by rw [hsa]; decide)]
-  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N b 0) 0) (spinfulIndex N a 0) = 0 := by
+  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N b 0) 0) (spinfulIndex N a 0) = 0 :=
+      by
     rw [Function.update_of_ne hpne, hcpz]
   rw [fermionMultiCreation_mul_Annihilation_mulVec_basisVec, if_pos ⟨hcq, hcp⟩,
     jwSign_mul_jwSign_update_backward (2 * N + 1) (spinfulIndex N b 0) (spinfulIndex N a 0)
@@ -68,7 +69,8 @@ theorem tJ_downhop_backward_nn_mulVec (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b
   have hcq : tJConfigOf N s (spinfulIndex N b 1) = 1 := by rw [tJConfigOf_apply_down, if_pos ha]
   have hcpz : tJConfigOf N s (spinfulIndex N a 1) = 0 := by
     rw [tJConfigOf_apply_down, if_neg (by rw [hsa]; decide)]
-  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N b 1) 0) (spinfulIndex N a 1) = 0 := by
+  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N b 1) 0) (spinfulIndex N a 1) = 0 :=
+      by
     rw [Function.update_of_ne hpne, hcpz]
   rw [fermionMultiCreation_mul_Annihilation_mulVec_basisVec, if_pos ⟨hcq, hcp⟩,
     jwSign_mul_jwSign_update_backward (2 * N + 1) (spinfulIndex N b 1) (spinfulIndex N a 1)
@@ -83,7 +85,8 @@ theorem tJ_downhop_backward_nn_mulVec (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b
     rfl
   rw [hsum, pow_zero, one_smul]
 
-/-- **Leftward NN up-hop matrix element.**  `⟨Φ_{s'} | ĉ†_{a↑}ĉ_{b↑} | Φ_s⟩ = [s' = tJSiteHop s b a]`. -/
+/-- **Leftward NN up-hop matrix element.**  `⟨Φ_{s'} | ĉ†_{a↑}ĉ_{b↑} | Φ_s⟩ = [s' = tJSiteHop s b
+a]`. -/
 theorem tJ_uphop_backward_nn_matrixElement (N : ℕ) (s s' : Fin (N + 1) → Fin 3) (a b : Fin (N + 1))
     (hb : b.val = a.val + 1) (ha : s b = 1) (hsa : s a = 0) :
     (∑ w, basisVec (tJConfigOf N s') w *

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackwardWrap.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackwardWrap.lean
@@ -84,7 +84,8 @@ private theorem tJ_bwrap_ge_eq_one_down (N : ℕ) (s : Fin (N + 1) → Fin 3) (b
   rw [hfilter, Finset.sum_singleton, tJConfigOf_apply_down, if_pos hsb]
   rfl
 
-/-- **Leftward wrap up-hop is sign-free for odd `Ne`.**  Source `N` ↑, target `0` empty: the electron
+/-- **Leftward wrap up-hop is sign-free for odd `Ne`.**  Source `N` ↑, target `0` empty: the
+electron
 hops `N → 0` with no sign for odd `Ne`. -/
 theorem tJ_uphop_backward_wrap_mulVec (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b : Fin (N + 1))
     (hpos : 0 < N) (ha0 : a.val = 0) (hbN : b.val = N) (ha : s b = 1) (hsa : s a = 0)
@@ -102,7 +103,8 @@ theorem tJ_uphop_backward_wrap_mulVec (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b
   have hcq : tJConfigOf N s (spinfulIndex N b 0) = 1 := by rw [tJConfigOf_apply_up, if_pos ha]
   have hcpz : tJConfigOf N s (spinfulIndex N a 0) = 0 := by
     rw [tJConfigOf_apply_up, if_neg (by rw [hsa]; decide)]
-  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N b 0) 0) (spinfulIndex N a 0) = 0 := by
+  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N b 0) 0) (spinfulIndex N a 0) = 0 :=
+      by
     rw [Function.update_of_ne hpne, hcpz]
   rw [fermionMultiCreation_mul_Annihilation_mulVec_basisVec, if_pos ⟨hcq, hcp⟩,
     jwSign_mul_jwSign_update_backward (2 * N + 1) (spinfulIndex N b 0) (spinfulIndex N a 0)
@@ -137,7 +139,8 @@ theorem tJ_downhop_backward_wrap_mulVec (N : ℕ) (s : Fin (N + 1) → Fin 3) (a
   have hcq : tJConfigOf N s (spinfulIndex N b 1) = 1 := by rw [tJConfigOf_apply_down, if_pos ha]
   have hcpz : tJConfigOf N s (spinfulIndex N a 1) = 0 := by
     rw [tJConfigOf_apply_down, if_neg (by rw [hsa]; decide)]
-  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N b 1) 0) (spinfulIndex N a 1) = 0 := by
+  have hcp : (Function.update (tJConfigOf N s) (spinfulIndex N b 1) 0) (spinfulIndex N a 1) = 0 :=
+      by
     rw [Function.update_of_ne hpne, hcpz]
   rw [fermionMultiCreation_mul_Annihilation_mulVec_basisVec, if_pos ⟨hcq, hcp⟩,
     jwSign_mul_jwSign_update_backward (2 * N + 1) (spinfulIndex N b 1) (spinfulIndex N a 1)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopWrap.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopWrap.lean
@@ -62,7 +62,8 @@ private theorem tJ_wrap_uphop_le_eq_one (N : ℕ) (s : Fin (N + 1) → Fin 3) (a
   rw [hfilter, Finset.sum_singleton, tJConfigOf_apply_up, if_pos ha]
   rfl
 
-/-- **Wrap up-hop is sign-free for odd `Ne`.**  For the cycle's wrap bond (`a.val = 0`, `b.val = N`),
+/-- **Wrap up-hop is sign-free for odd `Ne`.**  For the cycle's wrap bond (`a.val = 0`, `b.val =
+N`),
 source `a` ↑, target `b` empty, and an odd electron number `Ne = #↑ + #↓`, the strictly-between
 occupation is `Ne − 1` (even), so `ĉ†_{b↑}ĉ_{a↑} |Φ_s⟩ = |Φ_{tJSiteHop s a b}⟩`. -/
 theorem tJ_uphop_wrap_mulVec (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b : Fin (N + 1))

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedBelowFromArgmin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedBelowFromArgmin.lean
@@ -46,7 +46,8 @@ theorem balanced_GS_below_sInf_of_argmin
         sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M_chosen lam' D' ∩ Icc (0 : ℝ) 1) ≤
         sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M' lam' D' ∩ Icc (0 : ℝ) 1))
     -- "Every M' ≠ M_balanced (non-empty) has a crossing in Icc 0 1" — required to apply
-    -- strict_per_M_gap. For M' with no crossing, the strict gap trivially holds at all t' ∈ Icc 0 1.
+    -- strict_per_M_gap. For M' with no crossing, the strict gap trivially holds
+    -- at all t' ∈ Icc 0 1.
     (h_all_M_crossing_or_no_violation :
       ∀ M' : ℕ, ∀ _ : Nonempty (magConfigS Λ N M'), M' ≠ M_balanced → ∀ t' : ℝ,
         t' ∈ Icc (0 : ℝ) 1 →

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedMinEqFullAtSInf.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedMinEqFullAtSInf.lean
@@ -50,7 +50,8 @@ theorem balanced_min_eq_full_at_sInf
           (anisotropicHeisenbergParametricPath lam' D'
             (sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M_chosen lam' D' ∩ Icc (0 : ℝ) 1))).1
           (anisotropicHeisenbergParametricPath lam' D'
-            (sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M_chosen lam' D' ∩ Icc (0 : ℝ) 1))).2) :=
+            (sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M_chosen lam' D' ∩ Icc (0 : ℝ) 1))).2)
+                :=
   balanced_GS_at_first_crossing_of_argmin hJ N M_balanced M_chosen lam' D'
     hne_chosen h_GS_at_SU2 h_balanced_GS_below
 

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinGeSectorMin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinGeSectorMin.lean
@@ -73,7 +73,8 @@ theorem exists_sector_hermitianMinEigenvalue_le_full
   -- Sector restriction is a sector eigvec at the full min (PR #3988).
   set μ : ℝ := hermitianMinEigenvalue
     (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ N lam D) with hμ_def
-  have hsec_eig := anisotropicHeisenbergS_magSector_submatrix_mulVec_magSectorRestriction_of_full_eigen
+  have hsec_eig :=
+      anisotropicHeisenbergS_magSector_submatrix_mulVec_magSectorRestriction_of_full_eigen
     J ((lam : ℂ)) ((D : ℂ)) (μ := ((μ : ℝ) : ℂ)) (M := M) hv_eig
   -- Sector restriction is non-zero.
   -- Hence μ IS an eigenvalue of the sector submatrix; sector min ≤ μ.

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergGlobalMinFinrankLeTwo.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergGlobalMinFinrankLeTwo.lean
@@ -71,7 +71,8 @@ theorem spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min
   -- hswap_eq : hermitianMinEigenvalue Ĥ = hermitianMinEigenvalue axisSwapped.
   -- Chain: hermitianMinEigenvalue Ĥ = hermitianMinEigenvalue axisSwapped (via hswap_eq)
   --                                  = min(block-0, block-1) (via hblock_eq).
-  -- But axisSwapped_full_isHermitian_im uses the same matrix as axisSwappedAnisotropicHeisenbergS_isHermitian_of_real.
+  -- But axisSwapped_full_isHermitian_im uses the same matrix as
+  -- axisSwappedAnisotropicHeisenbergS_isHermitian_of_real.
   -- The hermitianMinEigenvalue values match by congruence on the Hermitian instance.
   -- Rewrite the eigenvalue in h3888 to hermitianMinEigenvalue Ĥ.
   have henergy_eq : (min (hermitianMinEigenvalue

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIBlockPFMin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIBlockPFMin.lean
@@ -845,7 +845,8 @@ theorem anisotropicHeisenbergS_case_ii_target_zero_magnetization_of_block_pf_min
   rcases caseII_axisSwapped_submatrix_blocks_path_of_pf_min
       (Λ := Λ) (N := N) (J := J) hJim hJself hJ_star h_even_pf h_odd_pf with
     ⟨h_even, h_odd⟩
-  exact anisotropicHeisenbergS_case_ii_target_zero_magnetization_of_axisSwapped_submatrix_blocks_path
+  exact
+      anisotropicHeisenbergS_case_ii_target_zero_magnetization_of_axisSwapped_submatrix_blocks_path
     (Λ := Λ) (N := N) A hJim hJnn hJpos hJself hJbip hJ_star hJ_sym hA_ne hB_ne hN
     M_balanced h_balanced hlam_case_ii hD_case_ii h_centered_nonzero
     h_strict_gap_at_SU2 h_GS_at_SU2 h_even h_odd hΦ_ne hΦ_gs

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergStrictGapAllMFromArgmin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergStrictGapAllMFromArgmin.lean
@@ -49,7 +49,8 @@ theorem strict_gap_all_M_below_sInf_of_argmin
   by_cases h_M'_ne : (perMCrossingSet (Λ := Λ) hJ N M_balanced M' lam' D' ∩ Icc (0 : ℝ) 1).Nonempty
   · -- Non-empty M' set: argmin gives sInf M_chosen ≤ sInf M', so t' < sInf M'.
     have h_le := h_argmin M' hNE_M' hne_eq_M' h_M'_ne
-    have ht'_lt_M' : t' < sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M' lam' D' ∩ Icc (0 : ℝ) 1) :=
+    have ht'_lt_M' : t' < sInf (perMCrossingSet (Λ := Λ) hJ N M_balanced M' lam' D' ∩ Icc (0 : ℝ)
+        1) :=
       lt_of_lt_of_le ht'_lt_sInf h_le
     exact strict_per_M_gap_of_lt_sInf_perMCrossingSet
       hJ N M_balanced M' lam' D' h_M'_ne ht'_in_Icc ht'_lt_M'

--- a/LatticeSystem/Quantum/SpinS/AxisSwappedBlockMinEq.lean
+++ b/LatticeSystem/Quantum/SpinS/AxisSwappedBlockMinEq.lean
@@ -121,7 +121,8 @@ theorem hermitianMinEigenvalue_axisSwapped_le_parity_block_min
         have h1 : magSumS σ % 2 < 2 := Nat.mod_lt _ (by norm_num)
         have h2 : magSumS τ % 2 < 2 := Nat.mod_lt _ (by norm_num)
         omega
-      exact axisSwappedAnisotropicHeisenbergS_apply_eq_zero_of_magSum_parity_ne hJself lam D hne hodd)
+      exact axisSwappedAnisotropicHeisenbergS_apply_eq_zero_of_magSum_parity_ne hJself lam D hne
+          hodd)
     (axisSwappedAnisotropicHeisenbergS_commute_magParityDiagS hJself lam D)
     ((μp : ℝ) : ℂ)
   have hpos_p : 1 ≤ finrank ℂ ↥(End.eigenspace (Matrix.toLin'

--- a/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/BareSubmatrixFinrankLeOneAtMinStructural.lean
@@ -25,7 +25,8 @@ open Matrix Module
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-/-- **(#3887.7) Bare submatrix `finrank ℂ ≤ 1` at `hermitianMinEigenvalue` (structural, no `h_intermediate`)**. -/
+/-- **(#3887.7) Bare submatrix `finrank ℂ ≤ 1` at `hermitianMinEigenvalue` (structural, no
+`h_intermediate`)**. -/
 theorem axisSwappedAnisotropicHeisenbergS_submatrix_finrank_le_one_at_hermitianMinEigenvalue
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapParityStepStrictPos.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapParityStepStrictPos.lean
@@ -32,7 +32,8 @@ open Matrix
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-/-- **Unified `ParityStepS` strict positivity of the shifted PF matrix** (case (i.2) strict, `D > 0`).
+/-- **Unified `ParityStepS` strict positivity of the shifted PF matrix** (case (i.2) strict, `D >
+0`).
 For a `ParityStepS` on `bipartiteCompleteGraphOf A` under `−1 < λ.re < 1` real, real `D > 0`
 strict, the shifted matrix entry is strict positive. -/
 theorem shiftedDressedAxisSwappedReMatrix_apply_pos_of_parityStepS_bipartite

--- a/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPFStructural.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedBareSubmatrixMinEqPFStructural.lean
@@ -24,7 +24,8 @@ open Matrix Module
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-/-- **(#3887.6-dressed) Dressed submatrix hermitianMinEigenvalue identification (no `h_intermediate`)**. -/
+/-- **(#3887.6-dressed) Dressed submatrix hermitianMinEigenvalue identification (no
+`h_intermediate`)**. -/
 theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
@@ -108,7 +109,8 @@ theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalu
     hermitianMinEigenvalue_eq_of_spectrum_eq _ _ h_spec_eq
   linarith [h_min_lift, h_min_bridge]
 
-/-- **(#3887.6-bare) Bare submatrix hermitianMinEigenvalue identification (no `h_intermediate`)**. -/
+/-- **(#3887.6-bare) Bare submatrix hermitianMinEigenvalue identification (no `h_intermediate`)**.
+-/
 theorem axisSwappedAnisotropicHeisenbergS_submatrix_hermitianMinEigenvalue_eq_pf
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)

--- a/LatticeSystem/Quantum/SpinS/InvolutionEigenspaceDecompEq.lean
+++ b/LatticeSystem/Quantum/SpinS/InvolutionEigenspaceDecompEq.lean
@@ -47,7 +47,8 @@ private theorem eigenspace_one_inf_neg_one_eq_bot
   rw [hv0]
   exact Submodule.zero_mem _
 
-/-- **Eigenspace finrank EQUALITY under a commuting involution** (strengthens #3776 from `≤` to `=`):
+/-- **Eigenspace finrank EQUALITY under a commuting involution** (strengthens #3776 from `≤` to
+`=`):
 for finite-dimensional `T, P` with `T ∘ P = P ∘ T` and `P ∘ P = id`, every `T`-eigenspace
 **splits as a direct sum** across the two `P`-eigenspaces `±1`, giving
 `finrank (eigenspace T μ) = finrank (eigenspace T μ ⊓ eigenspace P 1) + finrank (eigenspace T μ ⊓

--- a/LatticeSystem/Quantum/SpinS/JointDiagonalLI.lean
+++ b/LatticeSystem/Quantum/SpinS/JointDiagonalLI.lean
@@ -62,7 +62,8 @@ theorem jointDiagonalIterate_hasEigenvector (A : Λ → Bool)
 omit [DecidableEq Λ] in
 /-- The diagonal eigenvalue function `k_A ↦ s_A − k_A` is injective. -/
 theorem jointDiagonal_eigenvalue_injective (A : Λ → Bool) :
-    Function.Injective (fun kA : Fin ((Finset.univ.filter (fun x : Λ => (! A x) = true)).card * N + 1) =>
+    Function.Injective (fun kA : Fin ((Finset.univ.filter (fun x : Λ => (! A x) = true)).card * N +
+        1) =>
       ((Finset.univ.filter (fun x : Λ => A x = true)).card : ℂ) * (N : ℂ) / 2 - (kA.val : ℂ)) := by
   intro i j hij
   simp only at hij
@@ -75,7 +76,8 @@ theorem jointDiagonalIterate_linearIndependent (A : Λ → Bool)
       (Finset.univ.filter (fun x : Λ => A x = true)).card) :
     LinearIndependent ℂ (jointDiagonalIterate A N) := by
   apply Module.End.eigenvectors_linearIndependent' ((sublatticeSpinSOp3 N A).mulVecLin)
-    (fun kA => ((Finset.univ.filter (fun x : Λ => A x = true)).card : ℂ) * (N : ℂ) / 2 - (kA.val : ℂ))
+    (fun kA => ((Finset.univ.filter (fun x : Λ => A x = true)).card : ℂ) * (N : ℂ) / 2 - (kA.val :
+        ℂ))
     (jointDiagonal_eigenvalue_injective A)
   exact jointDiagonalIterate_hasEigenvector A horient
 

--- a/LatticeSystem/Quantum/SpinS/JointDiagonalPredictedEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/JointDiagonalPredictedEigenvector.lean
@@ -72,12 +72,14 @@ theorem exists_jointPredictedCasimir_eigenvector (A : Λ → Bool)
           (((Finset.univ.filter (fun x : Λ => A x = true)).card : ℂ) * ((N : ℂ) / 2) + 1)) • w ∧
       (sublatticeSpinSquaredS N (fun x => ! A x)).mulVec w =
         (((Finset.univ.filter (fun x : Λ => (! A x) = true)).card : ℂ) * ((N : ℂ) / 2) *
-          (((Finset.univ.filter (fun x : Λ => (! A x) = true)).card : ℂ) * ((N : ℂ) / 2) + 1)) • w := by
+          (((Finset.univ.filter (fun x : Λ => (! A x) = true)).card : ℂ) * ((N : ℂ) / 2) + 1)) • w
+              := by
   obtain ⟨w, hw_ne, hw_span, hw_ker⟩ := exists_jointDiagonal_totalSpinSOpPlus_kernel A horient
   -- w lies in the joint Casimir eigenspace W (span ⊆ W).
   have hw_W : w ∈ jointSublatticeCasimirEigenspace (Λ := Λ) A N :=
     (Submodule.span_le.mpr
-      (Set.range_subset_iff.mpr (jointDiagonalIterate_mem_jointSublatticeCasimirEigenspace A))) hw_span
+      (Set.range_subset_iff.mpr (jointDiagonalIterate_mem_jointSublatticeCasimirEigenspace A)))
+          hw_span
   obtain ⟨hw_A, hw_B⟩ := hw_W
   rw [SetLike.mem_coe, Module.End.mem_eigenspace_iff, Matrix.mulVecLin_apply] at hw_A
   rw [SetLike.mem_coe, Module.End.mem_eigenspace_iff, Matrix.mulVecLin_apply] at hw_B

--- a/LatticeSystem/Quantum/SpinS/JointLadderIterate.lean
+++ b/LatticeSystem/Quantum/SpinS/JointLadderIterate.lean
@@ -51,20 +51,24 @@ theorem sublatticeSpinSquaredS_mulVec_jointLadderIterateDownS (A : Λ → Bool) 
   have hcomm : Commute (sublatticeSpinSquaredS N A)
       ((sublatticeSpinSOpMinus N A) ^ kA *
         (sublatticeSpinSOpMinus N (fun x => ! A x)) ^ kB) :=
-    ((sublatticeSpinSquaredS_commute_sublatticeSpinSOpMinus (Λ := Λ) (N := N) A).pow_right kA).mul_right
-      ((sublatticeSpinSquaredS_commute_sublatticeSpinSOpMinus_complement (Λ := Λ) (N := N) A).pow_right kB)
+    ((sublatticeSpinSquaredS_commute_sublatticeSpinSOpMinus (Λ := Λ) (N := N) A).pow_right
+        kA).mul_right
+      ((sublatticeSpinSquaredS_commute_sublatticeSpinSOpMinus_complement (Λ := Λ) (N := N)
+          A).pow_right kB)
   rw [Matrix.mulVec_mulVec, hcomm.eq, ← Matrix.mulVec_mulVec,
       sublatticeSpinSquaredS_mulVec_allAlignedStateS_zero (N := N) A, Matrix.mulVec_smul]
 
 /-- `(Ŝ_¬A)²` acts on the joint iterate by the maximal `¬A`-Casimir `s_B(s_B+1)`. -/
-theorem sublatticeSpinSquaredS_complement_mulVec_jointLadderIterateDownS (A : Λ → Bool) (kA kB : ℕ) :
+theorem sublatticeSpinSquaredS_complement_mulVec_jointLadderIterateDownS (A : Λ → Bool) (kA kB : ℕ)
+    :
     (sublatticeSpinSquaredS N (fun x => ! A x)).mulVec (jointLadderIterateDownS A N kA kB) =
       (((Finset.univ.filter (fun x : Λ => (! A x) = true)).card : ℂ) * ((N : ℂ) / 2) *
         (((Finset.univ.filter (fun x : Λ => (! A x) = true)).card : ℂ) * ((N : ℂ) / 2) + 1)) •
         jointLadderIterateDownS A N kA kB := by
   rw [jointLadderIterateDownS_eq_prod]
   -- `Commute (Ŝ_¬A)² (Ŝ_A^-)`: the complement commute at `¬A` (with `¬¬A = A`).
-  have hcomm_cross : Commute (sublatticeSpinSquaredS N (fun x => ! A x)) (sublatticeSpinSOpMinus N A) := by
+  have hcomm_cross : Commute (sublatticeSpinSquaredS N (fun x => ! A x)) (sublatticeSpinSOpMinus N
+      A) := by
     have h := sublatticeSpinSquaredS_commute_sublatticeSpinSOpMinus_complement
       (Λ := Λ) (N := N) (fun x => ! A x)
     have hnotnot : (fun x => ! (! A x)) = A := by funext x; simp

--- a/LatticeSystem/Quantum/SpinS/JointLadderIterateNonvanishing.lean
+++ b/LatticeSystem/Quantum/SpinS/JointLadderIterateNonvanishing.lean
@@ -55,7 +55,8 @@ theorem jointLadderIterateDownS_ne_zero (A : Λ → Bool) {kA kB : ℕ}
       apply mul_ne_zero
       · exact_mod_cast Nat.succ_ne_zero kA
       · intro h_eq
-        have hcN : (((Finset.univ.filter (fun x : Λ => A x = true)).card : ℂ) * (N : ℂ)) = (kA : ℂ) :=
+        have hcN : (((Finset.univ.filter (fun x : Λ => A x = true)).card : ℂ) * (N : ℂ)) = (kA : ℂ)
+            :=
           sub_eq_zero.mp h_eq
         have hcN' : (((Finset.univ.filter (fun x : Λ => A x = true)).card * N : ℕ) : ℂ) =
             ((kA : ℕ) : ℂ) := by push_cast; exact hcN

--- a/LatticeSystem/Quantum/SpinS/JointLadderRaiseB.lean
+++ b/LatticeSystem/Quantum/SpinS/JointLadderRaiseB.lean
@@ -44,7 +44,8 @@ theorem sublatticeSpinSOpPlus_complement_mulVec_jointLadderIterateDownS_succB
   rw [hj (kB + 1), Matrix.mulVec_mulVec,
       ((sublatticeSpinSOpMinus_cross_commute_plus (Λ := Λ) (N := N) A).symm.pow_right kA).eq,
       ← Matrix.mulVec_mulVec,
-      sublatticeSpinSOpPlus_mulVec_sublatticeLadderIterateDownS_succ (Λ := Λ) (N := N) (fun x => ! A x) kB,
+      sublatticeSpinSOpPlus_mulVec_sublatticeLadderIterateDownS_succ (Λ := Λ) (N := N) (fun x => !
+          A x) kB,
       Matrix.mulVec_smul, ← hj kB]
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/JointLadderRaiseBoundary.lean
+++ b/LatticeSystem/Quantum/SpinS/JointLadderRaiseBoundary.lean
@@ -35,7 +35,8 @@ theorem sublatticeSpinSOpPlus_mulVec_jointLadderIterateDownS_zeroA (A : Λ → B
       Matrix.mulVec_zero]
 
 /-- `Ŝ_¬A^+` annihilates `jointIterate k_A 0` (the `¬A`-block is the highest weight). -/
-theorem sublatticeSpinSOpPlus_complement_mulVec_jointLadderIterateDownS_zeroB (A : Λ → Bool) (kA : ℕ) :
+theorem sublatticeSpinSOpPlus_complement_mulVec_jointLadderIterateDownS_zeroB (A : Λ → Bool) (kA :
+    ℕ) :
     (sublatticeSpinSOpPlus N (fun x => ! A x)).mulVec (jointLadderIterateDownS A N kA 0) = 0 := by
   unfold jointLadderIterateDownS
   rw [pow_zero, Matrix.one_mulVec, Matrix.mulVec_mulVec,

--- a/LatticeSystem/Quantum/SpinS/ParityReachConcentrateAB.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachConcentrateAB.lean
@@ -67,7 +67,8 @@ theorem parityReachableS_concentrate_AB
   -- σ_A on B-sites: σ_A b = σ b (since B-sites are not in A, hence not in aSitesExcept A a₀).
   have hsig_A_bSite : ∀ b, A b = false → σ_A b = σ b := by
     intro b hAb
-    have hb_ne_a₀ : b ≠ a₀ := by intro h; rw [h] at hAb; exact absurd (hAb.symm.trans ha₀) (by decide)
+    have hb_ne_a₀ : b ≠ a₀ := by intro h; rw [h] at hAb; exact absurd (hAb.symm.trans ha₀) (by
+        decide)
     have hb_notin : b ∉ aSitesExcept A a₀ := fun h => by
       have := (mem_aSitesExcept.mp h).1
       rw [hAb] at this; exact absurd this (by decide)
@@ -89,7 +90,8 @@ theorem parityReachableS_concentrate_AB
       (by intro h; exact (mem_bSitesExcept.mp h).2 rfl) with hsig_AB
   refine ⟨σ_AB, ParityReachableS.trans hreach_A hreach_B, ?_, ?_, ?_, ?_⟩
   · -- σ_AB a₀ = σ_A a₀ (a₀ ∉ B-sites since a₀ ∈ A).
-    have ha₀_ne_b₀ : a₀ ≠ b₀ := by intro h; rw [h] at ha₀; exact absurd (ha₀.symm.trans hb₀) (by decide)
+    have ha₀_ne_b₀ : a₀ ≠ b₀ := by intro h; rw [h] at ha₀; exact absurd (ha₀.symm.trans hb₀) (by
+        decide)
     have ha₀_notin_B : a₀ ∉ bSitesExcept A b₀ := fun h => by
       have := (mem_bSitesExcept.mp h).1
       rw [ha₀] at this; exact absurd this (by decide)
@@ -110,7 +112,8 @@ theorem parityReachableS_concentrate_AB
   · intro a ha
     have ha_ne_a₀ : a ≠ a₀ := (mem_aSitesExcept.mp ha).2
     have hAa : A a = true := (mem_aSitesExcept.mp ha).1
-    have ha_ne_b₀ : a ≠ b₀ := by intro h; rw [h] at hAa; exact absurd (hAa.symm.trans hb₀) (by decide)
+    have ha_ne_b₀ : a ≠ b₀ := by intro h; rw [h] at hAa; exact absurd (hAa.symm.trans hb₀) (by
+        decide)
     have ha_notin_B : a ∉ bSitesExcept A b₀ := fun h => by
       have := (mem_bSitesExcept.mp h).1
       rw [hAa] at this; exact absurd this (by decide)

--- a/LatticeSystem/Quantum/SpinS/PredictedGSFinrankLtJointCasimirFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/PredictedGSFinrankLtJointCasimirFinrank.lean
@@ -44,7 +44,8 @@ noncomputable def jointSublatticeCasimirEigenspace
 /-- **Predicted GS finrank < joint Casimir finrank** at non-deg
 (`|¬A| ≤ |A|`). Direct from strict subspace inclusion in finite-
 dimensional space. -/
-theorem bipartiteToyGroundStateSubspacePredicted_finrank_lt_joint_eigenspace_finrank_of_nondegenerate
+theorem
+    bipartiteToyGroundStateSubspacePredicted_finrank_lt_joint_eigenspace_finrank_of_nondegenerate
     (A : Λ → Bool) (N : ℕ)
     (hA : 0 < (Finset.univ.filter (fun x : Λ => A x = true)).card)
     (hAc : 0 < (Finset.univ.filter (fun x : Λ => (! A x) = true)).card)

--- a/LatticeSystem/Quantum/SpinS/SublatticeLadderIterateNonvanishing.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeLadderIterateNonvanishing.lean
@@ -41,14 +41,16 @@ theorem sublatticeLadderIterateDownS_ne_zero (A : Λ → Bool) {k : ℕ}
     have hk_lt : k < (Finset.univ.filter (fun x : Λ => A x = true)).card * N := hk
     have h_vk_ne := ih (Nat.le_of_lt hk_lt)
     intro h_vk_succ_zero
-    have h_eigen := sublatticeSpinSOpPlus_mulVec_sublatticeLadderIterateDownS_succ (Λ := Λ) (N := N) A k
+    have h_eigen := sublatticeSpinSOpPlus_mulVec_sublatticeLadderIterateDownS_succ (Λ := Λ) (N :=
+        N) A k
     rw [h_vk_succ_zero, Matrix.mulVec_zero] at h_eigen
     have h_scalar_ne : (((k + 1 : ℕ) : ℂ) *
         ((Finset.univ.filter (fun x : Λ => A x = true)).card * (N : ℂ) - (k : ℂ))) ≠ 0 := by
       apply mul_ne_zero
       · exact_mod_cast Nat.succ_ne_zero k
       · intro h_eq
-        have hcN : (((Finset.univ.filter (fun x : Λ => A x = true)).card : ℂ) * (N : ℂ)) = (k : ℂ) :=
+        have hcN : (((Finset.univ.filter (fun x : Λ => A x = true)).card : ℂ) * (N : ℂ)) = (k : ℂ)
+            :=
           sub_eq_zero.mp h_eq
         have hcN' : (((Finset.univ.filter (fun x : Λ => A x = true)).card * N : ℕ) : ℂ) =
             ((k : ℕ) : ℂ) := by push_cast; exact hcN

--- a/LatticeSystem/Quantum/SpinS/SublatticeMaxCasimirEigenspaceComplementNeBot.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeMaxCasimirEigenspaceComplementNeBot.lean
@@ -28,7 +28,8 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 theorem sublatticeMaxCasimirEigenspace_complement_ne_bot [Nonempty Λ] (A : Λ → Bool) :
     Module.End.eigenspace (sublatticeSpinSquaredS N (fun x => ! A x)).mulVecLin
         (((Finset.univ.filter (fun x : Λ => (! A x) = true)).card : ℂ) * ((N : ℂ) / 2) *
-          (((Finset.univ.filter (fun x : Λ => (! A x) = true)).card : ℂ) * ((N : ℂ) / 2) + 1)) ≠ ⊥ :=
+          (((Finset.univ.filter (fun x : Λ => (! A x) = true)).card : ℂ) * ((N : ℂ) / 2) + 1)) ≠ ⊥
+              :=
   sublatticeMaxCasimirEigenspace_ne_bot (Λ := Λ) (N := N) (fun x => ! A x)
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/Theorem23AntialignedJointEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23AntialignedJointEigenvector.lean
@@ -93,7 +93,8 @@ theorem sublatticeSpinSquaredS_complement_antiAligned_eq_max (A : V → Bool) :
     intro x hx
     have hxA : A x = false := by simpa using hx
     simp [antiAlignedConfigS, hxA]
-  have hcas := sublatticeSpinSquaredS_mulVec_of_sublatticeSpinSOpMinus_eq_zero (fun x => ! A x) hmag hker
+  have hcas := sublatticeSpinSquaredS_mulVec_of_sublatticeSpinSOpMinus_eq_zero (fun x => ! A x)
+      hmag hker
   rw [hcas, sublatticeMagEigenvalue_antiAligned_notA A]
   congr 1
   ring

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralGeneralFinal.lean
@@ -126,7 +126,8 @@ theorem tasaki_2_5_theorem_2_3_of_bipartiteCompletePositive
       exact ⟨he.trans hμM_eq, hr⟩
   · refine tasaki23_eigenvalue_ge_common A N c hJ_real hJ_real' hJ_nn hJ_sym hJ_bipartite
       hc_strict hcommon (fun {M} hM_non {μM φ} hφ_ne hφ => ?_)
-    haveI : Nonempty (magConfigS V N M) := nonempty_magConfigS_of_fn_ne_zero_general_structural hφ_ne
+    haveI : Nonempty (magConfigS V N M) := nonempty_magConfigS_of_fn_ne_zero_general_structural
+        hφ_ne
     exact tasaki23_general_hOutside A N c hJ_real hJ_real' hJ_nn hJ_sym hJ_bipartite hc_strict
       hcommon hM_non hφ_ne hφ
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorExistence.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralSectorExistence.lean
@@ -19,7 +19,8 @@ namespace LatticeSystem.Quantum
 
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
-/-- **Structural per-sector existence step toward Tasaki §2.5 Theorem 2.3 (no `h_intermediate`)**. -/
+/-- **Structural per-sector existence step toward Tasaki §2.5 Theorem 2.3 (no `h_intermediate`)**.
+-/
 theorem tasaki_2_5_theorem_2_3_sector_existence
     (A : V → Bool) {J : V → V → ℂ} (c : ℝ) {M : ℕ}
     [Nonempty (magConfigS V N M)]

--- a/LatticeSystem/Quantum/SpinS/Theorem23SublatticeBottomComponent.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23SublatticeBottomComponent.lean
@@ -74,7 +74,8 @@ theorem exists_sublattice_A_lowestWeight_component (A : Λ → Bool)
   have hk₀_max : ∀ k, k₀ < k → f k = 0 := by
     intro k hlt
     by_contra hne
-    have hmem : k ∈ Finset.univ.filter (fun k => f k ≠ 0) := Finset.mem_filter.mpr ⟨Finset.mem_univ k, hne⟩
+    have hmem : k ∈ Finset.univ.filter (fun k => f k ≠ 0) := Finset.mem_filter.mpr ⟨Finset.mem_univ
+        k, hne⟩
     exact absurd ((Finset.univ.filter (fun k => f k ≠ 0)).le_max' k hmem) (not_le.mpr hlt)
   -- Commute facts for inheriting the total Sz and Casimirs through the projection.
   have hcomm_tot : Commute (sublatticeSpinSOp3 N A) (totalSpinSOp3 Λ N) := by
@@ -126,7 +127,8 @@ theorem exists_sublattice_A_lowestWeight_component (A : Λ → Bool)
         exact Fin.ext (by exact_mod_cast (sub_right_inj.mp (sub_left_inj.mp hcontra)).symm)
       · intro h; exact absurd (Finset.mem_univ k₀) h
     -- The Ŝ_¬A^- contribution vanishes termwise.
-    have hB_term : sublatticeMagProjFn A L₁ ((sublatticeSpinSOpMinus N (fun x => ! A x)).mulVec w) = 0 := by
+    have hB_term : sublatticeMagProjFn A L₁ ((sublatticeSpinSOpMinus N (fun x => ! A x)).mulVec w)
+        = 0 := by
       conv_lhs => rw [← hdecomp, Matrix.mulVec_sum, sublatticeMagProjFn_sum]
       refine Finset.sum_eq_zero (fun k _ => ?_)
       -- Ŝ_¬A^- (f k) ∈ A-mag level (sA − k) [preserves A-mag].

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyGSPredictedCasimirAt.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyGSPredictedCasimirAt.lean
@@ -83,7 +83,8 @@ theorem tasaki23_toy_groundState_casimir_eq_predicted_at_legacy
     (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) hComplex
   -- The toy ground state is a joint Casimir eigenvector (#3657).
   obtain ⟨⟨γ_tot, htot⟩, ⟨γ_A, hA⟩, ⟨γ_B, hB⟩⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos
+        hH
   set w : (V → Fin (N + 1)) → ℂ :=
     magSectorEmbedding (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) with hw
   -- Energy: μ = γ_tot − γ_A − γ_B, so (γ_tot − γ_A − γ_B).re ≤ E.

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyMinEnergyArith.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyMinEnergyArith.lean
@@ -42,10 +42,12 @@ theorem tasaki23_toy_min_energy_arith (a b sA sB : ℝ)
   rcases le_total b a with hba | hab
   · -- a ≥ b: |a − b| = a − b, f(a,b) = −2 b (a + 1).
     rw [abs_of_nonneg (by linarith)]
-    nlinarith [mul_le_mul hbB (by linarith : a + 1 ≤ sA + 1) (by linarith) (by linarith : (0:ℝ) ≤ sB)]
+    nlinarith [mul_le_mul hbB (by linarith : a + 1 ≤ sA + 1) (by linarith) (by linarith : (0:ℝ) ≤
+        sB)]
   · -- a < b: |a − b| = b − a, f(a,b) = −2 a (b + 1).
     rw [abs_of_nonpos (by linarith)]
     have hasB : a ≤ sB := le_trans hab hbB
-    nlinarith [mul_le_mul hasB (by linarith : b + 1 ≤ sA + 1) (by linarith) (by linarith : (0:ℝ) ≤ sB)]
+    nlinarith [mul_le_mul hasB (by linarith : b + 1 ≤ sA + 1) (by linarith) (by linarith : (0:ℝ) ≤
+        sB)]
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToySectorEnergyLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToySectorEnergyLowerBound.lean
@@ -74,7 +74,8 @@ theorem tasaki23_toy_sector_energy_ge_predicted_legacy
   have hH := heisenbergHamiltonianS_mulVec_magSectorEmbedding (bipartiteCoupling A)
     (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ)) hComplex
   obtain ⟨⟨γ_tot, htot⟩, ⟨γ_A, hA⟩, ⟨γ_B, hB⟩⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos
+        hH
   -- The ground-state energy equals the Casimir combination `(γ_tot − γ_A − γ_B).re`.
   have hEnergy := heisenbergToyHamiltonianS_mulVec_of_joint_casimir_eigenvector A htot hA hB
   have hμGS_eq : γ_tot - γ_A - γ_B = (μGS : ℂ) :=

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToySublatticeBounds.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToySublatticeBounds.lean
@@ -59,7 +59,8 @@ theorem tasaki23_toy_groundState_sublattice_casimir_re_le_legacy
           ((Finset.univ.filter (fun x : V => (! A x) = true)).card : ℝ) * (N : ℝ) / 2 *
             (((Finset.univ.filter (fun x : V => (! A x) = true)).card : ℝ) * (N : ℝ) / 2 + 1)) := by
   obtain ⟨_, ⟨γ_A, hγ_A⟩, ⟨γ_B, hγ_B⟩⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos
+        hH
   have hne := tasaki23_marshallPositive_magSectorEmbedding_ne_zero A hv_pos
   exact ⟨⟨γ_A, hγ_A, sublatticeSpinSquaredS_eigenvalue_re_le_sA A hne hγ_A⟩,
     ⟨γ_B, hγ_B, sublatticeSpinSquaredS_eigenvalue_re_le_sA (fun x => ! A x) hne hγ_B⟩⟩

--- a/LatticeSystem/Quantum/SpinS/Theorem23ToyWitness.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23ToyWitness.lean
@@ -74,15 +74,18 @@ theorem tasaki23_toy_groundState_casimir_eq_predicted_of_energy_le
   have hΨ_ne : Ψ ≠ 0 := tasaki23_marshallPositive_magSectorEmbedding_ne_zero A hv_pos
   -- Joint Casimir eigenvector (#3657): total and sublattice eigen-equations.
   obtain ⟨⟨γ_tot, htot⟩, _, _⟩ :=
-    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_joint_casimir_eigenvector_legacy A N c hc_strict h_intermediate hv_pos
+        hH
   -- Sublattice Casimir bounds (#3677).
   obtain ⟨⟨γ_A, hA_eq, hA_bd⟩, ⟨γ_B, hB_eq, hB_bd⟩⟩ :=
-    tasaki23_toy_groundState_sublattice_casimir_re_le_legacy A N c hc_strict h_intermediate hv_pos hH
+    tasaki23_toy_groundState_sublattice_casimir_re_le_legacy A N c hc_strict h_intermediate hv_pos
+        hH
   -- Toy energy formula (#3673): Ĥ_toy Ψ = (γ_tot − γ_A − γ_B) • Ψ.
   have hEnergy := heisenbergToyHamiltonianS_mulVec_of_joint_casimir_eigenvector A htot hA_eq hB_eq
   -- Ĥ_toy = heisenbergHamiltonianS (bipartiteCoupling A); so μ = γ_tot − γ_A − γ_B.
   have hμ_eq : (γ_tot - γ_A - γ_B) = (μ : ℂ) := by
-    have hHtoy : heisenbergToyHamiltonianS (Λ := V) A N = heisenbergHamiltonianS (bipartiteCoupling A) N :=
+    have hHtoy : heisenbergToyHamiltonianS (Λ := V) A N = heisenbergHamiltonianS (bipartiteCoupling
+        A) N :=
       rfl
     rw [hHtoy] at hEnergy
     have hcombine : (γ_tot - γ_A - γ_B) • Ψ = (μ : ℂ) • Ψ := hEnergy.symm.trans hH


### PR DESCRIPTION
Tracked in #4569.

## Summary

Wraps all remaining long-line warnings — code lines and single-line `/-- … -/`
doc-comments — at sensible break points (≤100 codepoints), code continuations
indented under their head. **Completes the long-line category: 266 → 0.**

## Build-speed evaluation

Formatting only (line wrapping); no code semantics / import-DAG / elaboration-time
change. Full rebuild clean, 0 errors, 0 long-line warnings.

## Verification

- Full `lake build` rebuild: 0 errors; 0 long-line warnings remain (was 70).

Remaining warning categories: 83 unused-hypothesis, 57 deprecated `_legacy`,
2 empty-line (on legacy decls, cleared with the legacy PR).