### PR TITLE
Tasaki §6.2 Theorem 6.3 (PR2): ring ground-sector structure — #4762

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -60,6 +60,7 @@ import LatticeSystem.Quantum.SpinS.LiebSchultzMattis
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisProof
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisOrthogonality
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisRingUniqueness
+import LatticeSystem.Quantum.SpinS.LiebSchultzMattisRingGroundUnique
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisGeneral
 import LatticeSystem.Quantum.SpinS.ShastryNoSSB
 import LatticeSystem.Quantum.SpinS.FerrimagneticLRO

--- a/LatticeSystem/Quantum/SpinS/LiebSchultzMattisRingGroundUnique.lean
+++ b/LatticeSystem/Quantum/SpinS/LiebSchultzMattisRingGroundUnique.lean
@@ -1,0 +1,70 @@
+import LatticeSystem.Quantum.SpinS.LiebSchultzMattisRingUniqueness
+import LatticeSystem.Quantum.SpinS.StrictHOutsideFerrimagnetic
+import LatticeSystem.Quantum.SpinS.ConnectedSectorFinrankLeOne
+import LatticeSystem.Quantum.SpinS.Theorem24SU2GlobalUniquenessFromMLMCore
+import LatticeSystem.Quantum.SpinS.Theorem24SU2GlobalUniquenessFromMLMCoreSectors
+import LatticeSystem.Quantum.SpinS.FerrimagneticLROUniversal
+
+/-!
+# Tasaki §6.2 Theorem 6.3: ground-state uniqueness of the AFM Heisenberg ring
+
+Building on the ring setup (`LiebSchultzMattisRingUniqueness`), this module proves the
+**sublattice balance** of the even ring (the two parity classes have equal cardinality), the
+prerequisite for the singleton-ground-sector structure used by the Marshall–Lieb–Mattis
+uniqueness machinery toward Theorem 6.3.
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems* (1st ed., Springer,
+2020), §6.2, p. 162.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix SimpleGraph
+
+/-- **Sublattice balance on the even ring**: the even-index and odd-index sites of `Fin L` are
+equinumerous when `L` is even.  The cyclic successor `x ↦ x + 1` is a bijection from one parity
+class to the other (parity flips because `L` is even). -/
+theorem ringSublattice_card_eq (L : ℕ) (hLeven : Even L) (hL2 : 2 ≤ L) :
+    (Finset.univ.filter (fun x : Fin L => ringSublattice L x = true)).card =
+      (Finset.univ.filter (fun x : Fin L => (! ringSublattice L x) = true)).card := by
+  classical
+  obtain ⟨k, hk⟩ := hLeven
+  have : NeZero L := ⟨by omega⟩
+  have hone : ((1 : Fin L)).val = 1 := by rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
+  refine Finset.card_nbij' (fun x => x + 1) (fun x => x - 1) ?_ ?_ ?_ ?_
+  · -- maps even-class into odd-class
+    intro x hx
+    rw [Finset.mem_coe, Finset.mem_filter] at hx
+    simp only [ringSublattice, decide_eq_true_eq] at hx
+    rw [Finset.mem_coe, Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    simp only [ringSublattice, Bool.not_eq_true', decide_eq_false_iff_not]
+    have hlt : x.val + 1 < L := by omega
+    have hxv : ((x + 1 : Fin L)).val = x.val + 1 := by
+      rw [Fin.val_add, hone, Nat.mod_eq_of_lt hlt]
+    rw [hxv]; omega
+  · -- maps odd-class into even-class
+    intro x hx
+    rw [Finset.mem_coe, Finset.mem_filter] at hx
+    simp only [ringSublattice, Bool.not_eq_true', decide_eq_false_iff_not] at hx
+    rw [Finset.mem_coe, Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    simp only [ringSublattice, decide_eq_true_eq]
+    have hxne : x ≠ 0 := by
+      intro h; rw [h] at hx; simp at hx
+    have hxv : ((x - 1 : Fin L)).val = x.val - 1 := Fin.val_sub_one_of_ne_zero hxne
+    rw [hxv]; omega
+  · intro x _; simp
+  · intro x _; simp
+
+/-- **The even ring has a single ground sector**: the Tasaki §2.5 ground-state sectors of the AFM
+Heisenberg ring collapse to the balanced magnetization sector `M0 = (L/2)·N` (the `Ŝ_tot^{(3)} = 0`
+sector), since the two parity sublattices are equinumerous.  This is the singleton structure
+consumed by the full-eigenspace uniqueness lift. -/
+theorem ring_tasaki23GroundStateSectors_singleton (L N : ℕ) (hLeven : Even L) (hL2 : 2 ≤ L) :
+    tasaki23GroundStateSectors (V := Fin L) (ringSublattice L) N =
+      {((Finset.univ.filter (fun x : Fin L => ringSublattice L x = true)).card * N)} :=
+  tasaki23GroundStateSectors_eq_singleton_of_card_eq (ringSublattice L) N
+    (ringSublattice_card_eq L hLeven hL2)
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #4762 (master #4718). Second PR of the §6.2 Theorem 6.3 discharge thread (ring ground-state uniqueness).

Establishes the **singleton ground-sector structure** of the even AFM Heisenberg ring — the prerequisite for the Marshall–Lieb–Mattis full-eigenspace uniqueness lift (`heisenbergHamiltonianS_full_eigenspace_finrank_le_one_of_strict_sector_lower`, whose `h_strict_outside` is `∀ M ≠ M0`, i.e. needs a *single* ground sector).

### Lemmas (critical path to Theorem 6.3)
- `ringSublattice_card_eq`: the two parity sublattices of `Fin L` are equinumerous for `L` even — proved by the cyclic-successor bijection `x ↦ x + 1` (parity flips because `L` is even), via `Finset.card_nbij'`.
- `ring_tasaki23GroundStateSectors_singleton`: the Tasaki §2.5 ground-state sectors of the ring collapse to the single balanced magnetization sector `M0 = (L/2)·N` (the `Ŝ_tot^{(3)} = 0` sector), via `tasaki23GroundStateSectors_eq_singleton_of_card_eq` + the balance.

### Status
- `lake build` green (root), zero warnings on the new file `LiebSchultzMattisRingGroundUnique.lean`, wired into `LatticeSystem.lean`.
- Foundational sub-PR (no axiom discharged yet); `docs/index.md` + `tex/proof-guide.tex` synced at the Theorem 6.3 capstone.

### Next (under #4762)
PR3: GS uniqueness assembly proper — instantiate `tasaki23_strict_hOutside_of_connected` for `(A=ringSublattice, G=cycleGraph L, J=ringCouplingSym L)` (using PR1's edge-positivity/bipartiteness + this PR's singleton structure), apply the connected per-sector PF finrank ≤ 1 and the full-eigenspace lift, then transfer to `afmHeisenbergChainHamiltonianS` via PR1's `2•` symmetrization. PR4: finite-dim Hermitian min-max / second-eigenvalue. PR5: assemble `IsPositiveSpectralGap` + discharge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
