### PR TITLE
chore(tests): zero-warning NeelState2D (silence deprecation linter)

### DIFF
--- a/LatticeSystem/Tests/NeelState2D.lean
+++ b/LatticeSystem/Tests/NeelState2D.lean
@@ -6,6 +6,11 @@ import LatticeSystem.Quantum.NeelState
 Split out of `Tests/NeelState.lean` for build speed; the 1D chain tests remain there.
 -/
 
+-- The marshallSign{Chain,Square,Cubic}Config regression tests below intentionally
+-- exercise the deprecated specialised helpers (thin wrappers over the generic
+-- marshallSignOf); silence the deprecation linter for this test file.
+set_option linter.deprecated false
+
 namespace LatticeSystem.Tests.NeelState
 
 open LatticeSystem.Quantum


### PR DESCRIPTION
Zero-warning hygiene PR. Tests/NeelState2D.lean had 10 pre-existing linter.deprecated warnings (its
Marshall-sign regression examples call deprecated helpers marshallSign{Chain,Square,Cubic}Config, thin
wrappers over generic marshallSignOf kept for backward compat). These tests deliberately pin the
deprecated helpers' values while they exist, so file-level set_option linter.deprecated false is the
right fix. lake build LatticeSystem.Tests.NeelState2D = 2448 jobs, 0 errors, 0 warnings. No behavior change.
