### PR TITLE
Eliminate 4 duplicate star_mulVec_dotProduct into Math/ComplexVectorKernel — #4914

### DIFF
--- a/LatticeSystem/Math/ComplexVectorKernel.lean
+++ b/LatticeSystem/Math/ComplexVectorKernel.lean
@@ -1,4 +1,5 @@
 import Mathlib.LinearAlgebra.Matrix.DotProduct
+import Mathlib.LinearAlgebra.Matrix.ConjTranspose
 import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 
 /-!
@@ -29,5 +30,11 @@ theorem complexVec_eq_zero_of_star_dotProduct {n : Type*} [Fintype n] {v : n →
     (Finset.sum_eq_zero_iff_of_nonneg (fun k _ => Complex.normSq_nonneg _)).mp hsum j
       (Finset.mem_univ j)
   exact Complex.normSq_eq_zero.mp hj
+
+/-- For a complex square matrix `M`, `star (M *ᵥ v) ⬝ᵥ w = star v ⬝ᵥ Mᴴ *ᵥ w`
+(adjoint move across the dot product). -/
+theorem star_mulVec_dotProduct {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) (v w : ι → ℂ) :
+    star (M.mulVec v) ⬝ᵥ w = star v ⬝ᵥ M.conjTranspose.mulVec w := by
+  rw [Matrix.star_mulVec, Matrix.dotProduct_mulVec]
 
 end LatticeSystem

--- a/LatticeSystem/Quantum/SpinS/LiebSchultzMattisOrthogonality.lean
+++ b/LatticeSystem/Quantum/SpinS/LiebSchultzMattisOrthogonality.lean
@@ -1,5 +1,6 @@
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisProof
 import LatticeSystem.Quantum.SpinS.TotalSpin
+import LatticeSystem.Math.ComplexVectorKernel
 import Mathlib.Logic.Equiv.Fin.Rotate
 
 /-!
@@ -243,11 +244,6 @@ theorem lsmPhase_chainConfigShift (L N : ℕ) (hL : 0 < L) (σ : Fin L → Fin (
         split_ifs <;> ring]
   rw [Finset.sum_sub_distrib]
 
-/-- Adjoint–vector identity (file-local copy). -/
-private theorem star_mulVec_dotProduct' {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) (v w : ι → ℂ) :
-    star (M.mulVec v) ⬝ᵥ w = star v ⬝ᵥ M.conjTranspose.mulVec w := by
-  rw [Matrix.star_mulVec, Matrix.dotProduct_mulVec]
-
 /-- The boundary wrap exponentiates to `(−1)^{2S} = (−1)^N`: `e^{−i·2π(S − m)} = (−1)^N`. -/
 theorem exp_neg_I_two_pi_half_sub (N m : ℕ) :
     NormedSpace.exp (-Complex.I * ((2 * Real.pi : ℂ) * ((N : ℂ) / 2 - (m : ℂ)))) =
@@ -373,7 +369,7 @@ theorem lsm_ground_twist_orthogonal (L N : ℕ) (hL : 0 < L) (hNodd : Odd N)
   have hcc : star c * c = 1 := by
     have hu : star ((chainTranslationOp L N).mulVec Φ_GS) ⬝ᵥ
         (chainTranslationOp L N).mulVec Φ_GS = star Φ_GS ⬝ᵥ Φ_GS := by
-      rw [star_mulVec_dotProduct', Matrix.mulVec_mulVec, chainTranslationOp_unitary,
+      rw [star_mulVec_dotProduct, Matrix.mulVec_mulVec, chainTranslationOp_unitary,
         Matrix.one_mulVec]
     rw [hc, star_smul, smul_dotProduct, dotProduct_smul, smul_eq_mul, smul_eq_mul,
       ← mul_assoc] at hu
@@ -382,7 +378,7 @@ theorem lsm_ground_twist_orthogonal (L N : ℕ) (hL : 0 < L) (hNodd : Odd N)
   unfold lsmTrialState
   have hb : star Φ_GS ⬝ᵥ ((chainTranslationOp L N).conjTranspose * lsmTwistOperator L N *
         chainTranslationOp L N).mulVec Φ_GS = star Φ_GS ⬝ᵥ (lsmTwistOperator L N).mulVec Φ_GS := by
-    rw [Matrix.mul_assoc, ← Matrix.mulVec_mulVec, ← star_mulVec_dotProduct', hc,
+    rw [Matrix.mul_assoc, ← Matrix.mulVec_mulVec, ← star_mulVec_dotProduct, hc,
       ← Matrix.mulVec_mulVec, hc, Matrix.mulVec_smul, star_smul, smul_dotProduct,
       dotProduct_smul, smul_eq_mul, smul_eq_mul, ← mul_assoc, hcc, one_mul]
   have ha : star Φ_GS ⬝ᵥ ((chainTranslationOp L N).conjTranspose * lsmTwistOperator L N *

--- a/LatticeSystem/Quantum/SpinS/LiebSchultzMattisProof.lean
+++ b/LatticeSystem/Quantum/SpinS/LiebSchultzMattisProof.lean
@@ -8,6 +8,7 @@ import Mathlib.Analysis.Complex.Order
 import LatticeSystem.Quantum.SpinS.AxisSwapUnitarySSpinSCore
 import LatticeSystem.Quantum.SpinS.Problem25cZAxisRotationInput
 import LatticeSystem.Math.PosSemidef.Basics
+import LatticeSystem.Math.ComplexVectorKernel
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.Matrix.Normed
 
@@ -30,12 +31,6 @@ namespace LatticeSystem.Quantum
 
 open Matrix NormedSpace
 open scoped ComplexOrder
-
-/-- Adjoint–vector identity: `⟨M v, w⟩ = ⟨v, Mᴴ w⟩` for the (conjugate-linear-left) dot product.
-(File-local private copy; the generic foundations live in `LiebSchultzMattisProofCore`.) -/
-private theorem star_mulVec_dotProduct {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) (v w : ι → ℂ) :
-    star (M.mulVec v) ⬝ᵥ w = star v ⬝ᵥ M.conjTranspose.mulVec w := by
-  rw [Matrix.star_mulVec, Matrix.dotProduct_mulVec]
 
 /-- The **LSM twist generator** `G = Σ_x θ_x Ŝ³_x` (`θ_x = 2π(x+1)/L`), the Hermitian operator
 exponentiated (with `−i`) to form `lsmTwistOperator`. -/

--- a/LatticeSystem/Quantum/SpinS/LiebSchultzMattisProofCore.lean
+++ b/LatticeSystem/Quantum/SpinS/LiebSchultzMattisProofCore.lean
@@ -6,6 +6,7 @@ import Mathlib.Analysis.Complex.Order
 import LatticeSystem.Quantum.SpinS.AxisSwapUnitarySSpinSCore
 import LatticeSystem.Quantum.SpinS.Problem25cZAxisRotationInput
 import LatticeSystem.Math.PosSemidef.Basics
+import LatticeSystem.Math.ComplexVectorKernel
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.Matrix.Normed
 
@@ -41,12 +42,6 @@ theorem dotProduct_star_self_re_pos {ι : Type*} [Fintype ι] {v : ι → ℂ} (
   rw [hsum, Complex.ofReal_re]
   exact Finset.sum_pos' (fun i _ => Complex.normSq_nonneg _)
     ⟨i₀, Finset.mem_univ _, Complex.normSq_pos.mpr hi₀⟩
-
-/-- Adjoint–vector identity: `⟨M v, w⟩ = ⟨v, Mᴴ w⟩` for the (conjugate-linear-left) dot product.
-(File-local copy to keep this module self-contained; a public version lives elsewhere.) -/
-private theorem star_mulVec_dotProduct {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) (v w : ι → ℂ) :
-    star (M.mulVec v) ⬝ᵥ w = star v ⬝ᵥ M.conjTranspose.mulVec w := by
-  rw [Matrix.star_mulVec, Matrix.dotProduct_mulVec]
 
 /-- Complex exponentials multiply by adding exponents (forward rewrite helper, `a b` explicit so the
 `Commute` witness is resolved inside the proof — avoids metavariable issues in `←` rewrites). -/

--- a/LatticeSystem/Quantum/SpinS/SU2ExpectationLadderInvariant.lean
+++ b/LatticeSystem/Quantum/SpinS/SU2ExpectationLadderInvariant.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Quantum.SpinS.Theorem23TotalLoweringNonvanishing
+import LatticeSystem.Math.ComplexVectorKernel
 
 /-!
 # SU(2)-invariant operator expectations are total-ladder invariant
@@ -47,15 +48,6 @@ private theorem star_dotProduct_self_eq'' {n : Type*} [Fintype n] (v : n → ℂ
   rw [dotProduct, Complex.ofReal_sum]
   refine Finset.sum_congr rfl (fun i _ => ?_)
   rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
-
-/-- **Matrix-adjoint dot-product law.** For a square matrix `M` and vectors `a b`,
-`star (M *ᵥ a) ⬝ᵥ b = star a ⬝ᵥ (Mᴴ *ᵥ b)`.  This is the finite-dimensional
-adjoint identity `⟨M a, b⟩ = ⟨a, Mᴴ b⟩` written in `dotProduct` form, obtained from
-`Matrix.star_mulVec` and `Matrix.dotProduct_mulVec`. -/
-theorem star_mulVec_dotProduct {n : Type*} [Fintype n]
-    (M : Matrix n n ℂ) (a b : n → ℂ) :
-    star (M.mulVec a) ⬝ᵥ b = star a ⬝ᵥ (M.conjTranspose.mulVec b) := by
-  rw [Matrix.star_mulVec, Matrix.dotProduct_mulVec]
 
 /-- **Scalar action of `Ŝ⁺_tot Ŝ⁻_tot` on a joint eigenvector.** If
 `Ŝ³_tot v = m • v` and `(Ŝ_tot)² v = γ • v`, then


### PR DESCRIPTION
Part of #4914

## Purpose

Issue #4914 PR4. Eliminate the 4 byte-identical duplicate copies of the
generic matrix lemma `star_mulVec_dotProduct`

```
star (M *ᵥ v) ⬝ᵥ w = star v ⬝ᵥ (Mᴴ *ᵥ w)
```

by consolidating a single public copy into `Math/ComplexVectorKernel.lean`.

## Background

Four statement-identical copies currently exist across the Quantum tree:

- `LiebSchultzMattisProofCore.lean:47` (private)
- `SU2ExpectationLadderInvariant.lean:55` (public)
- `LiebSchultzMattisOrthogonality.lean:247` (private, primed `star_mulVec_dotProduct'`)
- `LiebSchultzMattisProof.lean:36` (private)

None of these depend on any book-specific structure; the lemma is pure
generic linear algebra over `Matrix`/`Mᴴ`/`⬝ᵥ`, so it belongs in `Math/`
per the project's "organize generic math by mathematical topic, not by
textbook-source module name" convention.

## Change

- Add one public lemma `star_mulVec_dotProduct` to
  `Math/ComplexVectorKernel.lean`.
- Delete all 4 duplicate copies (including the primed variant in
  `LiebSchultzMattisOrthogonality.lean`, renamed to the unified name at
  call sites).
- Add the necessary `import` to each of the 4 consumer files
  (`LiebSchultzMattisProofCore.lean`, `SU2ExpectationLadderInvariant.lean`,
  `LiebSchultzMattisOrthogonality.lean`, `LiebSchultzMattisProof.lean`).

Design detail: `.self-local/reports/design-pr4-star-mulvec.md`.

## Scope note

This is a refactor of a generic helper lemma, not a new textbook theorem;
per project convention no `docs/index.md` row or `tex/proof-guide.tex`
update is expected. This will be confirmed as part of the docs-sync check
before merge.

## Checklist

- [ ] Add `star_mulVec_dotProduct` to `Math/ComplexVectorKernel.lean`
- [ ] Remove duplicate in `LiebSchultzMattisProofCore.lean`
- [ ] Remove duplicate in `SU2ExpectationLadderInvariant.lean`
- [ ] Remove duplicate (primed) in `LiebSchultzMattisOrthogonality.lean`
- [ ] Remove duplicate in `LiebSchultzMattisProof.lean`
- [ ] `lake build` clean, zero warnings
- [ ] `audit_gate.py --diff main` passes
- [ ] codex review verdict obtained before merge

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
