### PR TITLE
Refactor PR10: clear 37 unused Fintype/DecidableEq-instance warnings (omit) — #4569

### DIFF
--- a/LatticeSystem/Quantum/MarshallLiebMattis/Connectivity.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/Connectivity.lean
@@ -65,24 +65,29 @@ relation containing `SwapStep G` that is reflexive and transitive. -/
 def SwapReachable (G : SimpleGraph Λ) : (Λ → Fin 2) → (Λ → Fin 2) → Prop :=
   Relation.ReflTransGen (SwapStep G)
 
+omit [Fintype Λ] in
 theorem SwapReachable.refl (G : SimpleGraph Λ) (σ : Λ → Fin 2) :
     SwapReachable G σ σ :=
   Relation.ReflTransGen.refl
 
+omit [Fintype Λ] in
 theorem SwapReachable.single (G : SimpleGraph Λ) {σ σ' : Λ → Fin 2}
     (h : SwapStep G σ σ') : SwapReachable G σ σ' :=
   Relation.ReflTransGen.single h
 
+omit [Fintype Λ] in
 theorem SwapReachable.trans {G : SimpleGraph Λ} {σ τ σ' : Λ → Fin 2}
     (h₁ : SwapReachable G σ τ) (h₂ : SwapReachable G τ σ') :
     SwapReachable G σ σ' :=
   Relation.ReflTransGen.trans h₁ h₂
 
+omit [Fintype Λ] in
 theorem SwapReachable.tail' {G : SimpleGraph Λ} {σ τ σ' : Λ → Fin 2}
     (h₁ : SwapReachable G σ τ) (h₂ : SwapStep G τ σ') :
     SwapReachable G σ σ' :=
   Relation.ReflTransGen.tail h₁ h₂
 
+omit [Fintype Λ] in
 /-- Single-edge case: a direct `SwapStep` is a `SwapReachable`. -/
 theorem SwapReachable.of_step {G : SimpleGraph Λ}
     {σ σ' : Λ → Fin 2} (h : SwapStep G σ σ') :
@@ -91,6 +96,7 @@ theorem SwapReachable.of_step {G : SimpleGraph Λ}
 
 /-! ## Walk-based connectivity -/
 
+omit [Fintype Λ] in
 /-- Helper: `basisSwap` agrees with the underlying configuration off
 `{x, y}`. -/
 private theorem basisSwap_off_xy {x y : Λ} (σ : Λ → Fin 2)
@@ -99,12 +105,14 @@ private theorem basisSwap_off_xy {x y : Λ} (σ : Λ → Fin 2)
   unfold basisSwap
   rw [Function.update_of_ne hzy, Function.update_of_ne hzx]
 
+omit [Fintype Λ] in
 /-- Helper: `basisSwap σ x y` at site `x` equals `σ y`. -/
 private theorem basisSwap_at_x {x y : Λ} (hxy : x ≠ y) (σ : Λ → Fin 2) :
     basisSwap σ x y x = σ y := by
   unfold basisSwap
   rw [Function.update_of_ne hxy, Function.update_self]
 
+omit [Fintype Λ] in
 /-- Helper: `basisSwap σ x y` at site `y` equals `σ x`. -/
 private theorem basisSwap_at_y {x y : Λ} (σ : Λ → Fin 2) :
     basisSwap σ x y y = σ x := by
@@ -117,6 +125,7 @@ private theorem fin2_eq_of_both_ne {s t u : Fin 2} (h₁ : s ≠ t) (h₂ : s �
   fin_cases s <;> fin_cases t <;> fin_cases u <;>
     first | rfl | (exact absurd rfl h₁) | (exact absurd rfl h₂)
 
+omit [Fintype Λ] in
 /-- **Key lemma (Tasaki p. 41).** If `G.Walk x y` exists and
 `σ x ≠ σ y`, then `σ` and `basisSwap σ x y` are `SwapReachable`.
 
@@ -231,6 +240,7 @@ theorem swapReachable_of_walk_of_ne
                 rw [basisSwap_off_xy σ hzu hzv]
         rw [← hgoal]; exact hcomb
 
+omit [Fintype Λ] in
 /-- **Property (iii) ingredient.** For a connected graph `G`, any
 two distinct vertices `x, y ∈ Λ` with `σ x ≠ σ y` admit a swap
 chain reaching `basisSwap σ x y`. -/
@@ -241,6 +251,7 @@ theorem swapReachable_of_reachable_of_ne
   obtain ⟨w⟩ := hxy_reach
   exact swapReachable_of_walk_of_ne w h
 
+omit [Fintype Λ] in
 /-- For a preconnected graph, the swap-reachability holds for any
 `x, y` with `σ x ≠ σ y`. -/
 theorem swapReachable_of_preconnected_of_ne

--- a/LatticeSystem/Quantum/MarshallLiebMattis/HeisenbergSwapEntry.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/HeisenbergSwapEntry.lean
@@ -34,6 +34,7 @@ open Matrix
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 
+omit [Fintype Λ] in
 /-- For `σ' = basisSwap σ x y` (with `x ≠ y`, `σ_x ≠ σ_y`) and any
 `u ≠ v`, if `{u, v} ≠ {x, y}` (encoded as the negation of "ordered
 match" with both orientations), then `basisSwap σ' u v ≠ σ`.

--- a/LatticeSystem/Quantum/MarshallLiebMattis/HeisenbergSwapValue.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/HeisenbergSwapValue.lean
@@ -31,6 +31,7 @@ open Matrix
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 
+omit [Fintype Λ] in
 /-- `basisSwap` is symmetric in the two site arguments:
 `basisSwap σ x y = basisSwap σ y x`. -/
 private theorem basisSwap_swap_args (σ : Λ → Fin 2) {x y : Λ} (hxy : x ≠ y) :

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeCasimirNeel.lean
@@ -500,6 +500,7 @@ theorem magnetization_neelConfigOf_complement (A : Λ → Bool) :
   rw [magnetization_neelConfigOf]
   simp [Bool.not_not]
 
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- The spin-`1/2` Néel configuration `neelConfigOf A` is distinct from
 its sublattice-complement `neelConfigOf (¬A)` (as functions `Λ → Fin 2`)
 when `Λ` is non-empty: at any vertex `x` the swap exchanges `0 ↔ 1`,
@@ -507,6 +508,7 @@ witnessing the inequality. Spin-`1/2` mirror of γ-4 step 171's
 distinctness witness. -/
 theorem neelConfigOf_ne_complement [Nonempty Λ] (A : Λ → Bool) :
     neelConfigOf A ≠ neelConfigOf (fun x : Λ => ! A x) := by
+  classical
   obtain ⟨x⟩ := ‹Nonempty Λ›
   intro h
   have hx := congr_fun h x

--- a/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonian.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/ToyHamiltonian.lean
@@ -52,14 +52,17 @@ This is the (unnormalised) coupling for the MLM toy Hamiltonian
 noncomputable def bipartiteCoupling (A : Λ → Bool) : Λ → Λ → ℂ :=
   fun x y => if A x ≠ A y then 1 else 0
 
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- The bipartite coupling is real (no imaginary part). -/
 theorem bipartiteCoupling_im (A : Λ → Bool) (x y : Λ) :
     (bipartiteCoupling A x y).im = 0 := by
+  classical
   unfold bipartiteCoupling
   by_cases h : A x ≠ A y
   · rw [if_pos h]; simp
   · rw [if_neg h]; simp
 
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- The bipartite coupling is symmetric: `J(x, y) = J(y, x)`. -/
 theorem bipartiteCoupling_symm (A : Λ → Bool) (x y : Λ) :
     bipartiteCoupling A x y = bipartiteCoupling A y x := by
@@ -70,6 +73,7 @@ theorem bipartiteCoupling_symm (A : Λ → Bool) (x y : Λ) :
     push Not at h
     rw [if_neg (by push Not; exact h.symm)]
 
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- The bipartite coupling is non-negative: `0 ≤ (J(x, y)).re`. -/
 theorem bipartiteCoupling_nonneg (A : Λ → Bool) (x y : Λ) :
     0 ≤ (bipartiteCoupling A x y).re := by
@@ -78,16 +82,19 @@ theorem bipartiteCoupling_nonneg (A : Λ → Bool) (x y : Λ) :
   · rw [if_pos h]; simp
   · rw [if_neg h]; simp
 
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- The bipartite coupling vanishes on intra-sublattice pairs:
 `A x = A y → J(x, y) = 0`. -/
 theorem bipartiteCoupling_eq_zero_of_same_sublattice
     (A : Λ → Bool) {x y : Λ} (h : A x = A y) :
     bipartiteCoupling A x y = 0 := by
+  classical
   unfold bipartiteCoupling
   rw [if_neg]
   push Not
   exact h
 
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- The bipartite coupling is positive on inter-sublattice pairs:
 `A x ≠ A y → 0 < (J(x, y)).re`. -/
 theorem bipartiteCoupling_pos_of_diff_sublattice

--- a/LatticeSystem/Quantum/MarshallLiebMattis/ToyPF.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/ToyPF.lean
@@ -33,6 +33,7 @@ open Matrix
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- The bipartite coupling and bipartite graph are mutually
 consistent: bipartiteGraphFromA-edges coincide with positive
 bipartiteCoupling. -/
@@ -44,10 +45,12 @@ private theorem bipartite_pos_on_graph (A : Λ → Bool) :
   exact bipartiteCoupling_pos_of_diff_sublattice A hadj
 
 set_option linter.unusedSectionVars false in
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- The bipartite graph is bipartite-respecting: each edge crosses
 the sublattice partition. -/
 private theorem bipartite_graph_bipartite (A : Λ → Bool) :
     ∀ {x y : Λ}, (bipartiteGraphFromA A).Adj x y → A x ≠ A y := by
+  classical
   intro x y hadj
   rwa [bipartiteGraphFromA_adj] at hadj
 

--- a/LatticeSystem/Quantum/SpinS/AllAlignedStateDistinct.lean
+++ b/LatticeSystem/Quantum/SpinS/AllAlignedStateDistinct.lean
@@ -25,10 +25,12 @@ namespace LatticeSystem.Quantum
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 set_option linter.unusedSectionVars false in
+omit [DecidableEq V] [Fintype V] in
 /-- `allAlignedConfigS V N c₁ ≠ allAlignedConfigS V N c₂` when
 `c₁ ≠ c₂` and `V` is non-empty. -/
 theorem allAlignedConfigS_injective [Nonempty V] :
     Function.Injective (allAlignedConfigS V N) := by
+  classical
   intros c₁ c₂ h
   obtain ⟨x⟩ := ‹Nonempty V›
   exact congrFun h x

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -342,6 +342,7 @@ theorem raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy
 /-! ## Preconnectedness of `bipartiteCompleteGraphOf` -/
 
 set_option linter.unusedSectionVars false in
+omit [DecidableEq V] [Fintype V] in
 /-- The bipartite-complete graph `bipartiteCompleteGraphOf A` is
 preconnected when both sublattices are non-empty. Any two `x, y ∈ V`
 are joined by a walk of length ≤ 2:
@@ -356,6 +357,7 @@ theorem bipartiteCompleteGraphOf_preconnected
     (A : V → Bool)
     (hA_pos : ∃ x : V, A x = true) (hA_neg : ∃ y : V, A y = false) :
     (bipartiteCompleteGraphOf A).Preconnected := by
+  classical
   intro x y
   by_cases hAxy : A x = A y
   · -- Same sublattice: pick a vertex in the opposite sublattice.

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
@@ -148,6 +148,7 @@ theorem magSumS_neelConfigOfS_complement (A : Λ → Bool) (N : ℕ) :
   rw [magSumS_neelConfigOfS]
   simp [Bool.not_not]
 
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- The Néel configuration `neelConfigOfS A N` is distinct from its
 sublattice-complement `neelConfigOfS (¬A) N` (as functions `Λ → Fin (N+1)`)
 when `Λ` is non-empty and `0 < N`: at any vertex `x`, the swap takes
@@ -155,6 +156,7 @@ when `Λ` is non-empty and `0 < N`: at any vertex `x`, the swap takes
 theorem neelConfigOfS_ne_complement [Nonempty Λ] (A : Λ → Bool) (N : ℕ)
     (hN : 0 < N) :
     neelConfigOfS A N ≠ neelConfigOfS (fun x : Λ => ! A x) N := by
+  classical
   obtain ⟨x⟩ := ‹Nonempty Λ›
   intro h
   have hx := congr_fun h x
@@ -230,12 +232,14 @@ theorem totalSpinSOp3_mulVec_neelStateOfS (A : Λ → Bool) (N : ℕ) :
 
 /-! ## Néel config under sublattice swap -/
 
+omit [DecidableEq Λ] [Fintype Λ] in
 /-- `neelConfigOfS (¬A) N` is the "swapped" Néel configuration: `σ x = N`
 for `A x = true` (i.e., on `A`) and `σ x = 0` for `A x = false` (on `¬A`).
 This is the natural sublattice-swap dual of `neelConfigOfS A N`. -/
 theorem neelConfigOfS_complement (A : Λ → Bool) (N : ℕ) (x : Λ) :
     neelConfigOfS (fun y => ! A y) N x =
       if A x then Fin.last N else 0 := by
+  classical
   unfold neelConfigOfS
   by_cases hA : A x = true
   · simp [hA]


### PR DESCRIPTION
Tracked in #4569.

## Summary

Fixes the `linter.unusedFintypeInType` warnings (and DecidableEq companions on the
same mixed declarations) for section-variable `[Fintype V]`/`[Fintype Λ]` unused
in the statement type: adds `omit [Fintype …] in` (and `classical` where a
co-omitted `DecidableEq` is consumed). All 25 flagged declarations' proofs turned
out not to need the `Fintype` instance, so the omits are clean. 9 files.

## Build-speed evaluation

Instance-binder only; no import-DAG change. Full rebuild clean, 0 errors.
Unused-hypothesis warnings 55 → 18.

Remaining unused-hyp (18): a few `DecidableEq` whose proofs need the specific
instance (term-mode / `def`), and decl-local `[DecidableEq n]` binders — handled
per-decl separately.