### PR TITLE
Eliminate Group-A Fermion/Hubbard private-copy duplicates — #4914

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreBasis.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreBasis.lean
@@ -75,7 +75,7 @@ private theorem fermionDownNumber_mulVec_basisVec_eq_zero_of_empty
 
 /-- The double-occupancy operator annihilates a basis vector whose up-orbital
 at site `i` is empty (commute `n_↑ n_↓ = n_↓ n_↑`, then `n_↑` kills it). -/
-private theorem hubbardDoubleOccupancy_mulVec_basisVec_eq_zero_of_up_empty
+theorem hubbardDoubleOccupancy_mulVec_basisVec_eq_zero_of_up_empty
     (N : ℕ) (i : Fin (N + 1)) (c : Fin (2 * N + 2) → Fin 2)
     (h : c (spinfulIndex N i 0) = 0) :
     (hubbardDoubleOccupancy N i).mulVec (basisVec c) = 0 := by
@@ -85,7 +85,7 @@ private theorem hubbardDoubleOccupancy_mulVec_basisVec_eq_zero_of_up_empty
 
 /-- The double-occupancy operator annihilates a basis vector whose
 down-orbital at site `i` is empty (`n_↓` kills it directly). -/
-private theorem hubbardDoubleOccupancy_mulVec_basisVec_eq_zero_of_down_empty
+theorem hubbardDoubleOccupancy_mulVec_basisVec_eq_zero_of_down_empty
     (N : ℕ) (i : Fin (N + 1)) (c : Fin (2 * N + 2) → Fin 2)
     (h : c (spinfulIndex N i 1) = 0) :
     (hubbardDoubleOccupancy N i).mulVec (basisVec c) = 0 := by

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreSpan.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreSpan.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreBasis
+import LatticeSystem.Fermion.JordanWigner.Hubbard.HopConfig
 
 /-!
 # Span of the one-hole hard-core sector by the basis states
@@ -42,11 +43,6 @@ def IsOneHoleHardcoreConfig (N : ℕ) (c : Fin (2 * N + 2) → Fin 2) : Prop :=
 private theorem fin_two_eq_zero_of_ne_one {v : Fin 2} (h : v ≠ 1) : v = 0 := by
   have h2 := v.isLt
   exact Fin.ext (by have : v.val ≠ 1 := fun hv => h (Fin.ext hv); omega)
-
-/-- A `Fin 2` value that is not `0` is `1`. -/
-private theorem fin_two_eq_one_of_ne_zero {v : Fin 2} (h : v ≠ 0) : v = 1 := by
-  have h2 := v.isLt
-  exact Fin.ext (by have : v.val ≠ 0 := fun hv => h (Fin.ext hv); omega)
 
 /-! ## The parametrized configurations are exactly the one-hole hard-core ones -/
 
@@ -99,7 +95,7 @@ theorem exists_eq_hubbardOneHoleConfig_of_isOneHoleHardcore
       · rw [if_pos hcu]; exact hcu
       · rw [if_neg hcu]; exact fin_two_eq_zero_of_ne_one hcu
   · -- down orbital
-    obtain rfl : s = 1 := fin_two_eq_one_of_ne_zero hs
+    obtain rfl : s = 1 := fin_two_ne_zero hs
     rw [hubbardOneHoleConfig_apply_down]
     by_cases hix : i = x
     · subst hix; rw [if_pos rfl]; exact hx_hole.2
@@ -114,7 +110,7 @@ theorem exists_eq_hubbardOneHoleConfig_of_isOneHoleHardcore
         · exact h
       · rw [if_neg hcu]
         have hup0 : c (spinfulIndex N i 0) = 0 := fin_two_eq_zero_of_ne_one hcu
-        exact fin_two_eq_one_of_ne_zero (fun hd => hnothole ⟨hup0, hd⟩)
+        exact fin_two_ne_zero (fun hd => hnothole ⟨hup0, hd⟩)
 
 /-! ## The one-hole hard-core sector and its spanning set -/
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HopAction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HopAction.lean
@@ -26,11 +26,6 @@ namespace LatticeSystem.Fermion
 
 open Matrix LatticeSystem.Quantum
 
