### PR TITLE
Refactor (build speed): split BipartiteCompleteGraph into Core + capstone — #4667

### DIFF
--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraph.lean
@@ -1,5 +1,5 @@
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 import LatticeSystem.Quantum.SpinS.ConfigDist
-import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 
 set_option linter.unusedSectionVars false
@@ -30,68 +30,6 @@ Tracked in #412.
 namespace LatticeSystem.Quantum
 
 variable {V : Type*}
-
-/-- The complete bipartite graph induced by a sublattice indicator
-`A : V → Bool`: an edge between `x` and `y` iff they are distinct
-and lie on different sublattices. -/
-@[simps]
-def bipartiteCompleteGraphOf (A : V → Bool) : SimpleGraph V where
-  Adj x y := x ≠ y ∧ A x ≠ A y
-  symm := fun _ _ ⟨h, hA⟩ => ⟨h.symm, fun heq => hA heq.symm⟩
-  loopless := ⟨fun _ ⟨h, _⟩ => h rfl⟩
-
-/-- Adjacency in `bipartiteCompleteGraphOf A`: an edge iff distinct and
-on different sublattices. -/
-theorem bipartiteCompleteGraphOf_adj_iff (A : V → Bool) (x y : V) :
-    (bipartiteCompleteGraphOf A).Adj x y ↔ x ≠ y ∧ A x ≠ A y :=
-  Iff.rfl
-
-/-- Every adjacency in `bipartiteCompleteGraphOf A` has endpoints
-on different sublattices. -/
-theorem bipartiteCompleteGraphOf_adj_sublattice_ne {A : V → Bool}
-    {x y : V} (hadj : (bipartiteCompleteGraphOf A).Adj x y) :
-    A x ≠ A y :=
-  hadj.2
-
-/-- Adjacency in `bipartiteCompleteGraphOf A` implies `x ≠ y`. -/
-theorem bipartiteCompleteGraphOf_adj_ne {A : V → Bool}
-    {x y : V} (hadj : (bipartiteCompleteGraphOf A).Adj x y) :
-    x ≠ y :=
-  hadj.1
-
-/-- Decidability instance for adjacency in `bipartiteCompleteGraphOf A`,
-useful for downstream computations (e.g. graph-derived couplings via
-`couplingOf`). Relies on `DecidableEq V`. -/
-instance bipartiteCompleteGraphOf_decidableAdj {V : Type*} [DecidableEq V]
-    (A : V → Bool) :
-    DecidableRel (bipartiteCompleteGraphOf A).Adj := by
-  intro x y
-  unfold bipartiteCompleteGraphOf SimpleGraph.Adj
-  infer_instance
-
-/-- The Marshall-trivial sublattice `A := fun _ => false` gives the
-empty graph. -/
-theorem bipartiteCompleteGraphOf_const_false {V : Type*} :
-    bipartiteCompleteGraphOf (V := V) (fun _ => false) = ⊥ := by
-  ext x y
-  rw [bipartiteCompleteGraphOf_adj_iff]
-  simp
-
-/-- The Marshall-trivial sublattice `A := fun _ => true` gives the
-empty graph. -/
-theorem bipartiteCompleteGraphOf_const_true {V : Type*} :
-    bipartiteCompleteGraphOf (V := V) (fun _ => true) = ⊥ := by
-  ext x y
-  rw [bipartiteCompleteGraphOf_adj_iff]
-  simp
-
-/-- For exactly-two-vertex `V` with the two vertices on different
-sublattices, `bipartiteCompleteGraphOf A` has exactly the (single)
-edge between them — a single edge graph. -/
-theorem bipartiteCompleteGraphOf_adj_of_ne_of_sublattice_ne
-    {A : V → Bool} {x y : V} (hxy : x ≠ y) (hAne : A x ≠ A y) :
-    (bipartiteCompleteGraphOf A).Adj x y :=
-  ⟨hxy, hAne⟩
 
 /-! ## Bipartite step from over/under sites -/
 

