### PR TITLE
Refactor PR12: clear 3 more unused DecidableEq via omit + classical — #4569

### DIFF
--- a/LatticeSystem/Quantum/SpinS/HermitianMinEigenvalueLipschitz.lean
+++ b/LatticeSystem/Quantum/SpinS/HermitianMinEigenvalueLipschitz.lean
@@ -29,6 +29,7 @@ open Matrix
 
 variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
 
+omit [DecidableEq n] in
 /-- Helper: for Hermitian `A` and `B`, the upper bound
 `rayleighInfMatrix B ≤ rayleighInfMatrix A + Σ ‖(B - A)_{ij}‖`. -/
 theorem rayleighInfMatrix_le_add_sum_entryNorms
@@ -62,11 +63,13 @@ theorem rayleighInfMatrix_le_add_sum_entryNorms
     exact le_ciInf key
   linarith
 
+omit [DecidableEq n] in
 /-- **Lipschitz continuity** of `rayleighInfMatrix` in the entry-norm sum:
 `|rayleighInfMatrix A - rayleighInfMatrix B| ≤ Σ ‖(A - B)_{ij}‖`. -/
 theorem abs_rayleighInfMatrix_sub_le_sum_entryNorms
     {A B : Matrix n n ℂ} (hA : A.IsHermitian) (hB : B.IsHermitian) :
     |rayleighInfMatrix A - rayleighInfMatrix B| ≤ ∑ i, ∑ j, ‖(A - B) i j‖ := by
+  classical
   have hAB := rayleighInfMatrix_le_add_sum_entryNorms (A := A) (B := B) hA
   have hBA := rayleighInfMatrix_le_add_sum_entryNorms (A := B) (B := A) hB
   -- Σ ‖(B - A)_ij‖ = Σ ‖(A - B)_ij‖

--- a/LatticeSystem/Quantum/SpinS/RayleighInfMatrixUpper.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighInfMatrixUpper.lean
@@ -33,10 +33,12 @@ Hermitian `M` this equals `hermitianMinEigenvalue hM` (Rayleigh-Ritz). -/
 noncomputable def rayleighInfMatrix (M : Matrix n n ℂ) : ℝ :=
   ⨅ v : {v : n → ℂ // dotProduct (star v) v = 1}, rayleighOnVec M v.val
 
+omit [DecidableEq n] in
 /-- The matrix-side unit-sphere indexing subtype is nonempty for any Hermitian `M`
 (via the existence of a unit eigenvector). -/
 theorem nonempty_unit_dotProduct_subtype {M : Matrix n n ℂ} (hM : M.IsHermitian) :
     Nonempty {v : n → ℂ // dotProduct (star v) v = 1} := by
+  classical
   obtain ⟨v, hunit, _⟩ := exists_unit_vec_rayleighOnVec_eq_hermitianMinEigenvalue hM
   exact ⟨v, hunit⟩
 


### PR DESCRIPTION
Tracked in #4569.

Clears `linter.unusedDecidableInType` on `RayleighInfMatrixUpper` /
`HermitianMinEigenvalueLipschitz` lemmas via `omit [DecidableEq n] in` +
`classical` (the obtained lemmas synthesize DecidableEq, now supplied by classical).

Build-speed eval: instance-binder/classical only. Full rebuild clean, 0 errors.
Unused-hypothesis warnings 15 → 12.

Remaining 12: ~4 on `_legacy` decls + decls consuming the instance computably
(need per-decl restructuring). Deferred.