### PR TITLE
Refactor (Issue #4569): redirect 2 live parity-block use-sites to canonical twins — #4569

### DIFF
--- a/LatticeSystem/Quantum/SpinS/ComplexDressedSubmatrixPFEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/ComplexDressedSubmatrixPFEigenvector.lean
@@ -1,4 +1,6 @@
 import LatticeSystem.Quantum.SpinS.DressedSubmatrixPFEigenvector
+import LatticeSystem.Quantum.SpinS.DressedSubmatrixPFEigenvectorStructural
+import LatticeSystem.Quantum.SpinS.MagConfig
 import LatticeSystem.Quantum.SpinS.ComplexDressedParityBlockFinrank
 import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
 
@@ -50,10 +52,15 @@ theorem dressedAxisSwappedAnisotropicHeisenbergS_submatrix_complex_eigenvector_e
           (fun σ : parityConfigS Λ N p => σ.1)
           (fun σ : parityConfigS Λ N p => σ.1)) w = (ν : ℂ) • w := by
   -- (j.1): get positive real eigenvector.
+  -- (j.1) canonical (h_intermediate-free) variant; `1 ≤ N` from `h_intermediate`
+  -- (with `Λ` nonempty, from `hA_ne`).
+  have hN : 1 ≤ N := by
+    haveI : Nonempty Λ := ⟨hA_ne.choose⟩
+    exact (h_intermediate_imp_conditions A h_intermediate).2.2
   obtain ⟨ν, v, hv_pos, hvEq⟩ :=
-    dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists_legacy
+    dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists
       A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
-      hA_ne hB_ne h_intermediate p
+      hA_ne hB_ne hN p
   refine ⟨ν, fun i => (v i : ℂ), ?_, ?_⟩
   · -- v.map ofReal ≠ 0: since v > 0, in particular v(any i) > 0, hence (v(i) : ℂ) ≠ 0.
     intro hzero

--- a/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityBlockPerronFinrank.lean
@@ -1,4 +1,5 @@
-import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducibleUnconditional
+import LatticeSystem.Quantum.SpinS.DressedAxisSwapBlockIrreducibleStructural
+import LatticeSystem.Quantum.SpinS.MagConfig
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapPFMatrix
 import LatticeSystem.Math.PerronFrobeniusFinrank
 import LatticeSystem.Math.PerronFrobenius
@@ -59,10 +60,14 @@ theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_perron_eigenspace_finrank
     unfold Matrix.IsHermitian
     rw [Matrix.conjTranspose_eq_transpose_of_trivial]
     exact hSymm
-  -- Irreducibility unconditional via #3824.
-  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_legacy
+  -- Irreducibility unconditional via the canonical (h_intermediate-free) variant.
+  -- `1 ≤ N` follows from `h_intermediate` (with `Λ` nonempty, from `hA_ne`).
+  have hN : 1 ≤ N := by
+    haveI : Nonempty Λ := ⟨hA_ne.choose⟩
+    exact (h_intermediate_imp_conditions A h_intermediate).2.2
+  have hIrred := shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDpos hc_strict
-    hA_ne hB_ne h_intermediate p
+    hA_ne hB_ne hN p
   -- Perron positive eigenvector + finrank ≤ 1 (#3779).
   obtain ⟨μ, v, hAv, _hvne, hv_pos⟩ :=
     LatticeSystem.Math.PerronFrobenius.exists_pos_eigenvec_max hHerm hIrred


### PR DESCRIPTION
Tracked in #4569.

## Summary

Refactoring PR (Issue #4569, `_legacy` migration — **high-layer phase, live
use-site redirects**): redirect the two remaining LIVE callers of parity-block
`_legacy` irreducibility/eigenvector lemmas to their canonical
(`h_intermediate`-free) `*Structural*` twins.

## Changes

- **ParityBlockPerronFinrank.lean** —
  `shiftedDressedAxisSwappedReMatrixOnParityBlock_perron_eigenspace_finrank_le_one`
  now calls `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible`
  (canonical) instead of `..._isIrreducible_legacy`.
- **ComplexDressedSubmatrixPFEigenvector.lean** —
  `dressedAxisSwappedAnisotropicHeisenbergS_submatrix_complex_eigenvector_exists`
  now calls `dressedAxisSwappedAnisotropicHeisenbergSReMatrixOnParityBlock_pos_eigenvector_exists`
  (canonical) instead of `..._exists_legacy`.

The canonical twins take `hN : 1 ≤ N` where the legacy ones took `h_intermediate`.
Each caller keeps its `h_intermediate` hypothesis (so **no signature change / no
downstream impact**) and derives `hN` locally via `h_intermediate_imp_conditions`
(with `Nonempty Λ` obtained from `hA_ne`). Added the `*Structural*` and `MagConfig`
imports needed for the twin + the bridge helper.

## Effect

This frees the last live callers of the parity-block legacy chain:
`..._pos_eigenvector_exists_legacy` is now dead, and `..._isIrreducible_legacy` is
called only by it — both become deletable in a follow-up wave (#4569). No public
declaration statement changed → no `docs/index.md` / `tex` update needed.

## Build-speed evaluation

Neutral: only call-target + import edits; proof bodies unchanged. Full `lake
build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