--- a/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphCore.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteCompleteGraphCore.lean
@@ -1,0 +1,87 @@
+import Mathlib.Combinatorics.SimpleGraph.Basic
+
+set_option linter.unusedSectionVars false
+set_option linter.unusedSimpArgs false
+set_option linter.unusedVariables false
+
+/-!
+# The complete bipartite graph induced by a sublattice indicator (foundation)
+
+Foundational layer extracted from `BipartiteCompleteGraph.lean` for build speed.  This file defines
+`bipartiteCompleteGraphOf` — the complete bipartite graph on a vertex type `V` with sublattice
+indicator `A : V → Bool`, where `Adj x y ↔ x ≠ y ∧ A x ≠ A y` — together with its adjacency
+characterisation, decidable-adjacency instance, and the constant-indicator degenerations.
+
+The bipartite raise/lower step / reachability theorems and the preconnectedness of
+`bipartiteCompleteGraphOf` (which depend on the configuration-distance machinery and graph
+connectivity) are kept in the capstone module `BipartiteCompleteGraph.lean`.
+
+Tracked in #412.
+-/
+
+namespace LatticeSystem.Quantum
+
+variable {V : Type*}
+
+/-- The complete bipartite graph induced by a sublattice indicator
+`A : V → Bool`: an edge between `x` and `y` iff they are distinct
+and lie on different sublattices. -/
+@[simps]
+def bipartiteCompleteGraphOf (A : V → Bool) : SimpleGraph V where
+  Adj x y := x ≠ y ∧ A x ≠ A y
+  symm := fun _ _ ⟨h, hA⟩ => ⟨h.symm, fun heq => hA heq.symm⟩
+  loopless := ⟨fun _ ⟨h, _⟩ => h rfl⟩
+
+/-- Adjacency in `bipartiteCompleteGraphOf A`: an edge iff distinct and
+on different sublattices. -/
+theorem bipartiteCompleteGraphOf_adj_iff (A : V → Bool) (x y : V) :
+    (bipartiteCompleteGraphOf A).Adj x y ↔ x ≠ y ∧ A x ≠ A y :=
+  Iff.rfl
+
+/-- Every adjacency in `bipartiteCompleteGraphOf A` has endpoints
+on different sublattices. -/
+theorem bipartiteCompleteGraphOf_adj_sublattice_ne {A : V → Bool}
+    {x y : V} (hadj : (bipartiteCompleteGraphOf A).Adj x y) :
+    A x ≠ A y :=
+  hadj.2
+
+/-- Adjacency in `bipartiteCompleteGraphOf A` implies `x ≠ y`. -/
+theorem bipartiteCompleteGraphOf_adj_ne {A : V → Bool}
+    {x y : V} (hadj : (bipartiteCompleteGraphOf A).Adj x y) :
+    x ≠ y :=
+  hadj.1
+
+/-- Decidability instance for adjacency in `bipartiteCompleteGraphOf A`,
+useful for downstream computations (e.g. graph-derived couplings via
+`couplingOf`). Relies on `DecidableEq V`. -/
+instance bipartiteCompleteGraphOf_decidableAdj {V : Type*} [DecidableEq V]
+    (A : V → Bool) :
+    DecidableRel (bipartiteCompleteGraphOf A).Adj := by
+  intro x y
+  unfold bipartiteCompleteGraphOf SimpleGraph.Adj
+  infer_instance
+
+/-- The Marshall-trivial sublattice `A := fun _ => false` gives the
+empty graph. -/
+theorem bipartiteCompleteGraphOf_const_false {V : Type*} :
+    bipartiteCompleteGraphOf (V := V) (fun _ => false) = ⊥ := by
+  ext x y
+  rw [bipartiteCompleteGraphOf_adj_iff]
+  simp
+
+/-- The Marshall-trivial sublattice `A := fun _ => true` gives the
+empty graph. -/
+theorem bipartiteCompleteGraphOf_const_true {V : Type*} :
+    bipartiteCompleteGraphOf (V := V) (fun _ => true) = ⊥ := by
+  ext x y
+  rw [bipartiteCompleteGraphOf_adj_iff]
+  simp
+
+/-- For exactly-two-vertex `V` with the two vertices on different
+sublattices, `bipartiteCompleteGraphOf A` has exactly the (single)
+edge between them — a single edge graph. -/
+theorem bipartiteCompleteGraphOf_adj_of_ne_of_sublattice_ne
+    {A : V → Bool} {x y : V} (hxy : x ≠ y) (hAne : A x ≠ A y) :
+    (bipartiteCompleteGraphOf A).Adj x y :=
+  ⟨hxy, hAne⟩
+end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapRaiseLowerStrictNeg.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapRaiseLowerStrictNeg.lean
@@ -2,7 +2,7 @@ import LatticeSystem.Quantum.SpinS.DressedAxisSwapBondReStrictNeg
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapOffDiag
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapPFMatrix
 import LatticeSystem.Quantum.SpinS.HeisenbergRaiseLower
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 
 set_option linter.unusedSectionVars false
 set_option linter.unusedSimpArgs false

--- a/LatticeSystem/Quantum/SpinS/DressedHeisenbergRaiseLowerCore.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedHeisenbergRaiseLowerCore.lean
@@ -1,6 +1,6 @@
 import LatticeSystem.Quantum.SpinS.HeisenbergRaiseLower
 import LatticeSystem.Quantum.SpinS.DressedHeisenberg
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 
 /-!
 # Dressed Heisenberg raise/lower steps: complex-matrix form (foundation)

--- a/LatticeSystem/Quantum/SpinS/MagConfig.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfig.lean
@@ -1,6 +1,6 @@
 import LatticeSystem.Quantum.SpinS.Magnetization
 import LatticeSystem.Quantum.SpinS.RaiseLower
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 import Mathlib.Combinatorics.SimpleGraph.Basic
 
 set_option linter.unusedSectionVars false

--- a/LatticeSystem/Quantum/SpinS/ParityReachStepDown.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachStepDown.lean
@@ -1,7 +1,7 @@
 import LatticeSystem.Quantum.SpinS.ParityReachable
 import LatticeSystem.Quantum.SpinS.ParityReachWitness
 import LatticeSystem.Quantum.SpinS.MagSumStepDown
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 
 /-!
 # Single-step `magSumS` reduction (easy cases) for (d) reachability totality