-/-- A `Fin 2` value that is not `0` is `1`. -/
-private theorem fin_two_ne_zero {v : Fin 2} (h : v ≠ 0) : v = 1 := by
-  have h2 := v.isLt
-  exact Fin.ext (by have : v.val ≠ 0 := fun hv => h (Fin.ext hv); omega)
-
 /-- The one-hole configuration is empty on both orbitals at the hole site. -/
 private theorem hubbardOneHoleConfig_hole_zero
     (N : ℕ) (x : Fin (N + 1)) (σ : Fin (N + 1) → Bool) (s : Fin 2) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HopConfig.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HopConfig.lean
@@ -26,7 +26,7 @@ def hubbardSpinMove (N : ℕ) (σ : Fin (N + 1) → Bool) (x y : Fin (N + 1)) :
   Function.update σ x (σ y)
 
 /-- A `Fin 2` value that is not `0` is `1`. -/
-private theorem fin_two_ne_zero {v : Fin 2} (h : v ≠ 0) : v = 1 := by
+theorem fin_two_ne_zero {v : Fin 2} (h : v ≠ 0) : v = 1 := by
   have h2 := v.isLt
   exact Fin.ext (by have : v.val ≠ 0 := fun hv => h (Fin.ext hv); omega)
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/RemainingProjectionCommutes.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/RemainingProjectionCommutes.lean
@@ -28,20 +28,6 @@ namespace LatticeSystem.Fermion
 
 open LatticeSystem.Quantum
 
-private lemma n_commute_one_sub
-    (N : ℕ) (i j : Fin (N + 1)) :
-    Commute (fermionMultiNumber N i) (1 - fermionMultiNumber N j) := by
-  unfold Commute SemiconjBy
-  have hcomm := (fermionMultiNumber_commute N i j).eq
-  rw [mul_sub, sub_mul, Matrix.one_mul, Matrix.mul_one, hcomm]
-
-private lemma one_sub_commute_n
-    (N : ℕ) (i j : Fin (N + 1)) :
-    Commute (1 - fermionMultiNumber N i) (fermionMultiNumber N j) := by
-  unfold Commute SemiconjBy
-  have hcomm := (fermionMultiNumber_commute N i j).eq
-  rw [sub_mul, mul_sub, Matrix.one_mul, Matrix.mul_one, hcomm]
-
 private lemma one_sub_commute_one_sub
     (N : ℕ) (i j : Fin (N + 1)) :
     Commute (1 - fermionMultiNumber N i) (1 - fermionMultiNumber N j) := by
@@ -65,11 +51,11 @@ theorem fermionEmptyProjection_commute_fermionUpProjection_of_any
     Commute ((1 - fermionUpNumber N i) * (1 - fermionDownNumber N i))
       (fermionUpNumber N j * (1 - fermionDownNumber N j)) := by
   unfold fermionUpNumber fermionDownNumber
-  have c00 := one_sub_commute_n (2 * N + 1)
+  have c00 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 0)
   have c01 := one_sub_commute_one_sub (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 1)
-  have c10 := one_sub_commute_n (2 * N + 1)
+  have c10 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 0)
   have c11 := one_sub_commute_one_sub (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 1)
@@ -84,11 +70,11 @@ theorem fermionEmptyProjection_commute_fermionDownProjection_of_any
   unfold fermionUpNumber fermionDownNumber
   have c00 := one_sub_commute_one_sub (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 0)
-  have c01 := one_sub_commute_n (2 * N + 1)
+  have c01 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 1)
   have c10 := one_sub_commute_one_sub (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 0)
-  have c11 := one_sub_commute_n (2 * N + 1)
+  have c11 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 1)
   exact Commute.mul_right (Commute.mul_left c00 c10)
     (Commute.mul_left c01 c11)
@@ -99,13 +85,13 @@ theorem fermionEmptyProjection_commute_fermionDoublyProjection_of_any
     Commute ((1 - fermionUpNumber N i) * (1 - fermionDownNumber N i))
       (fermionUpNumber N j * fermionDownNumber N j) := by
   unfold fermionUpNumber fermionDownNumber
