### PR TITLE
Eliminate duplicate spinHalfDot_mulVec_const across SpinDot modules — #4914

### DIFF
--- a/LatticeSystem/Quantum/SpinDot/Hamiltonian.lean
+++ b/LatticeSystem/Quantum/SpinDot/Hamiltonian.lean
@@ -20,21 +20,6 @@ open Matrix
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 
-/-- `Ŝ_x · Ŝ_y` action on a uniformly-aligned basis state (constant `s`):
-`(3/4) |s⟩` for `x = y`, `(1/4) |s⟩` for `x ≠ y`.  (Private copy of the
-`HamiltonianCore` helper, duplicated because `private` declarations do not cross
-module boundaries.) -/
-private theorem spinHalfDot_mulVec_const (s : Fin 2) (x y : Λ) :
-    (spinHalfDot x y).mulVec (basisVec (fun _ : Λ => s)) =
-      (if x = y then (3 / 4 : ℂ) else (1 / 4 : ℂ)) •
-        basisVec (fun _ : Λ => s) := by
-  by_cases hxy : x = y
-  · subst hxy
-    rw [if_pos rfl, spinHalfDot_self]
-    rw [Matrix.smul_mulVec, Matrix.one_mulVec]
-  · rw [if_neg hxy]
-    exact spinHalfDot_mulVec_basisVec_parallel hxy _ rfl
-
 /-! ## Spin-`1/2` total `Ŝ_tot^{(1,2)}` zero expectation (γ-4 step 215) -/
 
 /-- Per-site spin-`1/2` `Ŝ^(1)_x` has zero expectation on every basis

--- a/LatticeSystem/Quantum/SpinDot/HamiltonianCore.lean
+++ b/LatticeSystem/Quantum/SpinDot/HamiltonianCore.lean
@@ -138,8 +138,9 @@ theorem heisenbergHamiltonian_mulVec_preserves_totalSpinHalfSquared_eigenvalue
 /-! ## Casimir eigenvalue on the all-up / all-down states -/
 
 /-- `Ŝ_x · Ŝ_y` action on a uniformly-aligned basis state (constant `s`):
-`(3/4) |s⟩` for `x = y`, `(1/4) |s⟩` for `x ≠ y`. -/
-private theorem spinHalfDot_mulVec_const (s : Fin 2) (x y : Λ) :
+`(3/4) |s⟩` for `x = y`, `(1/4) |s⟩` for `x ≠ y`.  Canonical version; the
+downstream `SpinDot/Hamiltonian.lean` imports and reuses this (no copy). -/
+theorem spinHalfDot_mulVec_const (s : Fin 2) (x y : Λ) :
     (spinHalfDot x y).mulVec (basisVec (fun _ : Λ => s)) =
       (if x = y then (3 / 4 : ℂ) else (1 / 4 : ℂ)) •
         basisVec (fun _ : Λ => s) := by

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -2970,7 +2970,7 @@ parallel spins).
 Unfold \texttt{heisenbergHamiltonian} to
 $\sum_{x,y} J(x,y)\,\hat S_x\cdot\hat S_y$. By
 \texttt{Matrix.sum\_mulVec} each summand acts on the constant basis
-state independently. The internal lemma
+state independently. The lemma
 \texttt{spinHalfDot\_mulVec\_const} provides the eigenvalue
 $\tfrac{3}{4}$ for $x=y$ (using \texttt{spinHalfDot\_self}, which
 gives $\hat S_x\cdot\hat S_x = (3/4)\,I$) and $\tfrac{1}{4}$ for


### PR DESCRIPTION
## 概要
Issue #4914 PR2。`spinHalfDot_mulVec_const` が `SpinDot/HamiltonianCore.lean` (canonical) と
`SpinDot/Hamiltonian.lean` の**両方に `private` で重複**していた (後者は「private は module 境界を
越えないから複製」という撤回済み異常慣習の産物; doc にも "Private copy" と明記されていた)。

## 修正
- HamiltonianCore の `spinHalfDot_mulVec_const` を **public 化** (define once)。
- Hamiltonian.lean の private コピーを削除 (Hamiltonian は既に Core を import; 唯一の使用箇所は
  import された補題に解決)。
- `tex/proof-guide.tex`: "internal lemma" → "lemma" (public 可視性に整合)。

## 検証
- `lake build LatticeSystem.Quantum.SpinDot.Hamiltonian` green・警告なし。
- 宣言は1つに (Core:143)、使用は Core:159/171 + Hamiltonian:161。
- `audit_gate.py --full` V2 が `spinHalfDot_mulVec_const` を flag しなくなった (0)。
