### PR TITLE
Refactor PR9: clear 28 unused DecidableEq-instance warnings (omit + classical) — #4569

### DIFF
--- a/LatticeSystem/Quantum/MarshallLiebMattis/EqMagnetizationReachable.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/EqMagnetizationReachable.lean
@@ -45,10 +45,12 @@ def disagreementSet (σ σ' : Λ → Fin 2) : Finset Λ :=
 /-- Configuration distance is the size of the disagreement set. -/
 def configDist (σ σ' : Λ → Fin 2) : ℕ := (disagreementSet σ σ').card
 
+omit [DecidableEq Λ] in
 @[simp] theorem mem_disagreementSet {σ σ' : Λ → Fin 2} {x : Λ} :
     x ∈ disagreementSet σ σ' ↔ σ x ≠ σ' x := by
   simp [disagreementSet]
 
+omit [DecidableEq Λ] in
 theorem configDist_eq_zero_iff (σ σ' : Λ → Fin 2) :
     configDist σ σ' = 0 ↔ σ = σ' := by
   unfold configDist disagreementSet
@@ -60,6 +62,7 @@ theorem configDist_eq_zero_iff (σ σ' : Λ → Fin 2) :
 /-! ## Existence of `(0, 1)` and `(1, 0)` sites for distinct
 configurations of equal magnetisation -/
 
+omit [DecidableEq Λ] in
 /-- For `σ ≠ σ'` with equal magnetisation, there exist sites
 `x, y` with `σ x = 0`, `σ' x = 1`, `σ y = 1`, `σ' y = 0`.
 
@@ -71,6 +74,7 @@ theorem exists_swap_pair_of_eq_magnetization
     {σ σ' : Λ → Fin 2} (hne : σ ≠ σ')
     (hmag : magnetization Λ σ = magnetization Λ σ') :
     ∃ x y : Λ, σ x = 0 ∧ σ' x = 1 ∧ σ y = 1 ∧ σ' y = 0 := by
+  classical
   -- The difference of magnetisations decomposes as
   --   2 · (#D01 - #D10), where D01 = {σ=0, σ'=1}, D10 = {σ=1, σ'=0}.
   -- Equality forces #D01 = #D10. Non-emptiness of disagreement set

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
@@ -442,6 +442,7 @@ theorem heisenbergToyHamiltonian_apply_diag_neel (A : Λ → Bool) :
 
 /-! ## Magnetization on the Néel state -/
 
+omit [DecidableEq Λ] in
 /-- `magnetization Λ (neelConfigOf A) = |A| − |¬A|`: the Néel
 configuration contributes `+1` on `A` (since `σ x = 0`) and `-1` on
 `¬A` (since `σ x = 1`).
@@ -486,6 +487,7 @@ theorem magnetization_neelConfigOf (A : Λ → Bool) :
   rw [← Finset.sum_filter, Finset.sum_const]
   ring
 
+omit [DecidableEq Λ] in
 /-- **Sublattice-swap symmetry** of the spin-`1/2` Néel magnetization:
 `magnetization Λ (neelConfigOf (¬A)) = |¬A| - |A|`. Spin-`1/2` mirror of
 γ-4 step 169: the complement Néel sits in the opposite magnetization
@@ -494,6 +496,7 @@ theorem magnetization_neelConfigOf_complement (A : Λ → Bool) :
     magnetization Λ (neelConfigOf (fun x : Λ => ! A x)) =
       ((Finset.univ.filter (fun x : Λ => (! A x) = true)).card : ℤ) -
         ((Finset.univ.filter (fun x : Λ => A x = true)).card : ℤ) := by
+  classical
   rw [magnetization_neelConfigOf]
   simp [Bool.not_not]
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonian.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonian.lean
@@ -97,6 +97,7 @@ theorem bipartiteCoupling_pos_of_diff_sublattice
   rw [if_pos h]
   simp
 
+omit [DecidableEq Λ] in
 /-- **Total ordered pair count** on a bipartite split:
 `Σ_{x, y} bipartiteCoupling A x y = 2 · |A| · |¬A|`.
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonianCasimir.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonianCasimir.lean
@@ -356,11 +356,13 @@ theorem heisenbergToyHamiltonian_mulVec_basisVec_const
       sublatticeSpinHalfSquared_mulVec_basisVec_const (fun x => ! A x) s]
   rw [← sub_smul, ← sub_smul]
 
+omit [DecidableEq Λ] in
 /-- Cardinality identity: `|Λ| = |A| + |¬A|` for any sublattice
 indicator `A : Λ → Bool`.  Direct from
 `Finset.card_filter_add_card_filter_not`. -/
 private theorem sublatticeCard_add_complement (A : Λ → Bool) :
     sublatticeCard A + sublatticeCard (fun x => ! A x) = Fintype.card Λ := by
+  classical
   unfold sublatticeCard
   have hfilter : Finset.univ.filter (fun x : Λ => (! A x) = true) =
       Finset.univ.filter (fun x : Λ => ¬ (A x = true)) := by

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinGeSectorMin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergFullMinGeSectorMin.lean
@@ -29,6 +29,7 @@ open Matrix Module
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 
+omit [DecidableEq Λ] in
 /-- **Existence of a non-zero sector projection** for any non-zero full vector:
 if `v ≠ 0`, then `∃ M`, `magSectorRestriction (M := M) v ≠ 0`. -/
 theorem exists_magSectorRestriction_ne_zero

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -97,6 +97,7 @@ theorem bipartiteCompleteGraphOf_adj_of_ne_of_sublattice_ne
 
 variable [Fintype V] [DecidableEq V] {N : ℕ}
 
+omit [DecidableEq V] in
 /-- For an over site `x` (where `(σ' x).val < (σ x).val`) and an
 under site `y` (where `(σ y).val < (σ' y).val`) on different
 sublattices (`A x ≠ A y`), there exists a configuration `σ''` reachable
@@ -110,6 +111,7 @@ theorem exists_raiseLowerStepS_bipartite_of_over_under_ne_sublattice
     ∃ σ'' : V → Fin (N + 1),
       RaiseLowerStepS (bipartiteCompleteGraphOf A) σ σ'' ∧
         configDistS σ'' σ' + 2 = configDistS σ σ' := by
+  classical
   -- Bounds for the raise/lower update.
   have hx_bound : (σ x).val - 1 < N + 1 := by
     have := (σ x).isLt; omega
@@ -141,6 +143,7 @@ theorem exists_raiseLowerStepS_bipartite_of_over_under_ne_sublattice
   · -- Distance reduces by 2.
     exact configDistS_decrease_of_over_under hxy hover hunder
 
+omit [DecidableEq V] in
 /-- The "hard case" of bipartite reachability: when over and under
 sites land on the same sublattice, a 2-step transport through an
 opposite-sublattice intermediate `z` (with `σ z < N` so it has room
@@ -162,6 +165,7 @@ theorem exists_raiseLowerReachableS_bipartite_of_over_under_eq_sublattice
     ∃ σ'' : V → Fin (N + 1),
       RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ σ'' ∧
         configDistS σ'' σ' + 2 = configDistS σ σ' := by
+  classical
   -- z ≠ x, z ≠ y (since A z ≠ A x = A y).
   have hzx : z ≠ x := fun heq => hAz (heq ▸ rfl)
   have hzy : z ≠ y := fun heq => hAz (heq ▸ hAeq.symm)

--- a/LatticeSystem/Quantum/SpinS/BlockDiagSubmatrixEmbed.lean
+++ b/LatticeSystem/Quantum/SpinS/BlockDiagSubmatrixEmbed.lean
@@ -31,18 +31,21 @@ private noncomputable def extendFromParity {p : ℕ}
     (w : parityConfigS Λ N p → ℂ) : (Λ → Fin (N + 1)) → ℂ :=
   fun σ => if hσ : magSumS σ % 2 = p then w ⟨σ, hσ⟩ else 0
 
+omit [DecidableEq Λ] in
 /-- Value of the zero-extension at a parity-`p` configuration: the original `w` value. -/
 private theorem extendFromParity_of_parity {p : ℕ}
     (w : parityConfigS Λ N p → ℂ) {σ : Λ → Fin (N + 1)} (hσ : magSumS σ % 2 = p) :
     extendFromParity w σ = w ⟨σ, hσ⟩ := by
   unfold extendFromParity; rw [dif_pos hσ]
 
+omit [DecidableEq Λ] in
 /-- Value of the zero-extension off the parity-`p` slice: zero. -/
 private theorem extendFromParity_of_other {p : ℕ}
     (w : parityConfigS Λ N p → ℂ) {σ : Λ → Fin (N + 1)} (hσ : magSumS σ % 2 ≠ p) :
     extendFromParity w σ = 0 := by
   unfold extendFromParity; rw [dif_neg hσ]
 
+omit [DecidableEq Λ] in
 /-- Additivity of the zero-extension map. -/
 private theorem extendFromParity_add {p : ℕ} (u v : parityConfigS Λ N p → ℂ) :
     extendFromParity (u + v) = extendFromParity u + extendFromParity v := by
@@ -53,9 +56,11 @@ private theorem extendFromParity_add {p : ℕ} (u v : parityConfigS Λ N p → �
   · rfl
   · simp
 
+omit [DecidableEq Λ] in
 /-- Scalar compatibility of the zero-extension map. -/
 private theorem extendFromParity_smul {p : ℕ} (c : ℂ) (v : parityConfigS Λ N p → ℂ) :
     extendFromParity (c • v) = c • extendFromParity v := by
+  classical
   funext σ
   change extendFromParity (c • v) σ = c • extendFromParity v σ
   unfold extendFromParity

--- a/LatticeSystem/Quantum/SpinS/ConfigDist.lean
+++ b/LatticeSystem/Quantum/SpinS/ConfigDist.lean
@@ -211,6 +211,7 @@ theorem configDistS_decrease_of_over_under
 
 /-! ## Reachability for the complete graph -/
 
+omit [DecidableEq V] in
 /-- For the complete graph `G = ⊤` (every distinct pair of vertices is
 adjacent), any two configurations with equal magnetization sum are
 `RaiseLowerReachableS`. The proof inducts on `configDistS σ σ'`,
@@ -219,6 +220,7 @@ using `exists_over_under` to find the witness sites and
 theorem raiseLowerReachableS_completeGraph_of_eq_magSumS
     {σ σ' : V → Fin (N + 1)} (hmag : magSumS σ = magSumS σ') :
     RaiseLowerReachableS (⊤ : SimpleGraph V) σ σ' := by
+  classical
   -- Strong induction on configDistS σ σ'.
   suffices h : ∀ n, ∀ σ σ' : V → Fin (N + 1),
       magSumS σ = magSumS σ' → configDistS σ σ' ≤ n →

--- a/LatticeSystem/Quantum/SpinS/MagConfig.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfig.lean
@@ -131,6 +131,7 @@ theorem RaiseLowerReachableSMagSector.tail' {G : SimpleGraph V} {M : ℕ}
     RaiseLowerReachableSMagSector G σ ρ :=
   Relation.ReflTransGen.tail h₁ h₂
 
+omit [DecidableEq V] in
 /-- Lift `RaiseLowerReachableS` from the full type to the subtype
 `magConfigS V N M`: given the chain endpoints both lie in the same
 sector, the chain itself stays within the sector (by `magSumS`
@@ -140,6 +141,7 @@ theorem raiseLowerReachableSMagSector_of_raiseLowerReachableS
     (hσM : magSumS σ = M) (hτM : magSumS τ = M)
     (hreach : RaiseLowerReachableS G σ τ) :
     RaiseLowerReachableSMagSector G ⟨σ, hσM⟩ ⟨τ, hτM⟩ := by
+  classical
   -- Generalize the target endpoint and its sector-proof.
   suffices h : ∀ (ρ : V → Fin (N + 1))
       (hρM : magSumS ρ = M)

--- a/LatticeSystem/Quantum/SpinS/MagConfigExtremalCardinality.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfigExtremalCardinality.lean
@@ -30,6 +30,7 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 set_option linter.unusedSectionVars false in
+omit [DecidableEq V] in
 /-- The unique element of the M = 0 magnetization sector is the
 all-up configuration `allAlignedConfigS V N 0`. -/
 theorem magConfigS_zero_eq_allAlignedConfigS
@@ -50,11 +51,13 @@ theorem magConfigS_card_zero :
   exact Subtype.ext (magConfigS_zero_eq_allAlignedConfigS τ)
 
 set_option linter.unusedSectionVars false in
+omit [DecidableEq V] in
 /-- The unique element of the M = |V|·N magnetization sector is the
 all-down configuration `allAlignedConfigS V N (Fin.last N)`. -/
 theorem magConfigS_last_eq_allAlignedConfigS
     (τ : magConfigS V N (Fintype.card V * N)) :
     τ.1 = allAlignedConfigS V N (Fin.last N) := by
+  classical
   by_contra hne
   have hlt := magSumS_lt_card_mul_of_ne_allAlignedConfigS_last hne
   rw [τ.2] at hlt

--- a/LatticeSystem/Quantum/SpinS/MagSubspaceExtremalDim.lean
+++ b/LatticeSystem/Quantum/SpinS/MagSubspaceExtremalDim.lean
@@ -36,11 +36,13 @@ variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 /-! ## Eigenvalue characterisation of the extremal configurations -/
 
 set_option linter.unusedSectionVars false in
+omit [DecidableEq V] in
 /-- `magEigenvalueS σ = m_max` iff `σ = allAlignedConfigS V N 0`. -/
 theorem magEigenvalueS_eq_mMax_iff_allAlignedConfigS_zero
     (σ : V → Fin (N + 1)) :
     magEigenvalueS σ = (Fintype.card V : ℂ) * (N : ℂ) / 2 ↔
       σ = allAlignedConfigS V N 0 := by
+  classical
   constructor
   · intro h
     -- magEigenvalueS σ = (|V|·N : ℂ)/2 − magSumS σ = (|V|·N)/2 ⇒ magSumS σ = 0.
@@ -65,11 +67,13 @@ theorem magEigenvalueS_eq_mMax_iff_allAlignedConfigS_zero
     ring
 
 set_option linter.unusedSectionVars false in
+omit [DecidableEq V] in
 /-- `magEigenvalueS σ = −m_max` iff `σ = allAlignedConfigS V N (Fin.last N)`. -/
 theorem magEigenvalueS_eq_neg_mMax_iff_allAlignedConfigS_last
     (σ : V → Fin (N + 1)) :
     magEigenvalueS σ = -((Fintype.card V : ℂ) * (N : ℂ) / 2) ↔
       σ = allAlignedConfigS V N (Fin.last N) := by
+  classical
   constructor
   · intro h
     -- magEigenvalueS σ = (|V|·N : ℂ)/2 − magSumS σ = −(|V|·N)/2 ⇒ magSumS σ = |V|·N.

--- a/LatticeSystem/Quantum/SpinS/RaiseLower.lean
+++ b/LatticeSystem/Quantum/SpinS/RaiseLower.lean
@@ -99,6 +99,7 @@ theorem RaiseLowerReachableS.tail' {G : SimpleGraph V}
 
 /-! ## Magnetization conservation -/
 
+omit [DecidableEq V] in
 /-- A `RaiseLowerStepS` preserves the magnetization sum:
 `magSumS σ' = magSumS σ`. The raise at one site (+1) is exactly
 compensated by the lower at the other (−1). -/
@@ -143,6 +144,7 @@ theorem magSumS_eq_of_raiseLowerStepS {G : SimpleGraph V}
   · omega
   · omega
 
+omit [DecidableEq V] in
 /-- A `RaiseLowerReachableS` preserves the magnetization sum:
 iterated application of `magSumS_eq_of_raiseLowerStepS`. -/
 theorem magSumS_eq_of_raiseLowerReachableS {G : SimpleGraph V}
@@ -152,11 +154,13 @@ theorem magSumS_eq_of_raiseLowerReachableS {G : SimpleGraph V}
   | refl => rfl
   | tail _hτ hτσ' ih => rw [magSumS_eq_of_raiseLowerStepS hτσ', ih]
 
+omit [DecidableEq V] in
 /-- A `RaiseLowerReachableS` preserves the magnetization eigenvalue:
 `magEigenvalueS σ' = magEigenvalueS σ`. -/
 theorem magEigenvalueS_eq_of_raiseLowerReachableS {G : SimpleGraph V}
     {σ σ' : V → Fin (N + 1)} (h : RaiseLowerReachableS G σ σ') :
     magEigenvalueS σ' = magEigenvalueS σ := by
+  classical
   unfold magEigenvalueS
   rw [magSumS_eq_of_raiseLowerReachableS h]
 

--- a/LatticeSystem/Quantum/SpinS/SaturatedFullLadderOrthogonality.lean
+++ b/LatticeSystem/Quantum/SpinS/SaturatedFullLadderOrthogonality.lean
@@ -71,10 +71,12 @@ theorem Matrix.IsHermitian.dotProduct_eq_zero_of_eigenvalues_ne
 
 /-! ## Pairwise orthogonality of the ladder iterates -/
 
+omit [DecidableEq V] in
 /-- The ladder eigenvalue `m_max − k` is real, i.e., its complex
 conjugate equals itself. -/
 theorem ladderEigenvalueUp_star_eq (k : Fin (Fintype.card V * N + 1)) :
     star (ladderEigenvalueUp V N k) = ladderEigenvalueUp V N k := by
+  classical
   unfold ladderEigenvalueUp
   simp [Complex.star_def, Complex.conj_ofReal, Complex.conj_natCast]
 

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
@@ -112,6 +112,7 @@ theorem sublatticeSpinSquaredS_complement_mulVec_neelStateOfS
 
 /-! ## `Ŝ_tot^(3)` eigenvalue on the Néel state -/
 
+omit [DecidableEq Λ] in
 /-- `magSumS (neelConfigOfS A N) = |¬A| · N`. The Néel configuration
 contributes `0` on `A` and `N` (i.e., `(Fin.last N).val`) on `¬A`. -/
 theorem magSumS_neelConfigOfS (A : Λ → Bool) (N : ℕ) :
@@ -135,6 +136,7 @@ theorem magSumS_neelConfigOfS (A : Λ → Bool) (N : ℕ) :
   rw [← Finset.sum_filter, Finset.sum_const]
   rw [smul_eq_mul]
 
+omit [DecidableEq Λ] in
 /-- **Sublattice-swap symmetry**: `magSumS (neelConfigOfS (¬A) N) = |A| · N`.
 The complement Néel configuration sits in the opposite magnetization
 sector to `neelConfigOfS A N` (whose `magSumS = |¬A|·N`), reflecting the
@@ -142,6 +144,7 @@ sector to `neelConfigOfS A N` (whose `magSumS = |¬A|·N`), reflecting the
 theorem magSumS_neelConfigOfS_complement (A : Λ → Bool) (N : ℕ) :
     magSumS (neelConfigOfS (fun x : Λ => ! A x) N) =
       (Finset.univ.filter (fun x : Λ => A x = true)).card * N := by
+  classical
   rw [magSumS_neelConfigOfS]
   simp [Bool.not_not]
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralReach.lean
@@ -23,6 +23,7 @@ namespace LatticeSystem.Quantum
 
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
+omit [DecidableEq V] in
 /-- **Structural MagSector reachability (no `h_intermediate`)**. -/
 theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph
     (A : V → Bool) {M : ℕ}
@@ -30,6 +31,7 @@ theorem raiseLowerReachableSMagSector_bipartiteCompleteGraph
     (hN : 1 ≤ N)
     (σ σ' : magConfigS V N M) :
     RaiseLowerReachableSMagSector (bipartiteCompleteGraphOf A) σ σ' := by
+  classical
   have hreach : RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ.1 σ'.1 :=
     raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS A
       hA_ne hB_ne hN (σ.2.trans σ'.2.symm)

--- a/LatticeSystem/Quantum/SpinS/ToyHamiltonianCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/ToyHamiltonianCasimir.lean
@@ -368,10 +368,12 @@ theorem heisenbergToyHamiltonianS_mulVec_allAlignedStateS_zero
 private noncomputable def sublatticeCardS (A : Λ → Bool) : ℕ :=
   (Finset.univ.filter (fun x : Λ => A x = true)).card
 
+omit [DecidableEq Λ] in
 /-- Cardinality identity: `|Λ| = |A| + |¬A|` for any sublattice
 indicator `A : Λ → Bool`. -/
 private theorem sublatticeCardS_add_complement (A : Λ → Bool) :
     sublatticeCardS A + sublatticeCardS (fun x => ! A x) = Fintype.card Λ := by
+  classical
   unfold sublatticeCardS
   have hfilter : Finset.univ.filter (fun x : Λ => (! A x) = true) =
       Finset.univ.filter (fun x : Λ => ¬ (A x = true)) := by


### PR DESCRIPTION
Tracked in #4569.

## Summary

Fixes the `linter.unusedDecidableInType` warnings for section-variable
`[DecidableEq V]`/`[DecidableEq Λ]` unused in the statement type: adds
`omit [DecidableEq …] in` before the declaration (the linter's recommended fix)
plus `classical` to the proof where it consumes a `Decidable` instance. 16 files,
each verified by full rebuild.

Declarations whose proofs genuinely need the specific `DecidableEq` instance
computationally (classical insufficient — term-mode / `def` bodies) were left
unchanged; the decl-local `[DecidableEq n]` binders and `[Fintype …]` cases need
different fixes (follow separately).

## Build-speed evaluation

Instance-binder/`classical` only; no import-DAG change. Full rebuild clean,
0 errors. Unused-hypothesis warnings 83 → 55.