### PR TITLE
Refactor PR11: drop unused decl-local DecidableEq binders (3 general lemmas) — #4569

### DIFF
--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapRaiseLowerStrictNeg.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapRaiseLowerStrictNeg.lean
@@ -42,8 +42,9 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 /-- A finite sum of real numbers is strictly negative if every term is non-positive and at least
 one term is strictly negative. -/
 theorem Finset.sum_neg_of_forall_nonpos_of_exists_neg
-    {α : Type*} [DecidableEq α] {s : _root_.Finset α} {f : α → ℝ}
+    {α : Type*} {s : _root_.Finset α} {f : α → ℝ}
     (hnp : ∀ a ∈ s, f a ≤ 0) (hex : ∃ a ∈ s, f a < 0) : ∑ a ∈ s, f a < 0 := by
+  classical
   obtain ⟨a₀, ha₀, hf₀⟩ := hex
   have hrest : ∑ a ∈ s.erase a₀, f a ≤ 0 :=
     _root_.Finset.sum_nonpos (fun a ha => hnp a (_root_.Finset.mem_of_mem_erase ha))

--- a/LatticeSystem/Quantum/SpinS/SaturatedFullLadderOrthogonality.lean
+++ b/LatticeSystem/Quantum/SpinS/SaturatedFullLadderOrthogonality.lean
@@ -43,7 +43,7 @@ eigenvalues are orthogonal in the dot product `star v ⬝ᵥ w`.
 
 The realness assumption is supplied as `star α = α` and `star β = β`. -/
 theorem Matrix.IsHermitian.dotProduct_eq_zero_of_eigenvalues_ne
-    {n : Type*} [Fintype n] [DecidableEq n]
+    {n : Type*} [Fintype n]
     {M : Matrix n n ℂ} (hM : M.IsHermitian)
     {α β : ℂ} (hα : star α = α) (hβ : star β = β)
     {v w : n → ℂ}

--- a/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirPredicted.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirPredicted.lean
@@ -37,7 +37,7 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 /-- **Realness of a Hermitian eigenvalue**: an eigenvalue of a Hermitian
 matrix that has a non-zero eigenvector is fixed by complex conjugation. -/
 theorem isHermitian_eigenvalue_star_eq
-    {n : Type*} [Fintype n] [DecidableEq n]
+    {n : Type*} [Fintype n]
     {A : Matrix n n ℂ} (hA : A.IsHermitian)
     {γ : ℂ} {v : n → ℂ} (hv : A.mulVec v = γ • v) (hv_ne : v ≠ 0) :
     star γ = γ := by


### PR DESCRIPTION
Tracked in #4569.

## Summary

Removes the `[DecidableEq …]` instance binder from three general lemmas whose
statement type does not use it (`linter.unusedDecidableInType`):
`isHermitian_eigenvalue_star_eq`, `Matrix.IsHermitian.dotProduct_eq_zero_of_eigenvalues_ne`
(plain removal), and `Finset.sum_neg_of_forall_nonpos_of_exists_neg` (removal +
`classical`, since its proof uses `Finset.erase`).

## Build-speed evaluation

Binder-only; no import-DAG change. Full rebuild clean, 0 errors.
Unused-hypothesis warnings 18 → 15.

Remaining 15: ~4 on `_legacy` decls (clear with the legacy migration) and decls
whose proofs genuinely consume the section-variable instance.