### PR TITLE
Tasaki §10.2 Theorem 10.2 (PR1): spin-reflection-positivity foundation — #4852

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner.lean
+++ b/LatticeSystem/Fermion/JordanWigner.lean
@@ -114,6 +114,7 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandProjectionBridg
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandProjectionBlock
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandTheorem1115
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralBasisHN
+import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractiveReflection
 import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractive
 import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebRepulsive
 import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebRepulsiveCorrelation

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractiveReflection.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractiveReflection.lean
@@ -1,0 +1,286 @@
+import LatticeSystem.Fermion.JordanWigner.Hubbard
+import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiHopActionCore
+import LatticeSystem.Math.PosSemidef.Basics
+import Mathlib.LinearAlgebra.Matrix.PosDef
+
+/-!
+# Spin-reflection foundation for Lieb's theorem (Tasaki §10.2.1)
+
+This file builds the finite-dimensional **spin-reflection positivity (SRP)**
+coefficient-matrix language in which Lieb's theorem for the attractive Hubbard
+model (Tasaki Theorem 10.2, `theorem_10_2_lieb_attractive_unique_singlet`) is
+proved.  It is the first layer (PR1) toward discharging that axiom; it does not
+yet touch the Hamiltonian positivity, the Perron–Frobenius uniqueness, or the
+singlet argument.
+
+## Main definitions
+
+* `hubbardSpinConfig N` — a single-species occupation configuration
+  `Fin (N + 1) → Fin 2` on the `N + 1` sites.
+* `hubbardUpConfig` / `hubbardDownConfig` / `hubbardMergeConfig` — the up/down
+  projections of a spin-orbital configuration `Fin (2 * N + 2) → Fin 2` (via
+  `spinfulIndex`) and their reconstruction.
+* `hubbardSpinConfigEquiv` — the resulting bijection
+  `(Fin (2 * N + 2) → Fin 2) ≃ hubbardSpinConfig N × hubbardSpinConfig N`
+  (the basis-level form of the factorization `H = H↑ ⊗ H↓`).
+* `hubbardSpinCoeffLinearEquiv` — the induced linear isomorphism of a state
+  vector with its **coefficient matrix** indexed by `(up config, down config)`.
+* `flipOccupation` / `particleHoleConfig` / `spinReflectionConfig` /
+  `spinReflectionThetaVec` — the spin-reflection `θ` (antiunitary spin-flip ∘
+  particle–hole) at the configuration and the state-vector level.
+* `spinReflectionCoeff` / `SpinReflectionPositive` — the SRP coefficient matrix
+  (down index read as a hole) and its positive-semidefiniteness predicate.
+
+## Main results
+
+* `particleHoleConfig_involutive`, `spinReflectionConfig_involutive` — the
+  involutivity of the reflections.
+* `spinReflectionThetaVec_smul`, `spinReflectionThetaVec_dotProduct` — `θ` is
+  conjugate-linear and preserves the inner product up to conjugation
+  (antiunitarity).
+* `spinReflectionCoeff_thetaVec` — `θ` acts on the coefficient matrix as the
+  conjugate transpose.
+* `spinReflection_gramMatrix_nonneg` — the reusable nonnegativity
+  `0 ≤ Re tr (C A C Aᴴ)` for `C` positive-semidefinite, the algebraic heart of
+  spin-reflection positivity.
+
+Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*,
+1st ed., Springer 2020, §10.2.1, pp. 348–349; E. H. Lieb, *Phys. Rev. Lett.*
+**62** (1989) 1201.
+-/
+
+namespace LatticeSystem.Fermion
+
+open Matrix LatticeSystem.Math
+open scoped BigOperators ComplexOrder
+
+variable {N : ℕ}
+
+/-! ## Up/down configuration factorization -/
+
+/-- A single-species occupation configuration on the `N + 1` sites. -/
+abbrev hubbardSpinConfig (N : ℕ) : Type := Fin (N + 1) → Fin 2
+
+/-- The up-spin part of a spin-orbital configuration `c`: site `i ↦ c (2 i)`. -/
+def hubbardUpConfig (N : ℕ) (c : Fin (2 * N + 2) → Fin 2) : hubbardSpinConfig N :=
+  fun i => c (spinfulIndex N i 0)
+
+/-- The down-spin part of a spin-orbital configuration `c`: site `i ↦ c (2 i + 1)`. -/
+def hubbardDownConfig (N : ℕ) (c : Fin (2 * N + 2) → Fin 2) : hubbardSpinConfig N :=
+  fun i => c (spinfulIndex N i 1)
+
+/-- Reconstruct a spin-orbital configuration from its up/down parts:
+the orbital `o = 2 i + σ` receives `u i` if `σ = 0` (even) and `d i` if `σ = 1`. -/
+def hubbardMergeConfig (N : ℕ) (u d : hubbardSpinConfig N) :
+    Fin (2 * N + 2) → Fin 2 :=
+  fun o =>
+    if o.val % 2 = 0 then u ⟨o.val / 2, by have := o.isLt; omega⟩
+    else d ⟨o.val / 2, by have := o.isLt; omega⟩
+
+@[simp]
+theorem hubbardMergeConfig_spinfulIndex_zero (N : ℕ) (u d : hubbardSpinConfig N)
+    (i : Fin (N + 1)) : hubbardMergeConfig N u d (spinfulIndex N i 0) = u i := by
+  have hval : (spinfulIndex N i 0).val = 2 * i.val := by simp [spinfulIndex]
+  unfold hubbardMergeConfig
+  rw [if_pos (by omega)]
+  congr 1
+  have hdiv : (spinfulIndex N i 0).val / 2 = i.val := by omega
+  exact Fin.ext hdiv
+
+@[simp]
+theorem hubbardMergeConfig_spinfulIndex_one (N : ℕ) (u d : hubbardSpinConfig N)
+    (i : Fin (N + 1)) : hubbardMergeConfig N u d (spinfulIndex N i 1) = d i := by
+  have hval : (spinfulIndex N i 1).val = 2 * i.val + 1 := by simp [spinfulIndex]
+  unfold hubbardMergeConfig
+  rw [if_neg (by omega)]
+  congr 1
+  have hdiv : (spinfulIndex N i 1).val / 2 = i.val := by omega
+  exact Fin.ext hdiv
+
+@[simp]
+theorem hubbardUpConfig_merge (N : ℕ) (u d : hubbardSpinConfig N) :
+    hubbardUpConfig N (hubbardMergeConfig N u d) = u := by
+  funext i; simp [hubbardUpConfig]
+
+@[simp]
+theorem hubbardDownConfig_merge (N : ℕ) (u d : hubbardSpinConfig N) :
+    hubbardDownConfig N (hubbardMergeConfig N u d) = d := by
+  funext i; simp [hubbardDownConfig]
+
+@[simp]
+theorem hubbardMergeConfig_up_down (N : ℕ) (c : Fin (2 * N + 2) → Fin 2) :
+    hubbardMergeConfig N (hubbardUpConfig N c) (hubbardDownConfig N c) = c := by
+  funext o
+  obtain ⟨i, r, rfl⟩ := exists_spinfulIndex N o
+  fin_cases r
+  · simp [hubbardUpConfig]
+  · simp [hubbardDownConfig]
+
+/-- The basis-level factorization `H = H↑ ⊗ H↓`: a spin-orbital configuration is
+the same data as a pair `(up config, down config)`. -/
+def hubbardSpinConfigEquiv (N : ℕ) :
+    (Fin (2 * N + 2) → Fin 2) ≃ hubbardSpinConfig N × hubbardSpinConfig N where
+  toFun c := (hubbardUpConfig N c, hubbardDownConfig N c)
+  invFun p := hubbardMergeConfig N p.1 p.2
+  left_inv c := by simp
+  right_inv p := by obtain ⟨u, d⟩ := p; simp
+
+/-- The induced linear isomorphism between a state vector and its **coefficient
+matrix** `M_{u,d} = ψ (merge u d)` indexed by the up/down configurations. -/
+noncomputable def hubbardSpinCoeffLinearEquiv (N : ℕ) :
+    ((Fin (2 * N + 2) → Fin 2) → ℂ) ≃ₗ[ℂ]
+      Matrix (hubbardSpinConfig N) (hubbardSpinConfig N) ℂ where
+  toFun ψ := fun u d => ψ (hubbardMergeConfig N u d)
+  map_add' ψ φ := by funext u d; simp
+  map_smul' a ψ := by funext u d; simp
+  invFun M := fun c => M (hubbardUpConfig N c) (hubbardDownConfig N c)
+  left_inv ψ := by funext c; simp
+  right_inv M := by funext u d; simp
+
+/-! ## Sector bookkeeping -/
+
+/-- The total occupation splits into the up and down occupations:
+`∑_k c k = ∑_i (up c) i + ∑_i (down c) i`. -/
+theorem hubbardConfig_count_eq_up_add_down (N : ℕ) (c : Fin (2 * N + 2) → Fin 2) :
+    (∑ k : Fin (2 * N + 2), (c k).val) =
+      (∑ i : Fin (N + 1), (hubbardUpConfig N c i).val) +
+        (∑ i : Fin (N + 1), (hubbardDownConfig N c i).val) := by
+  rw [sum_spinful_reindex N (fun k => (c k).val)]
+  rw [← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  rw [Fin.sum_univ_two]
+  rfl
+
+/-! ## The spin reflection `θ` -/
+
+/-- Flip an occupation number: `0 ↦ 1`, `1 ↦ 0` (the particle–hole map on one
+orbital). -/
+def flipOccupation : Fin 2 → Fin 2 := fun a => if a = 0 then 1 else 0
+
+@[simp]
+theorem flipOccupation_flipOccupation (a : Fin 2) :
+    flipOccupation (flipOccupation a) = a := by
+  fin_cases a <;> rfl
+
+/-- The particle–hole map on a single-species configuration: flip every
+occupation number. -/
+def particleHoleConfig (N : ℕ) (c : hubbardSpinConfig N) : hubbardSpinConfig N :=
+  fun i => flipOccupation (c i)
+
+theorem particleHoleConfig_involutive (N : ℕ) :
+    Function.Involutive (particleHoleConfig N) := by
+  intro c; funext i; simp [particleHoleConfig]
+
+@[simp]
+theorem particleHoleConfig_particleHoleConfig (N : ℕ) (c : hubbardSpinConfig N) :
+    particleHoleConfig N (particleHoleConfig N c) = c :=
+  particleHoleConfig_involutive N c
+
+/-- The configuration-level spin reflection `θ`: swap the up/down species and
+apply the particle–hole map to each, i.e. `(n↑, n↓) ↦ (1 − n↓, 1 − n↑)`. -/
+def spinReflectionConfig (N : ℕ) (c : Fin (2 * N + 2) → Fin 2) :
+    Fin (2 * N + 2) → Fin 2 :=
+  hubbardMergeConfig N (particleHoleConfig N (hubbardDownConfig N c))
+    (particleHoleConfig N (hubbardUpConfig N c))
+
+theorem spinReflectionConfig_involutive (N : ℕ) :
+    Function.Involutive (spinReflectionConfig N) := by
+  intro c
+  simp only [spinReflectionConfig, hubbardUpConfig_merge, hubbardDownConfig_merge,
+    particleHoleConfig_particleHoleConfig, hubbardMergeConfig_up_down]
+
+/-- The spin reflection `θ` as a permutation of configurations. -/
+def spinReflectionConfigEquiv (N : ℕ) :
+    (Fin (2 * N + 2) → Fin 2) ≃ (Fin (2 * N + 2) → Fin 2) :=
+  (spinReflectionConfig_involutive N).toPerm
+
+/-- The antiunitary spin reflection `θ` on state vectors:
+`(θ ψ) c = conj (ψ (spinReflectionConfig c))`. -/
+noncomputable def spinReflectionThetaVec (N : ℕ)
+    (ψ : (Fin (2 * N + 2) → Fin 2) → ℂ) : (Fin (2 * N + 2) → Fin 2) → ℂ :=
+  fun c => star (ψ (spinReflectionConfig N c))
+
+/-- `θ` is conjugate-linear in the scalar: `θ (a • ψ) = conj a • θ ψ`. -/
+theorem spinReflectionThetaVec_smul (N : ℕ) (a : ℂ)
+    (ψ : (Fin (2 * N + 2) → Fin 2) → ℂ) :
+    spinReflectionThetaVec N (a • ψ) = star a • spinReflectionThetaVec N ψ := by
+  funext c
+  simp only [spinReflectionThetaVec, Pi.smul_apply, smul_eq_mul, star_mul']
+
+/-- `θ` is involutive on state vectors. -/
+theorem spinReflectionThetaVec_involutive (N : ℕ) :
+    Function.Involutive (spinReflectionThetaVec (N := N)) := by
+  intro ψ; funext c
+  simp [spinReflectionThetaVec, spinReflectionConfig_involutive N c]
+
+/-- **Antiunitarity of `θ`**: it preserves the Hermitian inner product up to
+conjugation, `⟨θ ψ, θ φ⟩ = conj ⟨ψ, φ⟩`. -/
+theorem spinReflectionThetaVec_dotProduct (N : ℕ)
+    (ψ φ : (Fin (2 * N + 2) → Fin 2) → ℂ) :
+    dotProduct (star (spinReflectionThetaVec N ψ)) (spinReflectionThetaVec N φ)
+      = star (dotProduct (star ψ) φ) := by
+  have hL : dotProduct (star (spinReflectionThetaVec N ψ)) (spinReflectionThetaVec N φ)
+      = ∑ c, ψ (spinReflectionConfig N c) * star (φ (spinReflectionConfig N c)) := by
+    unfold dotProduct
+    refine Finset.sum_congr rfl fun c _ => ?_
+    simp only [Pi.star_apply, spinReflectionThetaVec, star_star]
+  have hR : star (dotProduct (star ψ) φ) = ∑ x, ψ x * star (φ x) := by
+    unfold dotProduct
+    rw [star_sum]
+    refine Finset.sum_congr rfl fun x _ => ?_
+    simp only [Pi.star_apply, star_mul', star_star]
+  rw [hL, hR, ← Equiv.sum_comp (spinReflectionConfigEquiv N) (fun x => ψ x * star (φ x))]
+  rfl
+
+/-! ## The spin-reflection coefficient matrix -/
+
+/-- The spin-reflection coefficient matrix: the coefficient matrix of `ψ` with
+the **down index read as a hole configuration**,
+`(spinReflectionCoeff ψ) u h = ψ (merge u (particle-hole h))`. -/
+noncomputable def spinReflectionCoeff (N : ℕ)
+    (ψ : (Fin (2 * N + 2) → Fin 2) → ℂ) :
+    Matrix (hubbardSpinConfig N) (hubbardSpinConfig N) ℂ :=
+  fun u h => ψ (hubbardMergeConfig N u (particleHoleConfig N h))
+
+/-- A state vector is **spin-reflection positive** when its coefficient matrix
+(with the down hole gauge) is positive-semidefinite. -/
+def SpinReflectionPositive (N : ℕ)
+    (ψ : (Fin (2 * N + 2) → Fin 2) → ℂ) : Prop :=
+  (spinReflectionCoeff N ψ).PosSemidef
+
+/-- `θ` acts on the coefficient matrix as the conjugate transpose:
+`spinReflectionCoeff (θ ψ) = (spinReflectionCoeff ψ)ᴴ`. -/
+theorem spinReflectionCoeff_thetaVec (N : ℕ)
+    (ψ : (Fin (2 * N + 2) → Fin 2) → ℂ) :
+    spinReflectionCoeff N (spinReflectionThetaVec N ψ)
+      = (spinReflectionCoeff N ψ)ᴴ := by
+  funext u h
+  simp only [spinReflectionCoeff, spinReflectionThetaVec, conjTranspose_apply,
+    spinReflectionConfig, hubbardUpConfig_merge, hubbardDownConfig_merge,
+    particleHoleConfig_particleHoleConfig]
+
+/-! ## The spin-reflection-positivity nonnegativity -/
+
+/-- **The algebraic heart of spin-reflection positivity.**  For any
+positive-semidefinite matrix `C` and any matrix `A`, the trace
+`tr (C A C Aᴴ)` has nonnegative real part.  Writing `C = B²` with `B ≥ 0`
+Hermitian and `M := B A B`, cyclicity gives `tr (C A C Aᴴ) = tr (M Mᴴ) ≥ 0`. -/
+theorem spinReflection_gramMatrix_nonneg {ι : Type*} [Fintype ι]
+    {C : Matrix ι ι ℂ} (hC : C.PosSemidef) (A : Matrix ι ι ℂ) :
+    0 ≤ (Matrix.trace (C * A * C * Aᴴ)).re := by
+  classical
+  obtain ⟨B, hB, hBC⟩ := exists_posSemidef_sq_eq_of_posSemidef hC
+  have hBH : Bᴴ = B := hB.isHermitian.eq
+  have hMMH : (B * A * B) * (B * A * B)ᴴ = (B * A * B * B * Aᴴ) * B := by
+    simp only [conjTranspose_mul, hBH]; noncomm_ring
+  have htr : Matrix.trace (C * A * C * Aᴴ)
+      = Matrix.trace ((B * A * B) * (B * A * B)ᴴ) := by
+    rw [hMMH, Matrix.trace_mul_comm (B * A * B * B * Aᴴ) B, hBC]
+    congr 1
+    noncomm_ring
+  rw [htr]
+  have hpsd : ((B * A * B) * (B * A * B)ᴴ).PosSemidef :=
+    Matrix.posSemidef_self_mul_conjTranspose (B * A * B)
+  simpa using (Complex.le_def.mp hpsd.trace_nonneg).1
+
+end LatticeSystem.Fermion

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractiveReflection.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractiveReflection.lean
@@ -77,6 +77,7 @@ def hubbardMergeConfig (N : ℕ) (u d : hubbardSpinConfig N) :
     if o.val % 2 = 0 then u ⟨o.val / 2, by have := o.isLt; omega⟩
     else d ⟨o.val / 2, by have := o.isLt; omega⟩
 
+/-- Merging reads the up part on even orbitals: `merge u d (2 i) = u i`. -/
 @[simp]
 theorem hubbardMergeConfig_spinfulIndex_zero (N : ℕ) (u d : hubbardSpinConfig N)
     (i : Fin (N + 1)) : hubbardMergeConfig N u d (spinfulIndex N i 0) = u i := by
@@ -87,6 +88,7 @@ theorem hubbardMergeConfig_spinfulIndex_zero (N : ℕ) (u d : hubbardSpinConfig 
   have hdiv : (spinfulIndex N i 0).val / 2 = i.val := by omega
   exact Fin.ext hdiv
 
+/-- Merging reads the down part on odd orbitals: `merge u d (2 i + 1) = d i`. -/
 @[simp]
 theorem hubbardMergeConfig_spinfulIndex_one (N : ℕ) (u d : hubbardSpinConfig N)
     (i : Fin (N + 1)) : hubbardMergeConfig N u d (spinfulIndex N i 1) = d i := by
@@ -97,16 +99,20 @@ theorem hubbardMergeConfig_spinfulIndex_one (N : ℕ) (u d : hubbardSpinConfig N
   have hdiv : (spinfulIndex N i 1).val / 2 = i.val := by omega
   exact Fin.ext hdiv
 
+/-- The up projection recovers the up part of a merge: `up (merge u d) = u`. -/
 @[simp]
 theorem hubbardUpConfig_merge (N : ℕ) (u d : hubbardSpinConfig N) :
     hubbardUpConfig N (hubbardMergeConfig N u d) = u := by
   funext i; simp [hubbardUpConfig]
 
+/-- The down projection recovers the down part of a merge: `down (merge u d) = d`. -/
 @[simp]
 theorem hubbardDownConfig_merge (N : ℕ) (u d : hubbardSpinConfig N) :
     hubbardDownConfig N (hubbardMergeConfig N u d) = d := by
   funext i; simp [hubbardDownConfig]
 
+/-- Merging the up/down projections recovers the configuration:
+`merge (up c) (down c) = c`. -/
 @[simp]
 theorem hubbardMergeConfig_up_down (N : ℕ) (c : Fin (2 * N + 2) → Fin 2) :
     hubbardMergeConfig N (hubbardUpConfig N c) (hubbardDownConfig N c) = c := by
@@ -157,6 +163,7 @@ theorem hubbardConfig_count_eq_up_add_down (N : ℕ) (c : Fin (2 * N + 2) → Fi
 orbital). -/
 def flipOccupation : Fin 2 → Fin 2 := fun a => if a = 0 then 1 else 0
 
+/-- The occupation flip is an involution: `flip (flip a) = a`. -/
 @[simp]
 theorem flipOccupation_flipOccupation (a : Fin 2) :
     flipOccupation (flipOccupation a) = a := by
@@ -167,10 +174,12 @@ occupation number. -/
 def particleHoleConfig (N : ℕ) (c : hubbardSpinConfig N) : hubbardSpinConfig N :=
   fun i => flipOccupation (c i)
 
+/-- The particle–hole map is an involution. -/
 theorem particleHoleConfig_involutive (N : ℕ) :
     Function.Involutive (particleHoleConfig N) := by
   intro c; funext i; simp [particleHoleConfig]
 
+/-- The particle–hole map is an involution (simp form). -/
 @[simp]
 theorem particleHoleConfig_particleHoleConfig (N : ℕ) (c : hubbardSpinConfig N) :
     particleHoleConfig N (particleHoleConfig N c) = c :=
@@ -183,6 +192,7 @@ def spinReflectionConfig (N : ℕ) (c : Fin (2 * N + 2) → Fin 2) :
   hubbardMergeConfig N (particleHoleConfig N (hubbardDownConfig N c))
     (particleHoleConfig N (hubbardUpConfig N c))
 
+/-- The configuration-level spin reflection `θ` is an involution. -/
 theorem spinReflectionConfig_involutive (N : ℕ) :
     Function.Involutive (spinReflectionConfig N) := by
   intro c

--- a/docs/index.md
+++ b/docs/index.md
@@ -2953,6 +2953,17 @@ fermion mode acting on `ℂ²` with computational basis
 | `theorem_10_2_lieb_attractive_unique_singlet` | **Theorem 10.2** (Tasaki §10.2.1, p. 348, **AXIOM**): for an even electron number `N` with `0 < N ≤ 2\|Λ\|`, connected real symmetric hopping, and site-dependent attraction `U_x > 0`, the ground state of `Ĥ` in the `N`-electron sector is unique and a spin singlet (`(Ŝ_tot)² = 0`). Lieb's spin-space reflection positivity → faithful documented axiom. | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
 | `theorem_10_3_tian_pair_correlation_positive` | **Theorem 10.3** (Tian; Tasaki §10.2.1, p. 349, eq. (10.2.4), **AXIOM**): under the Theorem 10.2 hypotheses (with the non-full guard `N < 2\|Λ\|`), the unique ground state has strictly positive on-site pair-transfer correlation `⟨ΦGS\| ĉ†_{x↑}ĉ†_{x↓}ĉ_{y↓}ĉ_{y↑} \|ΦGS⟩ > 0` for all `x, y` (off-diagonal long-range order). Reflection positivity (Tian's extension) → faithful documented axiom. | `Fermion/JordanWigner/Hubbard/LiebAttractive.lean` |
 
+#### Spin-reflection-positivity foundation for Lieb's theorem (Tasaki §10.2.1, PR1 toward discharging Theorem 10.2)
+
+The finite-dimensional spin-reflection-positivity (SRP) coefficient-matrix language in which Lieb's proof is stated (the first layer toward discharging `theorem_10_2_lieb_attractive_unique_singlet`; the Hamiltonian positivity / Perron–Frobenius uniqueness / singlet argument are later layers). All axiom-free.
+
+| Lean name | Statement | File |
+|---|---|---|
+| `hubbardSpinConfig` / `hubbardUpConfig` / `hubbardDownConfig` / `hubbardMergeConfig` / `hubbardSpinConfigEquiv` | the basis-level factorization `H = H↑ ⊗ H↓`: a spin-orbital configuration `Fin (2N+2) → Fin 2` is the same data as a pair of single-species configurations `(up, down)` (via `spinfulIndex`), packaged as an `Equiv` | `Fermion/JordanWigner/Hubbard/LiebAttractiveReflection.lean` |
+| `hubbardSpinCoeffLinearEquiv` | the induced linear isomorphism of a state vector with its coefficient matrix `M_{u,d} = ψ (merge u d)` indexed by up/down configurations | `Fermion/JordanWigner/Hubbard/LiebAttractiveReflection.lean` |
+| `flipOccupation` / `particleHoleConfig` / `spinReflectionConfig` / `spinReflectionThetaVec` | the spin reflection `θ` (antiunitary spin-flip ∘ particle–hole, `(n↑,n↓) ↦ (1−n↓,1−n↑)`) at the configuration and state-vector level; `particleHoleConfig_involutive`, `spinReflectionConfig_involutive`, `spinReflectionThetaVec_smul` (conjugate-linear), `spinReflectionThetaVec_dotProduct` (`⟨θψ,θφ⟩ = conj⟨ψ,φ⟩`, antiunitarity) | `Fermion/JordanWigner/Hubbard/LiebAttractiveReflection.lean` |
+| `spinReflectionCoeff` / `SpinReflectionPositive` / `spinReflectionCoeff_thetaVec` / `spinReflection_gramMatrix_nonneg` | the SRP coefficient matrix (down index read as a hole), its positive-semidefiniteness predicate, the `θ`-on-coefficients = conjugate-transpose law, and the reusable nonnegativity `0 ≤ Re tr (C A C Aᴴ)` for `C` positive-semidefinite (the algebraic heart of SRP, via `C = B²` and `tr (C A C Aᴴ) = tr (M Mᴴ)`) | `Fermion/JordanWigner/Hubbard/LiebAttractiveReflection.lean` |
+
 #### Lieb's theorem for the repulsive Hubbard model at half-filling (Tasaki §10.2.2, Theorem 10.4)
 
 | Lean name | Statement | File |

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -5393,6 +5393,31 @@ $N < 2|\Lambda|$ (the fully-filled endpoint makes off-site pair transfer vanish 
 the concrete Fock representation). Proved by Tian's extension of Lieb's
 reflection-positivity method; recorded as a faithful documented \texttt{axiom}.
 
+\medskip
+\noindent\textbf{Spin-reflection-positivity foundation (PR1 toward discharging
+Theorem 10.2).} In file \texttt{LiebAttractiveReflection.lean} we build the
+finite-dimensional language in which Lieb's reflection-positivity proof is
+stated, all axiom-free. The state space $(\mathrm{Fin}\,(2N+2)\to\mathrm{Fin}\,2)
+\to\mathbb{C}$ factorizes at the basis level as $H=H_\uparrow\otimes H_\downarrow$:
+a spin-orbital configuration is the same data as a pair of single-species
+configurations via $\texttt{spinfulIndex}$ ($\texttt{hubbardSpinConfigEquiv}$),
+inducing the coefficient-matrix isomorphism $\psi\mapsto M_{u,d}=\psi(\mathrm{merge}\,
+u\,d)$ ($\texttt{hubbardSpinCoeffLinearEquiv}$). The spin reflection $\theta$
+combines the spin flip with a particle--hole transformation,
+$(n_\uparrow,n_\downarrow)\mapsto(1-n_\downarrow,1-n_\uparrow)$
+($\texttt{spinReflectionConfig}$, $\texttt{spinReflectionThetaVec}$); it is an
+involutive antiunitary, $\langle\theta\psi,\theta\varphi\rangle=
+\overline{\langle\psi,\varphi\rangle}$ ($\texttt{spinReflectionThetaVec\_dotProduct}$),
+and acts on the (down-hole gauged) coefficient matrix as the conjugate transpose,
+$\mathrm{coeff}(\theta\psi)=\mathrm{coeff}(\psi)^{\mathsf H}$
+($\texttt{spinReflectionCoeff\_thetaVec}$). The algebraic heart of SRP is the
+reusable nonnegativity $0\le\operatorname{Re}\operatorname{tr}(CAC A^{\mathsf H})$
+for any positive-semidefinite $C$ ($\texttt{spinReflection\_gramMatrix\_nonneg}$),
+proved by writing $C=B^2$ with $B\ge0$ Hermitian and using cyclicity to get
+$\operatorname{tr}(CAC A^{\mathsf H})=\operatorname{tr}(MM^{\mathsf H})\ge0$ with
+$M=BAB$. The Hamiltonian positivity, Perron--Frobenius uniqueness, and the singlet
+conclusion are later layers.
+
 %======================================================================
 \subsection{Lieb's theorem for the repulsive Hubbard model at half-filling (Tasaki §10.2.2, Theorem 10.4)}
 \label{subsec:lieb-repulsive}


### PR DESCRIPTION
Tracked in #4852 (Tasaki Ch.10 Lieb's theorems). Master #4718.

## What

PR1 of the discharge of `theorem_10_2_lieb_attractive_unique_singlet` (Tasaki Theorem 10.2, Lieb 1989: the attractive Hubbard model at even filling on a connected hopping graph has a unique singlet ground state). This PR builds the finite-dimensional **spin-reflection-positivity (SRP)** coefficient-matrix language in which Lieb's proof is stated. **All axiom-free** (`propext`/`Classical.choice`/`Quot.sound` only); does not touch the existing Theorem 10.2/10.3 axioms.

New file `LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractiveReflection.lean`:

- **Up/down factorization** `H = H↑ ⊗ H↓` at the basis level: `hubbardSpinConfig`, `hubbardUpConfig` / `hubbardDownConfig` / `hubbardMergeConfig` (via `spinfulIndex`), packaged as `hubbardSpinConfigEquiv`, and the induced linear iso `hubbardSpinCoeffLinearEquiv` (state vector ↔ coefficient matrix `M_{u,d} = ψ (merge u d)`). Plus `hubbardConfig_count_eq_up_add_down` (occupation splits over species).
- **Spin reflection θ** (antiunitary spin-flip ∘ particle–hole, `(n↑,n↓) ↦ (1−n↓,1−n↑)`): `flipOccupation`, `particleHoleConfig`, `spinReflectionConfig`, `spinReflectionThetaVec`, with involutivity, conjugate-linearity (`spinReflectionThetaVec_smul`) and antiunitarity (`spinReflectionThetaVec_dotProduct`: `⟨θψ,θφ⟩ = conj⟨ψ,φ⟩`).
- **SRP coefficient matrix**: `spinReflectionCoeff` (down index read as a hole), `SpinReflectionPositive`, `spinReflectionCoeff_thetaVec` (θ acts as conjugate transpose), and `spinReflection_gramMatrix_nonneg` — the reusable nonnegativity `0 ≤ Re tr(C A C Aᴴ)` for positive-semidefinite `C` (the algebraic heart of SRP; `C = B²`, cyclicity ⟹ `tr(C A C Aᴴ) = tr(M Mᴴ) ≥ 0` with `M = BAB`).

Also: scoped **Lemma 10.1** decision in #4852 — `tasaki_lemma_10_1_degenerate_perturbation` is genuine second-order degenerate perturbation theory (`secondOrderEffectiveHamiltonian` + `λ→0⁺` limit), so it stays a documented axiom per the #4718 perturbation-theory exemption.

## Design

Codex-designed at PR start (independent of conversation context): the repo represents states as `(Fin (2N+2) → Fin 2) → ℂ` (not a tensor type), so the factorization is realized as a configuration `Equiv` and the SRP structure as a coefficient matrix indexed by `(up, down)` configs with the down column gauged to a hole. Later layers (separate PRs): Hamiltonian RP through `exp`, the polar/`|C|` replacement, connected-sector Perron–Frobenius, and the singlet conclusion.

## Verification

- `lake build` of the new file and of the `JordanWigner` aggregator: green, zero warnings.
- `#print axioms` on `spinReflection_gramMatrix_nonneg`, `spinReflectionThetaVec_dotProduct`, `spinReflectionCoeff_thetaVec`, `hubbardSpinConfigEquiv`: only `propext`, `Classical.choice`, `Quot.sound`.
- `docs/index.md` (new §10.2.1 SRP-foundation subsection) and `tex/proof-guide.tex` (new paragraph) synced; `latexmk -pdf proof-guide.tex` compiles clean (322 pp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