--- a/LatticeSystem/Quantum/SpinS/ParityReachStepDownHard.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachStepDownHard.lean
@@ -1,7 +1,7 @@
 import LatticeSystem.Quantum.SpinS.ParityReachable
 import LatticeSystem.Quantum.SpinS.ParityReachWitness
 import LatticeSystem.Quantum.SpinS.MagSumStepDown
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 
 /-!
 # Two-step `magSumS` reduction for the "hard" Case 2b of (d) reachability totality

--- a/LatticeSystem/Quantum/SpinS/ParityReachWitness.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachWitness.lean
@@ -1,5 +1,5 @@
 import LatticeSystem.Quantum.SpinS.ParityReachable
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 
 set_option linter.unusedSectionVars false
 set_option linter.unusedSimpArgs false

--- a/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
@@ -1,5 +1,5 @@
 import LatticeSystem.Quantum.SpinS.ParityReachable
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 
 set_option linter.unusedSectionVars false
 set_option linter.unusedSimpArgs false

--- a/LatticeSystem/Quantum/SpinS/ShiftedDressedMatrixCore.lean
+++ b/LatticeSystem/Quantum/SpinS/ShiftedDressedMatrixCore.lean
@@ -2,7 +2,7 @@ import LatticeSystem.Quantum.SpinS.DressedHeisenberg
 import LatticeSystem.Quantum.SpinS.DressedHeisenbergMarshall
 import LatticeSystem.Quantum.SpinS.DressedHeisenbergOffXY
 import LatticeSystem.Quantum.SpinS.DressedHeisenbergRaiseLower
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 import LatticeSystem.Quantum.SpinS.RaiseLowerMatrixPow
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeel.lean
@@ -6,7 +6,7 @@ import LatticeSystem.Quantum.SpinS.ToyHamiltonianCasimir
 import LatticeSystem.Quantum.SpinS.BasisVecSOrthonormal
 import LatticeSystem.Quantum.SpinS.MagConfig
 import LatticeSystem.Quantum.SpinS.SingleSiteCasimirExpectation
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 import LatticeSystem.Quantum.SpinS.AllAlignedStateOrthogonal
 import LatticeSystem.Quantum.SpinS.SingleSiteTransverseMeanZero
 import LatticeSystem.Quantum.SpinS.SublatticeCasimirNeelCore

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelCore.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelCore.lean
@@ -6,7 +6,7 @@ import LatticeSystem.Quantum.SpinS.ToyHamiltonianCasimir
 import LatticeSystem.Quantum.SpinS.BasisVecSOrthonormal
 import LatticeSystem.Quantum.SpinS.MagConfig
 import LatticeSystem.Quantum.SpinS.SingleSiteCasimirExpectation
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraph
+import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 import LatticeSystem.Quantum.SpinS.AllAlignedStateOrthogonal
 import LatticeSystem.Quantum.SpinS.SingleSiteTransverseMeanZero
 


### PR DESCRIPTION
Tracked in #4667.

## Summary
High-ROI build-speed split of `BipartiteCompleteGraph.lean` (314 lines, **12 importers**).

- **Core** (`BipartiteCompleteGraphCore.lean`): the graph definition `bipartiteCompleteGraphOf` + its adjacency characterisation, decidable-adjacency instance, and constant-indicator degenerations. Imports only `Mathlib.Combinatorics.SimpleGraph.Basic`.
- **Capstone** (`BipartiteCompleteGraph.lean`, filename kept): the bipartite raise/lower step + reachability theorems (`exists_raiseLowerStepS_bipartite_*`, `exists_raiseLowerReachableS_bipartite_*`) and `bipartiteCompleteGraphOf_preconnected`. Imports Core + `ConfigDist` + `SimpleGraph.Connectivity.Connected`.

## Import decoupling (the ROI)
Of the 12 importers, **10 use only the graph definition / adjacency** and are repointed to the Core, so they no longer transitively pull `ConfigDist` (the heavy configuration-distance machinery) or the graph-connectivity import:

`ParityReachableWithinSector`, `ShiftedDressedMatrixCore`, `SublatticeCasimirNeel`, `SublatticeCasimirNeelCore`, `DressedAxisSwapRaiseLowerStrictNeg`, `ParityReachStepDownHard`, `ParityReachStepDown`, `MagConfig`, `ParityReachWitness`, `DressedHeisenbergRaiseLowerCore`.

The 2 that use the step/reachability/preconnectedness theorems keep the capstone import (`Tests/SpinSBipartiteCompleteGraph`, `BipartiteCompleteGraphAltPath`).

## Verification
- `lake build` 0 errors / 0 warnings (root green, 4210 jobs) with all 10 repointed importers building against the Core.
- Core builds standalone with only `SimpleGraph.Basic`.
- No docs/tex sync: the only docs row (`bipartiteCompleteGraphOf_preconnected`) stays in the capstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
