### PR TITLE
Eliminate 3 redundant duplicate theorems in MarshallSignCore — #4914

### DIFF
--- a/LatticeSystem/Quantum/SpinS/MarshallSignCore.lean
+++ b/LatticeSystem/Quantum/SpinS/MarshallSignCore.lean
@@ -81,14 +81,6 @@ theorem marshallSignS_eq_of_eq (A : V → Bool)
     {σ' σ : V → Fin (N + 1)} (h : σ' = σ) :
     marshallSignS A σ' = marshallSignS A σ := by rw [h]
 
-/-- Symmetric form of the Marshall sign product:
-`marshallSignS A σ' * marshallSignS A σ = marshallSignS A σ * marshallSignS A σ'`. -/
-theorem marshallSignS_mul_swap (A : V → Bool) (σ σ' : V → Fin (N + 1)) :
-    marshallSignS A σ * marshallSignS A σ' =
-      marshallSignS A σ' * marshallSignS A σ :=
-  mul_comm _ _
-
-
 /-- For a constant configuration `σ ≡ s` and `s.val` even, the
 Marshall sign is `+1`. (Each `(-1)^(s.val)` factor is `+1`.) -/
 theorem marshallSignS_const_of_even
@@ -352,13 +344,6 @@ theorem marshallSignS_mul_self_inv (A : V → Bool) (σ : V → Fin (N + 1)) :
     marshallSignS A σ * (marshallSignS A σ)⁻¹ = 1 := by
   rw [marshallSignS_inv, marshallSignS_sq]
 
-/-- The Marshall sign is `±1` valued in `ℝ` (after embedding into ℂ). -/
-theorem marshallSignS_re (A : V → Bool) (σ : V → Fin (N + 1)) :
-    (marshallSignS A σ).re = 1 ∨ (marshallSignS A σ).re = -1 := by
-  rcases marshallSignS_eq_one_or_neg_one A σ with h | h
-  · left; rw [h]; rfl
-  · right; rw [h]; rfl
-
 /-- Imaginary part of the Marshall sign is zero. -/
 theorem marshallSignS_im (A : V → Bool) (σ : V → Fin (N + 1)) :
     (marshallSignS A σ).im = 0 := by
@@ -440,11 +425,6 @@ theorem marshallSignS_mul_comm (A : V → Bool) (σ σ' : V → Fin (N + 1)) :
     marshallSignS A σ * marshallSignS A σ' =
       marshallSignS A σ' * marshallSignS A σ :=
   mul_comm _ _
-
-/-- Restated form: `marshallSignS A σ * marshallSignS A σ = 1`. -/
-theorem marshallSignS_mul_self (A : V → Bool) (σ : V → Fin (N + 1)) :
-    marshallSignS A σ * marshallSignS A σ = 1 :=
-  marshallSignS_sq A σ
 
 /-- The Marshall sign belongs to the set `{1, -1}`. -/
 theorem marshallSignS_mem_pm_one


### PR DESCRIPTION
## 概要
Issue #4914 (重複宣言の全除去) PR1。`Quantum/SpinS/MarshallSignCore.lean` 内の
**参照0・冗長な重複定理3つ** を削除する。同一ファイル内・import/API 変更なし。

## 削除対象 (いずれも canonical 側が残り現役)
| 削除 (参照0) | canonical (残す) | 根拠 |
|---|---|---|
| `marshallSignS_mul_swap` | `marshallSignS_mul_comm` | statement 完全一致 + 証明 `mul_comm _ _` も同一 |
| `marshallSignS_mul_self` | `marshallSignS_sq` | 本体が `:= marshallSignS_sq A σ` の別名 |
| `marshallSignS_re` | `marshallSignS_re_eq_one_or_neg_one` | statement 完全一致 |

## 検証
- 削除3宣言の repo 全体参照: いずれも 0 (削除後も 0)。
- `lake build LatticeSystem.Quantum.SpinS.MarshallSignCore` (+ 下流 MarshallSign) green、警告なし。
- docs/index.md・tex/proof-guide.tex は生存側 `marshallSignS_re_eq_one_or_neg_one` のみ参照 (stale 参照なし)。

## 方針 (Issue #4914)
かつて Claude が勝手に採用した「意図的な重複コピー」慣習を撤回し、重複は allowlist 温存ではなく
**除去** する原則の第一歩。