-  have c00 := one_sub_commute_n (2 * N + 1)
+  have c00 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 0)
-  have c01 := one_sub_commute_n (2 * N + 1)
+  have c01 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 1)
-  have c10 := one_sub_commute_n (2 * N + 1)
+  have c10 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 0)
-  have c11 := one_sub_commute_n (2 * N + 1)
+  have c11 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 1)
   exact Commute.mul_right (Commute.mul_left c00 c10)
     (Commute.mul_left c01 c11)
@@ -120,9 +106,9 @@ theorem fermionUpProjection_commute_fermionDoublyProjection_of_any
     (spinfulIndex N i 0) (spinfulIndex N j 0)
   have c01 := fermionMultiNumber_commute (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 1)
-  have c10 := one_sub_commute_n (2 * N + 1)
+  have c10 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 0)
-  have c11 := one_sub_commute_n (2 * N + 1)
+  have c11 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 1)
   exact Commute.mul_right (Commute.mul_left c00 c10)
     (Commute.mul_left c01 c11)
@@ -133,9 +119,9 @@ theorem fermionDownProjection_commute_fermionDoublyProjection_of_any
     Commute ((1 - fermionUpNumber N i) * fermionDownNumber N i)
       (fermionUpNumber N j * fermionDownNumber N j) := by
   unfold fermionUpNumber fermionDownNumber
-  have c00 := one_sub_commute_n (2 * N + 1)
+  have c00 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 0)
-  have c01 := one_sub_commute_n (2 * N + 1)
+  have c01 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 1)
   have c10 := fermionMultiNumber_commute (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 0)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/SingleProjectionsCommute.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/SingleProjectionsCommute.lean
@@ -25,14 +25,18 @@ namespace LatticeSystem.Fermion
 
 open LatticeSystem.Quantum
 
-private lemma fermionMultiNumber_commute_one_sub_fermionMultiNumber'
+/-- `Commute (n_i) (1 − n_j)`: a number operator commutes with the
+complement of another (from `fermionMultiNumber_commute`). -/
+lemma fermionMultiNumber_commute_one_sub_fermionMultiNumber'
     (N : ℕ) (i j : Fin (N + 1)) :
     Commute (fermionMultiNumber N i) (1 - fermionMultiNumber N j) := by
   unfold Commute SemiconjBy
   have hcomm := (fermionMultiNumber_commute N i j).eq
   rw [mul_sub, sub_mul, Matrix.one_mul, Matrix.mul_one, hcomm]
 
-private lemma one_sub_fermionMultiNumber_commute_fermionMultiNumber'
+/-- `Commute (1 − n_i) (n_j)`: the complement of a number operator
+commutes with another (from `fermionMultiNumber_commute`). -/
+lemma one_sub_fermionMultiNumber_commute_fermionMultiNumber'
     (N : ℕ) (i j : Fin (N + 1)) :
     Commute (1 - fermionMultiNumber N i) (fermionMultiNumber N j) := by
   unfold Commute SemiconjBy

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/SiteProjectionsDoublyEmpty.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/SiteProjectionsDoublyEmpty.lean
@@ -27,7 +27,9 @@ namespace LatticeSystem.Fermion
 
 open LatticeSystem.Quantum
 
-private lemma fermionMultiNumber_mul_one_sub_self_eq_zero
+/-- `n_i · (1 − n_i) = 0` for the per-site multi-index number
+operator (from `n_i · (c_i · c_i†) = 0` and `c_i · c_i† = 1 − n_i`). -/
+lemma fermionMultiNumber_mul_one_sub_self_eq_zero
     (N : ℕ) (i : Fin (N + 1)) :
     fermionMultiNumber N i * (1 - fermionMultiNumber N i) = 0 := by
   have h := fermionMultiNumber_mul_fermionMultiAnnihilation_mul_fermionMultiCreation_eq_zero
@@ -36,7 +38,9 @@ private lemma fermionMultiNumber_mul_one_sub_self_eq_zero
   rw [fermionMultiAnnihilation_mul_fermionMultiCreation_eq_one_sub_number] at h
   exact h
 
