### PR TITLE
Tasaki §6.2 Theorem 6.3 (PR3): eigenspace transfer through symmetrization — #4762

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -61,6 +61,7 @@ import LatticeSystem.Quantum.SpinS.LiebSchultzMattisProof
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisOrthogonality
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisRingUniqueness
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisRingGroundUnique
+import LatticeSystem.Quantum.SpinS.LiebSchultzMattisRingEigenTransfer
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisGeneral
 import LatticeSystem.Quantum.SpinS.ShastryNoSSB
 import LatticeSystem.Quantum.SpinS.FerrimagneticLRO

--- a/LatticeSystem/Quantum/SpinS/LiebSchultzMattisRingEigenTransfer.lean
+++ b/LatticeSystem/Quantum/SpinS/LiebSchultzMattisRingEigenTransfer.lean
@@ -1,0 +1,44 @@
+import LatticeSystem.Quantum.SpinS.LiebSchultzMattisRingUniqueness
+import Mathlib.LinearAlgebra.Eigenspace.Basic
+
+/-!
+# Tasaki §6.2 Theorem 6.3: eigenspace transfer through the symmetrization
+
+The Marshall–Lieb–Mattis uniqueness machinery operates on
+`heisenbergHamiltonianS (ringCouplingSym L) N`, while the physical chain is
+`afmHeisenbergChainHamiltonianS L N`.  Since the former is `2 ·` the
+latter (`heisenbergHamiltonianS_ringCouplingSym_eq`), their eigenspaces coincide with eigenvalues
+scaled by `2`.  This module records the resulting **finrank transfer**, the bridge that carries
+ground-state uniqueness (`finrank ≤ 1`) from the symmetrized operator back to the physical chain.
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems* (1st ed., Springer,
+2020), §6.2, p. 162.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix Module
+
+/-- **Eigenspace under a nonzero scalar multiple**: `eigenspace ((2:ℂ) • f) (2μ) = eigenspace f μ`
+(the scalar `2` cancels in the eigenvalue equation). -/
+theorem eigenspace_two_smul {V : Type*} [AddCommGroup V] [Module ℂ V] (f : End ℂ V) (μ : ℂ) :
+    End.eigenspace ((2 : ℂ) • f) ((2 : ℂ) * μ) = End.eigenspace f μ := by
+  ext v
+  rw [End.mem_eigenspace_iff, End.mem_eigenspace_iff, LinearMap.smul_apply, mul_smul]
+  constructor
+  · intro h; exact smul_right_injective V (two_ne_zero) h
+  · intro h; rw [h]
+
+/-- **Eigenspace finrank transfer**: the `E`-eigenspace of the physical AFM chain and the
+`2E`-eigenspace of the symmetrized Hamiltonian have equal dimension.  Carries `finrank ≤ 1`
+(ground-state uniqueness) from the Marshall–Lieb–Mattis operator to the physical chain. -/
+theorem afmHeisenberg_eigenspace_finrank_eq_ringCouplingSym (L N : ℕ) (E : ℂ) :
+    Module.finrank ℂ
+        (End.eigenspace (Matrix.toLin' (heisenbergHamiltonianS (ringCouplingSym L) N)) (2 * E)) =
+      Module.finrank ℂ (End.eigenspace (Matrix.toLin' (afmHeisenbergChainHamiltonianS L N)) E) := by
+  have hop : Matrix.toLin' (heisenbergHamiltonianS (ringCouplingSym L) N) =
+      (2 : ℂ) • Matrix.toLin' (afmHeisenbergChainHamiltonianS L N) := by
+    rw [heisenbergHamiltonianS_ringCouplingSym_eq, map_smul]
+  rw [hop, eigenspace_two_smul]
+
+end LatticeSystem.Quantum


### PR DESCRIPTION
Tracked in #4762 (master #4718). Third PR of the §6.2 Theorem 6.3 discharge thread.

Records the **eigenspace transfer bridge** between the physical AFM chain `afmHeisenbergChainHamiltonianS L N` and the symmetrized operator `heisenbergHamiltonianS (ringCouplingSym L) N` (on which the Marshall–Lieb–Mattis uniqueness machinery acts). Since the latter is `2 ·` the former (PR1's `heisenbergHamiltonianS_ringCouplingSym_eq`), their eigenspaces coincide with eigenvalues scaled by `2`.

### Lemmas (critical path to Theorem 6.3)
- `eigenspace_two_smul` (generic): `eigenspace ((2:ℂ) • f) (2μ) = eigenspace f μ` — the scalar `2` cancels in the eigenvalue equation (`smul_right_injective`).
- `afmHeisenberg_eigenspace_finrank_eq_ringCouplingSym`: `finrank (eigenspace (toLin' (heisenbergHamiltonianS (ringCouplingSym L) N)) (2E)) = finrank (eigenspace (toLin' (afmHeisenbergChainHamiltonianS L N)) E)` — carries `finrank ≤ 1` (GS uniqueness) from the MLM operator back to the physical chain.

### Status
- `lake build` green (root), zero warnings on the new file `LiebSchultzMattisRingEigenTransfer.lean`, wired into `LatticeSystem.lean`.
- Foundational sub-PR (no axiom discharged yet); `docs/index.md` + `tex/proof-guide.tex` synced at the Theorem 6.3 capstone.

### Next (under #4762)
PR4: the MLM uniqueness assembly proper — instantiate `tasaki23_strict_hOutside_of_connected` for the ring, apply the connected per-sector PF + full-eigenspace lift to get `finrank (eigenspace (heisenbergHamiltonianS (ringCouplingSym L) N) μ) ≤ 1`, identify `μ` as the ground energy, and use this PR's bridge to obtain physical-chain GS uniqueness. PR5: finite-dim min-max second-eigenvalue + assemble `IsPositiveSpectralGap` + discharge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
