### PR TITLE
Refactor (Issue #4569): migrate ladder-link use-site to canonical twin (break vestigial cycle) — #4569

### DIFF
--- a/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23PFCasimirEigenvector.lean
@@ -1,4 +1,6 @@
 import LatticeSystem.Math.PerronFrobeniusSimple
+import LatticeSystem.Quantum.SpinS.Theorem23StructuralPFJointCasimir
+import LatticeSystem.Quantum.SpinS.MagConfig
 import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSector
 import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSectorMarshall
 import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSectorEigenvalueUnique
@@ -265,7 +267,7 @@ It is the form in which the sound chain applies directly to the actual
 Perron–Frobenius ground state. -/
 theorem tasaki23_pf_groundState_ladder_link_of_casimir_ne_kernel
     (A : V → Bool) {J : V → V → ℂ} (N : ℕ) (c : ℝ) {M : ℕ}
-    [Nonempty (magConfigS V N M)]
+    [Nonempty V] [Nonempty (magConfigS V N M)]
     (hJ_real : ∀ x y, (J x y).im = 0)
     (hJ_pos : ∀ x y : V, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
     (hJ_nn : ∀ x y, 0 ≤ (J x y).re)
@@ -306,9 +308,10 @@ theorem tasaki23_pf_groundState_ladder_link_of_casimir_ne_kernel
             (fun σ => (((marshallSignS A σ.1).re * v σ : ℝ) : ℂ))) ∈
         magSubspaceS V N
           ((((Fintype.card V : ℂ) * (N : ℂ) / 2) - (M : ℂ)) - 1) := by
+  obtain ⟨hA_ne, hB_ne, hN⟩ := h_intermediate_imp_conditions A h_intermediate
   obtain ⟨γ, hγ⟩ :=
-    tasaki23_pf_groundState_casimir_eigenvector_legacy A N c hJ_real hJ_pos hJ_nn
-      hJ_sym hJ_bipartite hc_strict h_intermediate hv_pos hH
+    tasaki23_pf_groundState_casimir_eigenvector A c hJ_real hJ_pos hJ_nn
+      hJ_sym hJ_bipartite hc_strict hA_ne hB_ne hN hv_pos hH
   exact tasaki23_pf_ladder_link_succ hH hγ (hγ_ne γ hγ)
     (tasaki23_marshallPositive_magSectorEmbedding_ne_zero A hv_pos)
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralCasimirEigenvec.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralCasimirEigenvec.lean
@@ -1,4 +1,5 @@
-import LatticeSystem.Quantum.SpinS.Theorem23PFCasimirEigenvector
+import LatticeSystem.Math.PerronFrobeniusSimple
+import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSectorMarshall
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralReach
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFJointCasimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralPFJointCasimir.lean
@@ -1,4 +1,9 @@
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralCasimirEigenvec
+import LatticeSystem.Quantum.SpinS.MagSectorEmbedding
+import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSectorEigenvalueUnique
+import LatticeSystem.Quantum.SpinS.SaturatedLadderJointEigenspace
+import LatticeSystem.Quantum.SpinS.Theorem23Casimir
+import LatticeSystem.Quantum.MarshallLiebMattis.ToyHamiltonian
 import LatticeSystem.Quantum.SpinS.SublatticeCasimirSpectralBound
 
 /-!


### PR DESCRIPTION
Tracked in #4569.

## Summary

Refactoring PR (Issue #4569, `_legacy` migration): migrate the **last non-base
live use-site** — the ladder-link `tasaki23_pf_groundState_ladder_link_of_casimir_ne_kernel`
(in `Theorem23PFCasimirEigenvector`) — from `tasaki23_pf_groundState_casimir_eigenvector_legacy`
to the canonical twin `tasaki23_pf_groundState_casimir_eigenvector`.

## Cycle break

Importing the twin's module created an import cycle:
`Theorem23StructuralPFJointCasimir → Theorem23StructuralCasimirEigenvec →
Theorem23PFCasimirEigenvector`. The offending edge was a **vestigial** import — the
`*Structural*` file referenced the legacy file only in prose comments. Removed it and
re-routed the two affected Structural files to the actual defining modules (the legacy
file had been a transitive conduit):
- `Theorem23StructuralCasimirEigenvec` += `PerronFrobeniusSimple`,
  `DressedMatrixOnMagSectorMarshall`
- `Theorem23StructuralPFJointCasimir` += `MagSectorEmbedding`,
  `DressedMatrixOnMagSectorEigenvalueUnique`, `SaturatedLadderJointEigenspace`,
  `Theorem23Casimir`, `ToyHamiltonian`

The cascade set (exactly 2 modules losing the conduit) was determined by import-graph
reachability analysis before editing.

## Caller change

The ladder-link keeps its `h_intermediate` hypothesis (deriving `hN` locally via
`h_intermediate_imp_conditions`, with `Nonempty V` from `hA_ne`) and gains a
`[Nonempty V]` instance argument — free, as it has **no downstream callers**.

## Effect

Frees the last live caller of `tasaki23_pf_groundState_casimir_eigenvector_legacy`
(#25), which — with #26/#27 — is now fully dead in `Theorem23PFCasimirEigenvector`
(deletable in a follow-up). `docs/index.md` already cites the canonical twin; no doc
change needed. Base-file `_legacy` decls remain deferred.

## Build-speed evaluation

Neutral: only import re-routing + one call-target swap; proof bodies unchanged. Full
`lake build` green (4097 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
