### PR TITLE
Eliminate Commute (1-n_i)(1-n_j) triplicate into SingleProjectionsCommute — #4914

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/EmptyProjectionCommute.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/EmptyProjectionCommute.lean
@@ -1,4 +1,4 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.DoubleOccupancyProjection
+import LatticeSystem.Fermion.JordanWigner.Hubbard.SingleProjectionsCommute
 
 /-!
 # Cross-site Hubbard empty projection commute
@@ -24,24 +24,6 @@ Tracked as part of Phase 2 fermion infrastructure (Issue #412).
 namespace LatticeSystem.Fermion
 
 open LatticeSystem.Quantum
-
-private lemma one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber
-    (N : ℕ) (i j : Fin (N + 1)) :
-    Commute (1 - fermionMultiNumber N i) (1 - fermionMultiNumber N j) := by
-  unfold Commute SemiconjBy
-  have hcomm := (fermionMultiNumber_commute N i j).eq
-  rw [show ((1 : ManyBodyOp (Fin (N + 1))) - fermionMultiNumber N i) *
-      (1 - fermionMultiNumber N j) =
-      1 - fermionMultiNumber N j - fermionMultiNumber N i +
-        fermionMultiNumber N i * fermionMultiNumber N j from by
-    rw [sub_mul, mul_sub, mul_sub]; simp only [one_mul, mul_one]; abel,
-    show ((1 : ManyBodyOp (Fin (N + 1))) - fermionMultiNumber N j) *
-      (1 - fermionMultiNumber N i) =
-      1 - fermionMultiNumber N i - fermionMultiNumber N j +
-        fermionMultiNumber N j * fermionMultiNumber N i from by
-    rw [sub_mul, mul_sub, mul_sub]; simp only [one_mul, mul_one]; abel]
-  rw [hcomm]
-  abel
 
 /-- `Commute (p_∅(i)) (p_∅(j))`: cross-site empty projections
 commute. -/

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/RemainingProjectionCommutes.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/RemainingProjectionCommutes.lean
@@ -28,23 +28,6 @@ namespace LatticeSystem.Fermion
 
 open LatticeSystem.Quantum
 
-private lemma one_sub_commute_one_sub
-    (N : ℕ) (i j : Fin (N + 1)) :
-    Commute (1 - fermionMultiNumber N i) (1 - fermionMultiNumber N j) := by
-  unfold Commute SemiconjBy
-  have hcomm := (fermionMultiNumber_commute N i j).eq
-  rw [show ((1 : ManyBodyOp (Fin (N + 1))) - fermionMultiNumber N i) *
-      (1 - fermionMultiNumber N j) =
-      1 - fermionMultiNumber N j - fermionMultiNumber N i +
-        fermionMultiNumber N i * fermionMultiNumber N j from by
-    rw [sub_mul, mul_sub, mul_sub]; simp only [one_mul, mul_one]; abel,
-    show ((1 : ManyBodyOp (Fin (N + 1))) - fermionMultiNumber N j) *
-      (1 - fermionMultiNumber N i) =
-      1 - fermionMultiNumber N i - fermionMultiNumber N j +
-        fermionMultiNumber N j * fermionMultiNumber N i from by
-    rw [sub_mul, mul_sub, mul_sub]; simp only [one_mul, mul_one]; abel]
-  rw [hcomm]; abel
-
 /-- `Commute (p_∅(i)) (p_↑(j))` for any `i, j`. -/
 theorem fermionEmptyProjection_commute_fermionUpProjection_of_any
     (N : ℕ) (i j : Fin (N + 1)) :
@@ -53,11 +36,11 @@ theorem fermionEmptyProjection_commute_fermionUpProjection_of_any
   unfold fermionUpNumber fermionDownNumber
   have c00 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 0)
-  have c01 := one_sub_commute_one_sub (2 * N + 1)
+  have c01 := one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 1)
   have c10 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 0)
-  have c11 := one_sub_commute_one_sub (2 * N + 1)
+  have c11 := one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 1)
   exact Commute.mul_right (Commute.mul_left c00 c10)
     (Commute.mul_left c01 c11)
@@ -68,11 +51,11 @@ theorem fermionEmptyProjection_commute_fermionDownProjection_of_any
     Commute ((1 - fermionUpNumber N i) * (1 - fermionDownNumber N i))
       ((1 - fermionUpNumber N j) * fermionDownNumber N j) := by
   unfold fermionUpNumber fermionDownNumber