-private lemma one_sub_fermionMultiNumber_mul_self_eq_zero
+/-- `(1 − n_i) · n_i = 0` for the per-site multi-index number
+operator (from `(c_i · c_i†) · n_i = 0` and `c_i · c_i† = 1 − n_i`). -/
+lemma one_sub_fermionMultiNumber_mul_self_eq_zero
     (N : ℕ) (i : Fin (N + 1)) :
     (1 - fermionMultiNumber N i) * fermionMultiNumber N i = 0 := by
   have h := fermionMultiAnnihilation_mul_fermionMultiCreation_mul_fermionMultiNumber_eq_zero

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/SiteProjectionsEmptySingle.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/SiteProjectionsEmptySingle.lean
@@ -31,22 +31,6 @@ namespace LatticeSystem.Fermion
 
 open LatticeSystem.Quantum
 
-private lemma fermionMultiNumber_mul_one_sub_self_eq_zero
-    (N : ℕ) (i : Fin (N + 1)) :
-    fermionMultiNumber N i * (1 - fermionMultiNumber N i) = 0 := by
-  have h := fermionMultiNumber_mul_fermionMultiAnnihilation_mul_fermionMultiCreation_eq_zero
-    N i
-  rw [fermionMultiAnnihilation_mul_fermionMultiCreation_eq_one_sub_number] at h
-  exact h
-
-private lemma one_sub_fermionMultiNumber_mul_self_eq_zero
-    (N : ℕ) (i : Fin (N + 1)) :
-    (1 - fermionMultiNumber N i) * fermionMultiNumber N i = 0 := by
-  have h := fermionMultiAnnihilation_mul_fermionMultiCreation_mul_fermionMultiNumber_eq_zero
-    N i
-  rw [fermionMultiAnnihilation_mul_fermionMultiCreation_eq_one_sub_number] at h
-  exact h
-
 /-- `p_∅(i) · p_↑(i) = 0`. -/
 theorem fermionEmptyProjection_mul_fermionUpProjection_eq_zero
     (N : ℕ) (i : Fin (N + 1)) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/SiteProjectionsSingleDoubly.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/SiteProjectionsSingleDoubly.lean
@@ -30,22 +30,6 @@ namespace LatticeSystem.Fermion
 
 open LatticeSystem.Quantum
 
-private lemma fermionMultiNumber_mul_one_sub_self_eq_zero
-    (N : ℕ) (i : Fin (N + 1)) :
-    fermionMultiNumber N i * (1 - fermionMultiNumber N i) = 0 := by
-  have h := fermionMultiNumber_mul_fermionMultiAnnihilation_mul_fermionMultiCreation_eq_zero
-    N i
-  rw [fermionMultiAnnihilation_mul_fermionMultiCreation_eq_one_sub_number] at h
-  exact h
-
-private lemma one_sub_fermionMultiNumber_mul_self_eq_zero
-    (N : ℕ) (i : Fin (N + 1)) :
-    (1 - fermionMultiNumber N i) * fermionMultiNumber N i = 0 := by
-  have h := fermionMultiAnnihilation_mul_fermionMultiCreation_mul_fermionMultiNumber_eq_zero
-    N i
-  rw [fermionMultiAnnihilation_mul_fermionMultiCreation_eq_one_sub_number] at h
-  exact h
-
 /-- `p_↑(i) · p_⇈(i) = 0`. -/
 theorem fermionUpProjection_mul_fermionDoublyProjection_eq_zero
     (N : ℕ) (i : Fin (N + 1)) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJRaisingTermination.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJRaisingTermination.lean
@@ -23,30 +23,6 @@ open scoped BigOperators
 
 variable {N : ℕ}
 
