### PR TITLE
Refactor (Issue #4569): clear 9 non-legacy unused-DecidableEq-in-type warnings — #4569

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiFlatBandBasisLemma.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiFlatBandBasisLemma.lean
@@ -33,7 +33,7 @@ whole single-electron space — so `{α_p} ∪ {β_u}` is a basis of `h ≅ ℂ^
 Proof: orthogonality makes the two spans disjoint, so
 `finrank (span α ⊔ span β) = finrank (span α) + finrank (span β) = |ιE| + |ιI| = |Λ|`, which equals
 the dimension of the whole space, forcing the join to be everything. -/
-theorem tasaki_lemma_11_10 {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+theorem tasaki_lemma_11_10 {Λ : Type*} [Fintype Λ]
     {ιE ιI : Type*} [Fintype ιE] [Fintype ιI]
     (α : ιE → EuclideanSpace ℂ Λ) (β : ιI → EuclideanSpace ℂ Λ)
     (hα : LinearIndependent ℂ α) (hβ : LinearIndependent ℂ β)

--- a/LatticeSystem/Quantum/SpinS/AxisSwapParityBlock.lean
+++ b/LatticeSystem/Quantum/SpinS/AxisSwapParityBlock.lean
@@ -26,6 +26,7 @@ open Matrix
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
+omit [DecidableEq Λ] in
 /-- For configurations agreeing off `{x, y}`, the global occupation parity matches the local
 `{x, y}` parity. -/
 theorem magSumS_add_parity_eq_of_agree_off_two_site
@@ -33,6 +34,7 @@ theorem magSumS_add_parity_eq_of_agree_off_two_site
     (h : ∀ k, k ≠ x → k ≠ y → σ' k = σ k) :
     (magSumS σ' + magSumS σ) % 2 =
       ((σ' x).val + (σ x).val + ((σ' y).val + (σ y).val)) % 2 := by
+  classical
   have hsum : magSumS σ' + magSumS σ = ∑ k : Λ, ((σ' k).val + (σ k).val) := by
     rw [magSumS_def, magSumS_def, ← Finset.sum_add_distrib]
   rw [hsum,
@@ -48,11 +50,13 @@ theorem magSumS_add_parity_eq_of_agree_off_two_site
   rw [hrest, ← Finset.mul_sum]
   omega
 
+omit [DecidableEq Λ] in
 /-- For configurations agreeing off a single site `x`, the global occupation parity matches the
 local `x` parity. -/
 theorem magSumS_add_parity_eq_of_agree_off_site
     (x : Λ) {σ' σ : Λ → Fin (N + 1)} (h : ∀ k, k ≠ x → σ' k = σ k) :
     (magSumS σ' + magSumS σ) % 2 = ((σ' x).val + (σ x).val) % 2 := by
+  classical
   have hsum : magSumS σ' + magSumS σ = ∑ k : Λ, ((σ' k).val + (σ k).val) := by
     rw [magSumS_def, magSumS_def, ← Finset.sum_add_distrib]
   rw [hsum, ← Finset.add_sum_erase _ (fun k => (σ' k).val + (σ k).val) (Finset.mem_univ x)]

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphAltPath.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphAltPath.lean
@@ -55,7 +55,7 @@ applied to `σ_1` (step 2: x-z edge).
 Mirror of `exists_raiseLowerReachableS_bipartite_of_over_under_eq_sublattice`
 with the `σ z` condition flipped. -/
 theorem exists_raiseLowerReachableS_bipartite_of_over_under_eq_sublattice_alt
-    [Fintype V] [DecidableEq V]
+    [Fintype V]
     {A : V → Bool} {σ σ' : V → Fin (N + 1)}
     {x y : V} (hxy : x ≠ y) (hAeq : A x = A y)
     (hover : (σ' x).val < (σ x).val)
@@ -64,6 +64,7 @@ theorem exists_raiseLowerReachableS_bipartite_of_over_under_eq_sublattice_alt
     ∃ σ'' : V → Fin (N + 1),
       RaiseLowerReachableS (bipartiteCompleteGraphOf A) σ σ'' ∧
         configDistS σ'' σ' + 2 = configDistS σ σ' := by
+  classical
   -- z ≠ x, z ≠ y (since A z ≠ A x = A y).
   have hzx : z ≠ x := fun heq => hAz (heq ▸ rfl)
   have hzy : z ≠ y := fun heq => hAz (heq ▸ hAeq.symm)

--- a/LatticeSystem/Quantum/SpinS/ParityReachableMagSum.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableMagSum.lean
@@ -24,6 +24,7 @@ namespace LatticeSystem.Quantum
 
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
+omit [DecidableEq V] in
 /-- A single parity-block step preserves the magnetization parity. -/
 theorem parityStepS_magSumS_parity_eq {G : SimpleGraph V} {σ σ' : V → Fin (N + 1)}
     (h : ParityStepS G σ σ') : magSumS σ' % 2 = magSumS σ % 2 := by
@@ -38,6 +39,7 @@ theorem parityStepS_magSumS_parity_eq {G : SimpleGraph V} {σ σ' : V → Fin (N
     have hp := magSumS_add_parity_eq_of_agree_off_site x hagree
     omega
 
+omit [DecidableEq V] in
 /-- `ParityReachableS` configurations have equal magnetization parity. -/
 theorem parityReachableS_magSumS_parity_eq {G : SimpleGraph V} {σ σ' : V → Fin (N + 1)}
     (h : ParityReachableS G σ σ') : magSumS σ' % 2 = magSumS σ % 2 := by

--- a/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
@@ -48,6 +48,7 @@ theorem parityReachableS_of_raiseLowerReachableS {G : SimpleGraph V} {σ σ' : V
   intro a b hab
   exact ParityStepS.of_raiseLower hab
 
+omit [DecidableEq V] in
 /-- **Within-sector ParityReachableS on the bipartite complete graph**: any two
 configurations sharing the same total magnetization are `ParityReachableS`-connected.
 
@@ -58,8 +59,9 @@ theorem parityReachableS_bipartiteCompleteGraph_of_eq_magSumS
     (h_intermediate : ∀ τ : V → Fin (N + 1), ∀ x : V,
       ∃ z, A z ≠ A x ∧ (τ z).val < N)
     {σ σ' : V → Fin (N + 1)} (hmag : magSumS σ = magSumS σ') :
-    ParityReachableS (bipartiteCompleteGraphOf A) σ σ' :=
-  parityReachableS_of_raiseLowerReachableS
+    ParityReachableS (bipartiteCompleteGraphOf A) σ σ' := by
+  classical
+  exact parityReachableS_of_raiseLowerReachableS
     (raiseLowerReachableS_bipartiteCompleteGraph_of_eq_magSumS_legacy A h_intermediate hmag)
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelExpectations.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelExpectations.lean
@@ -238,6 +238,7 @@ theorem neelStateOfS_inner_self (A : Λ → Bool) (N : ℕ) :
   unfold neelStateOfS
   exact basisVecS_inner_self _
 
+omit [DecidableEq Λ] in
 /-- **State-level distinctness** of `Φ_Néel(A)` and `Φ_Néel(¬A)` (spin-S):
 when `Λ` is non-empty and `0 < N`, the two Néel states are distinct as
 elements of the multi-site Hilbert space. Direct from γ-4 step 171
@@ -246,12 +247,14 @@ orthogonality combined with norm-squared = 1: equality would force
 theorem neelStateOfS_ne_complement
     [Nonempty Λ] (A : Λ → Bool) (N : ℕ) (hN : 0 < N) :
     neelStateOfS A N ≠ neelStateOfS (fun x : Λ => ! A x) N := by
+  classical
   intro h
   have horth := neelStateOfS_complement_orthogonal A N hN
   rw [h] at horth
   rw [neelStateOfS_inner_self] at horth
   exact one_ne_zero horth
 
+omit [DecidableEq Λ] in
 /-- **Néel-complement linear independence** (spin-S): a linear combination
 `c1 • Φ_Néel(A) + c2 • Φ_Néel(¬A) = 0` forces `c1 = c2 = 0`, when `Λ` is
 non-empty and `0 < N`. Direct consequence of γ-4 step 171 (orthogonality)
@@ -262,6 +265,7 @@ theorem neelStateOfS_complement_pair_independent
     {c1 c2 : ℂ}
     (h : c1 • neelStateOfS A N + c2 • neelStateOfS (fun x : Λ => ! A x) N = 0) :
     c1 = 0 ∧ c2 = 0 := by
+  classical
   have horth_AcA := neelStateOfS_complement_orthogonal A N hN
   have horth_cAA :
       dotProduct (star (neelStateOfS (fun x : Λ => ! A x) N))


### PR DESCRIPTION
Tracked in #4569.

## Summary

Refactoring PR (Issue #4569 linter-warning backlog): clears **9 non-legacy
`linter.unusedDecidableInType` warnings** — `[DecidableEq …]` instances that
appear in a declaration's *type signature* but are not needed to *state* it
(the proofs use them only computably). Per-declaration restructure so the
binder is dropped from the type while the proof still type-checks.

These are the "computable-instance edge cases" that resisted a blanket
`omit`/`classical` sweep: each needed individual handling.

## Changes (per file)

- **AxisSwapParityBlock.lean** — `magSumS_add_parity_eq_of_agree_off_two_site`,
  `…_off_site`: `omit [DecidableEq Λ] in` + `classical` (the `Finset.erase`
  in the proof needs `DecidableEq` only in tactic mode).
- **ParityReachableMagSum.lean** — `parityStepS_magSumS_parity_eq`,
  `parityReachableS_magSumS_parity_eq`: `omit` only (their callees above no
  longer require `DecidableEq`, so neither do they).
- **BipartiteCompleteGraphAltPath.lean** —
  `exists_raiseLowerReachableS_bipartite_of_over_under_eq_sublattice_alt`:
  drop the decl-local `[DecidableEq V]` binder + `classical` (`Function.update`).
- **SublatticeCasimirNeelExpectations.lean** — `neelStateOfS_ne_complement`,
  `neelStateOfS_complement_pair_independent`: `omit` + `classical` (the
  orthogonality callee needs `DecidableEq`).
- **ParityReachableWithinSector.lean** —
  `parityReachableS_bipartiteCompleteGraph_of_eq_magSumS`: convert term-mode to
  `by classical exact …` so `classical` supplies `DecidableEq` for the
  (deprecated) callee, then `omit`.
- **TasakiFlatBandBasisLemma.lean** — `tasaki_lemma_11_10`: the
  `[DecidableEq Λ]` binder is genuinely unused (only `finrank`), removed.

## Scope / remaining

Remaining `unusedDecidableInType` (3) are all on `@[deprecated] _legacy`
declarations (`BipartiteCompleteGraph.lean:251,284`, `MagConfig.lean:166`),
left to the cycle-blocked legacy relocation/removal tracked in #4569. The 2
empty-line warnings are likewise on those deprecated decls.

No public `def`/`theorem` is added or renamed → no `docs/index.md` /
`tex/proof-guide.tex` update required.

## Build-speed evaluation

No measurable build-time change: the edits only move/drop instance binders and
add `classical`/`omit`; proof bodies are otherwise unchanged. Each touched file
builds warning-free under `lake build` (the `unusedDecidableInType` linter is a
mathlib style linter that only fires under `lake build`, not `lake env lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