-  have c00 := one_sub_commute_one_sub (2 * N + 1)
+  have c00 := one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 0)
   have c01 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 1)
-  have c10 := one_sub_commute_one_sub (2 * N + 1)
+  have c10 := one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 0)
   have c11 := one_sub_fermionMultiNumber_commute_fermionMultiNumber' (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 1)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/SingleProjectionsCommute.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/SingleProjectionsCommute.lean
@@ -43,7 +43,9 @@ lemma one_sub_fermionMultiNumber_commute_fermionMultiNumber'
   have hcomm := (fermionMultiNumber_commute N i j).eq
   rw [sub_mul, mul_sub, Matrix.one_mul, Matrix.mul_one, hcomm]
 
-private lemma one_sub_one_sub_commute
+/-- `Commute (1 − n_i) (1 − n_j)`: the complements of two number
+operators commute (from `fermionMultiNumber_commute`). -/
+lemma one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber
     (N : ℕ) (i j : Fin (N + 1)) :
     Commute (1 - fermionMultiNumber N i) (1 - fermionMultiNumber N j) := by
   unfold Commute SemiconjBy
@@ -73,7 +75,7 @@ theorem fermionUpProjection_commute_of_any
     (2 * N + 1) (spinfulIndex N i 0) (spinfulIndex N j 1)
   have c10 := one_sub_fermionMultiNumber_commute_fermionMultiNumber'
     (2 * N + 1) (spinfulIndex N i 1) (spinfulIndex N j 0)
-  have c11 := one_sub_one_sub_commute (2 * N + 1)
+  have c11 := one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber (2 * N + 1)
     (spinfulIndex N i 1) (spinfulIndex N j 1)
   exact Commute.mul_right (Commute.mul_left c00 c10)
     (Commute.mul_left c01 c11)
@@ -85,7 +87,7 @@ theorem fermionDownProjection_commute_of_any
     Commute ((1 - fermionUpNumber N i) * fermionDownNumber N i)
       ((1 - fermionUpNumber N j) * fermionDownNumber N j) := by
   unfold fermionUpNumber fermionDownNumber
-  have c00 := one_sub_one_sub_commute (2 * N + 1)
+  have c00 := one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber (2 * N + 1)
     (spinfulIndex N i 0) (spinfulIndex N j 0)
   have c01 := one_sub_fermionMultiNumber_commute_fermionMultiNumber'
     (2 * N + 1) (spinfulIndex N i 0) (spinfulIndex N j 1)


### PR DESCRIPTION
Part of #4914

## Purpose
Group B(i) of the Issue #4914 dedup sweep: eliminate the `Commute (1 - n_i) (1 - n_j)`
triplicate identified by the Tier-1/Tier-2 audit of the fermion `Hubbard` directory.

## Problem
The identical `statement` (up to alpha-renaming) is proved as a `private` lemma in
three separate files, a leftover of the (now retracted) per-module private-copy
convention:

- `LatticeSystem/Fermion/JordanWigner/Hubbard/SingleProjectionsCommute.lean:46`
  `private lemma one_sub_one_sub_commute`
- `LatticeSystem/Fermion/JordanWigner/Hubbard/RemainingProjectionCommutes.lean:31`
  `private lemma one_sub_commute_one_sub`
- `LatticeSystem/Fermion/JordanWigner/Hubbard/EmptyProjectionCommute.lean:28`
  `private lemma one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber`

## Fix
- Canonicalize on `SingleProjectionsCommute.lean`: make the lemma public and rename
  it descriptively to
  `one_sub_fermionMultiNumber_commute_one_sub_fermionMultiNumber`.
- Delete the two duplicate `private` copies in `RemainingProjectionCommutes.lean`
  and `EmptyProjectionCommute.lean`.
- Add the missing `import` of `SingleProjectionsCommute` to `EmptyProjectionCommute.lean`
  (`RemainingProjectionCommutes.lean` already imports it).
- Rewrite all call sites to use the canonical name.
- No import cycle introduced; unrelated to the in-progress §10.2 Theorem 10.2 work.

## Scope
Pure refactor (no new math, no statement changes). Design reference:
`.self-local/reports/design-pr6-fermion-rest.md`, Group B(i).

## Verification
- `lake build` clean, zero warnings.
- `grep -rn "sorry"` in touched files: none.
- `scripts/audit_gate.py --diff main`: pass (no new decorative/duplicate declarations).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