-/-- Per-site `[N̂_↓, Ŝ⁺_x] = −Ŝ⁺_x` (local copy of the `TJSpinSymmetry` private helper). -/
-private theorem totalDownNumber_mul_siteSpinPlus (N : ℕ) (x : Fin (N + 1)) :
-    fermionTotalDownNumber N * fermionSiteSpinPlus N x =
-      fermionSiteSpinPlus N x * fermionTotalDownNumber N - fermionSiteSpinPlus N x := by
-  unfold fermionSiteSpinPlus
-  have hup := (fermionTotalDownNumber_commute_fermionUpCreation N x).eq
-  have han : fermionTotalDownNumber N * fermionDownAnnihilation N x =
-      fermionDownAnnihilation N x * fermionTotalDownNumber N - fermionDownAnnihilation N x := by
-    have h := fermionTotalDownNumber_commutator_fermionDownAnnihilation N x
-    linear_combination (norm := noncomm_ring) h
-  calc fermionTotalDownNumber N * (fermionUpCreation N x * fermionDownAnnihilation N x)
-      = (fermionTotalDownNumber N * fermionUpCreation N x) * fermionDownAnnihilation N x := by
-        rw [← mul_assoc]
-    _ = (fermionUpCreation N x * fermionTotalDownNumber N) * fermionDownAnnihilation N x := by
-        rw [hup]
-    _ = fermionUpCreation N x * (fermionTotalDownNumber N * fermionDownAnnihilation N x) := by
-        rw [mul_assoc]
-    _ = fermionUpCreation N x *
-          (fermionDownAnnihilation N x * fermionTotalDownNumber N -
-            fermionDownAnnihilation N x) := by
-        rw [han]
-    _ = fermionUpCreation N x * fermionDownAnnihilation N x * fermionTotalDownNumber N -
-          fermionUpCreation N x * fermionDownAnnihilation N x := by noncomm_ring
-
 /-- **Total `[N̂_↓, Ŝ⁺_tot] = −Ŝ⁺_tot`.**  Each raising removes one down-spin. -/
 theorem fermionTotalDownNumber_mul_fermionTotalSpinPlus (N : ℕ) :
     fermionTotalDownNumber N * fermionTotalSpinPlus N =

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorBasis.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorBasis.lean
@@ -51,23 +51,6 @@ theorem tJConfigOf_apply_down (N : ℕ) (s : Fin (N + 1) → Fin 3) (i : Fin (N 
   have hmod : (spinfulIndex N i 1).val % 2 = 1 := by rw [hval, Nat.mul_add_mod]
   simp only [tJConfigOf, hsite, hmod, if_neg (by norm_num : ¬ (1 = 0))]
 
-/-- The double-occupancy operator vanishes on `basisVec c` when the up-orbital is empty (duplicated
-private helper from `HardcoreBasis.lean`). -/
-private theorem tJ_doubleOcc_vanish_up (N : ℕ) (i : Fin (N + 1)) (c : Fin (2 * N + 2) → Fin 2)
-    (h : c (spinfulIndex N i 0) = 0) : (hubbardDoubleOccupancy N i).mulVec (basisVec c) = 0 := by
-  unfold hubbardDoubleOccupancy
-  rw [(fermionUpNumber_commute_fermionDownNumber N i).eq, ← Matrix.mulVec_mulVec]
-  unfold fermionUpNumber
-  rw [fermionMultiNumber_mulVec_basisVec, h]
-  simp
-
-/-- The double-occupancy operator vanishes on `basisVec c` when the down-orbital is empty. -/
-private theorem tJ_doubleOcc_vanish_down (N : ℕ) (i : Fin (N + 1)) (c : Fin (2 * N + 2) → Fin 2)
-    (h : c (spinfulIndex N i 1) = 0) : (hubbardDoubleOccupancy N i).mulVec (basisVec c) = 0 := by
-  unfold hubbardDoubleOccupancy fermionDownNumber
-  rw [← Matrix.mulVec_mulVec, fermionMultiNumber_mulVec_basisVec, h]
-  simp
-
 /-- **Every `tJConfigOf` basis state is hard-core**: at each site at least one orbital is empty
 (since `s i ∈ {0,1,2}` occupies at most one), so the double-occupancy operator vanishes. -/
 theorem tJConfigOf_mem_hardcore (N : ℕ) (s : Fin (N + 1) → Fin 3) :
@@ -75,9 +58,9 @@ theorem tJConfigOf_mem_hardcore (N : ℕ) (s : Fin (N + 1) → Fin 3) :
   rw [mem_hubbardHardcoreSubspace_iff]
   intro i
   by_cases h : s i = 2
-  · refine tJ_doubleOcc_vanish_up N i _ ?_
+  · refine hubbardDoubleOccupancy_mulVec_basisVec_eq_zero_of_up_empty N i _ ?_
     rw [tJConfigOf_apply_up, if_neg (by rw [h]; decide)]
-  · refine tJ_doubleOcc_vanish_down N i _ ?_
+  · refine hubbardDoubleOccupancy_mulVec_basisVec_eq_zero_of_down_empty N i _ ?_
     rw [tJConfigOf_apply_down, if_neg h]
 
 /-- `tJConfigOf` is injective: the spinful occupation determines the site state (the up-orbital

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorExchange.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorExchange.lean
@@ -55,7 +55,7 @@ theorem tJConfigOf_tJSpinSwap (N : ℕ) (s : Fin (N + 1) → Fin 3) (i j : Fin (
 
 /-- The modes below the successor `q` (`q.val = p.val + 1`) are those below `p` together with `p`.
 -/
-private theorem tJ_filt_succ (M : ℕ) (p q : Fin (M + 1)) (hq : q.val = p.val + 1) :
+theorem tJ_filt_succ (M : ℕ) (p q : Fin (M + 1)) (hq : q.val = p.val + 1) :
     (Finset.univ.filter (fun k : Fin (M + 1) => k.val < q.val))
       = insert p (Finset.univ.filter (fun k => k.val < p.val)) := by
   ext k; simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert]
@@ -66,7 +66,7 @@ private theorem tJ_filt_succ (M : ℕ) (p q : Fin (M + 1)) (hq : q.val = p.val +
   · rintro (rfl | hk) <;> omega
 
 /-- `p` lies above all the modes strictly below it. -/
-private theorem tJ_p_notmem (M : ℕ) (p : Fin (M + 1)) :
+theorem tJ_p_notmem (M : ℕ) (p : Fin (M + 1)) :
     p ∉ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < p.val)) := by
   simp only [Finset.mem_filter, Finset.mem_univ, true_and]; omega
 
@@ -94,7 +94,7 @@ private theorem jwSign_succ_cancel_low (M : ℕ) (c : Fin (M + 1) → Fin 2) (p 
 
 /-- **Adjacent-pair cancellation, high mode first.**  For successive modes `p, q` (`q.val =
 p.val + 1`) with `c p = 0`, `jwSign q c · jwSign p (update c q 0) = 1`. -/
-private theorem jwSign_succ_cancel_high (M : ℕ) (c : Fin (M + 1) → Fin 2) (p q : Fin (M + 1))
+theorem jwSign_succ_cancel_high (M : ℕ) (c : Fin (M + 1) → Fin 2) (p q : Fin (M + 1))
     (hq : q.val = p.val + 1) (hcp : c p = 0) :
     jwSign M q c * jwSign M p (Function.update c q 0) = 1 := by
   rw [jwSign_eq_neg_one_pow, jwSign_eq_neg_one_pow, ← pow_add]

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorRaise.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorRaise.lean
@@ -22,45 +22,6 @@ open scoped BigOperators
 
 variable {N : ℕ}
 
-/-- The modes below the successor `q` (`q.val = p.val + 1`) are those below `p` together with `p`.
-Local copy of the `TJSectorExchange` private helper (module-boundary convention). -/
-private theorem tJ_filt_succ (M : ℕ) (p q : Fin (M + 1)) (hq : q.val = p.val + 1) :
-    (Finset.univ.filter (fun k : Fin (M + 1) => k.val < q.val))
-      = insert p (Finset.univ.filter (fun k => k.val < p.val)) := by
-  ext k; simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert]
-  constructor
-  · intro hk; rcases eq_or_ne k p with rfl | h
-    · exact Or.inl rfl
-    · exact Or.inr (by have : k.val ≠ p.val := fun he => h (Fin.ext he); omega)
-  · rintro (rfl | hk) <;> omega
-
-/-- `p` lies above all the modes strictly below it. Local copy of the `TJSectorExchange` helper. -/
-private theorem tJ_p_notmem (M : ℕ) (p : Fin (M + 1)) :
-    p ∉ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < p.val)) := by
-  simp only [Finset.mem_filter, Finset.mem_univ, true_and]; omega
-
-/-- **Adjacent-pair cancellation, high mode first.**  For successive modes `p, q`
-(`q.val = p.val + 1`) with `c p = 0`, `jwSign q c · jwSign p (update c q 0) = 1`.  Local copy of the
-`TJSectorExchange` private helper (module-boundary convention). -/
-private theorem jwSign_succ_cancel_high (M : ℕ) (c : Fin (M + 1) → Fin 2) (p q : Fin (M + 1))
-    (hq : q.val = p.val + 1) (hcp : c p = 0) :
-    jwSign M q c * jwSign M p (Function.update c q 0) = 1 := by
-  rw [jwSign_eq_neg_one_pow, jwSign_eq_neg_one_pow, ← pow_add]
-  have hA : (∑ k ∈ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < q.val)), (c k).val)
-      = ∑ k ∈ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < p.val)), (c k).val := by
-    have h1 : (∑ k ∈ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < q.val)), (c k).val)
-        = (c p).val + ∑ k ∈ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < p.val)),
-            (c k).val := by
-      rw [tJ_filt_succ M p q hq]; exact Finset.sum_insert (tJ_p_notmem M p)
-    rw [h1, hcp]; simp
-  have hB : (∑ k ∈ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < p.val)),
-      ((Function.update c q 0) k).val)
-      = ∑ k ∈ (Finset.univ.filter (fun k : Fin (M + 1) => k.val < p.val)), (c k).val :=
-    Finset.sum_congr rfl fun k hk => by
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hk
-      rw [Function.update_of_ne (fun h => by rw [h] at hk; omega)]
-  rw [hA, hB, show ∀ a : ℕ, a + a = 2 * a from fun a => by ring, pow_mul]; norm_num
-
 /-- **Single-site raise config identity**: for `s x = ↓`, the spinful occupation of `s` with `x`
 raised to `↑` is `tJConfigOf s` with the down-orbital emptied and the up-orbital filled. -/
 theorem tJConfigOf_update_raise (N : ℕ) (s : Fin (N + 1) → Fin 3) (x : Fin (N + 1)) (hx : s x = 2) :

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSpinSymmetry.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSpinSymmetry.lean
@@ -46,7 +46,7 @@ private theorem totalUpNumber_mul_siteSpinPlus (N : ℕ) (x : Fin (N + 1)) :
           fermionUpCreation N x * fermionDownAnnihilation N x := by noncomm_ring
 
 /-- Weight relation `N̂_↓ Ŝ^+_x = Ŝ^+_x (N̂_↓ − 1)`: the down-number lowers by one on `Ŝ^+_x`. -/
-private theorem totalDownNumber_mul_siteSpinPlus (N : ℕ) (x : Fin (N + 1)) :
+theorem totalDownNumber_mul_siteSpinPlus (N : ℕ) (x : Fin (N + 1)) :
     fermionTotalDownNumber N * fermionSiteSpinPlus N x =
       fermionSiteSpinPlus N x * fermionTotalDownNumber N - fermionSiteSpinPlus N x := by
   unfold fermionSiteSpinPlus

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/UpDownProjectionCommute.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/UpDownProjectionCommute.lean
@@ -20,20 +20,6 @@ namespace LatticeSystem.Fermion
 
 open LatticeSystem.Quantum
 
-private lemma fermionMultiNumber_commute_one_sub_fermionMultiNumber''
-    (N : ℕ) (i j : Fin (N + 1)) :
-    Commute (fermionMultiNumber N i) (1 - fermionMultiNumber N j) := by
-  unfold Commute SemiconjBy
-  have hcomm := (fermionMultiNumber_commute N i j).eq
-  rw [mul_sub, sub_mul, Matrix.one_mul, Matrix.mul_one, hcomm]
-
-private lemma one_sub_fermionMultiNumber_commute_fermionMultiNumber''
-    (N : ℕ) (i j : Fin (N + 1)) :
-    Commute (1 - fermionMultiNumber N i) (fermionMultiNumber N j) := by
-  unfold Commute SemiconjBy
-  have hcomm := (fermionMultiNumber_commute N i j).eq
-  rw [sub_mul, mul_sub, Matrix.one_mul, Matrix.mul_one, hcomm]
-
 /-- `Commute (p_↑(i)) (p_↓(j))` for any `i, j`: cross-projection
 only-up vs only-down commute. -/
 theorem fermionUpProjection_commute_fermionDownProjection_of_any
@@ -42,7 +28,7 @@ theorem fermionUpProjection_commute_fermionDownProjection_of_any
       ((1 - fermionUpNumber N j) * fermionDownNumber N j) := by
   unfold fermionUpNumber fermionDownNumber
   -- Pairwise commute among {n_{2i}, 1-n_{2i+1}, 1-n_{2j}, n_{2j+1}}.
-  have c00 := fermionMultiNumber_commute_one_sub_fermionMultiNumber''
+  have c00 := fermionMultiNumber_commute_one_sub_fermionMultiNumber'
     (2 * N + 1) (spinfulIndex N i 0) (spinfulIndex N j 0)
   have c01 := fermionMultiNumber_commute (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 1)
@@ -69,7 +55,7 @@ theorem fermionUpProjection_commute_fermionDownProjection_of_any
             fermionMultiNumber (2 * N + 1) (spinfulIndex N i 1) from by
       rw [sub_mul, mul_sub, mul_sub]; simp only [one_mul, mul_one]; abel]
     rw [hcomm]; abel
-  have c11 := one_sub_fermionMultiNumber_commute_fermionMultiNumber''
+  have c11 := one_sub_fermionMultiNumber_commute_fermionMultiNumber'
     (2 * N + 1) (spinfulIndex N i 1) (spinfulIndex N j 1)
   exact Commute.mul_right (Commute.mul_left c00 c10)
     (Commute.mul_left c01 c11)


### PR DESCRIPTION
Part of #4914

## Purpose

PR5 of the Fermion/Hubbard/Jordan-Wigner duplicate-elimination thread (#4914).
Removes **Group A** duplicates: private helpers that were verbatim-copied into a
new module during a past file split (a since-retired practice), where the copy
site already imports (or can trivially import) the canonical module. These are
mechanical removals — no new design or new cross-module import direction is
introduced beyond making the existing canonical declaration non-`private` where
needed so the duplicate site can reference it directly.

Per `.self-local/reports/research-pr5-fermion-dedup.md`, Group A targets:

- `SiteProjections{EmptySingle,SingleDoubly}`: `fermionMultiNumber_mul_one_sub_self_eq_zero`
  / `one_sub_fermionMultiNumber_mul_self_eq_zero`
  (canonical: `SiteProjectionsDoublyEmpty`)
- `TJSectorExchange`: `tJ_filt_succ` / `tJ_p_notmem` / `jwSign_succ_cancel_high`
  (canonical: `TJSectorRaise`)
- `TJRaisingTermination`: `totalDownNumber_mul_siteSpinPlus`
  (canonical: `TJSpinSymmetry`)
- `RemainingProjectionCommutes` / `UpDownProjectionCommute`: the commute lemma(s)
  (canonical: `SingleProjectionsCommute`)
- `HopAction`: the `fin_two` lemma(s) (canonical: `HopConfig`)
- `HardcoreBasis`: the `doubleOcc` lemma(s) (canonical: `TJSectorBasis`,
  transitive import)

Where the canonical declaration was `private`, it is made non-`private` so the
duplicate site can import and reuse it instead of re-proving it.

## Scope / non-goals

- Group A is scoped to mechanical, same-statement duplicates with no new
  design decisions. Group B/C (semantic near-duplicates, harder import-graph
  restructuring) are tracked separately in #4914 and NOT part of this PR.
- Does not touch §10.2 (#4852) — that subtree is frozen and disjoint from the
  Group A target list above.
- Not a textbook theorem PR: no new `def`/`theorem`/`lemma` content is added,
  only duplicate removal + import wiring. `docs/index.md` / `tex/proof-guide.tex`
  are updated only if a moved/renamed declaration's file reference goes stale;
  otherwise no doc-sync is needed (confirmed after implementation).

## References

- Tracking issue: #4914
- Research doc: `.self-local/reports/research-pr5-fermion-dedup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
