### PR TITLE
Replace fin_two_ne_zero with mathlib Fin.eq_one_of_ne_zero (C-1) — #4914

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreSpan.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreSpan.lean
@@ -95,7 +95,7 @@ theorem exists_eq_hubbardOneHoleConfig_of_isOneHoleHardcore
       · rw [if_pos hcu]; exact hcu
       · rw [if_neg hcu]; exact fin_two_eq_zero_of_ne_one hcu
   · -- down orbital
-    obtain rfl : s = 1 := fin_two_ne_zero hs
+    obtain rfl : s = 1 := Fin.eq_one_of_ne_zero _ hs
     rw [hubbardOneHoleConfig_apply_down]
     by_cases hix : i = x
     · subst hix; rw [if_pos rfl]; exact hx_hole.2
@@ -110,7 +110,7 @@ theorem exists_eq_hubbardOneHoleConfig_of_isOneHoleHardcore
         · exact h
       · rw [if_neg hcu]
         have hup0 : c (spinfulIndex N i 0) = 0 := fin_two_eq_zero_of_ne_one hcu
-        exact fin_two_ne_zero (fun hd => hnothole ⟨hup0, hd⟩)
+        exact Fin.eq_one_of_ne_zero _ (fun hd => hnothole ⟨hup0, hd⟩)
 
 /-! ## The one-hole hard-core sector and its spanning set -/
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HopAction.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HopAction.lean
@@ -32,7 +32,7 @@ private theorem hubbardOneHoleConfig_hole_zero
     hubbardOneHoleConfig N x σ (spinfulIndex N x s) = 0 := by
   by_cases h : s = 0
   · subst h; rw [hubbardOneHoleConfig_apply_up, if_pos rfl]
-  · obtain rfl : s = 1 := fin_two_ne_zero h
+  · obtain rfl : s = 1 := Fin.eq_one_of_ne_zero _ h
     rw [hubbardOneHoleConfig_apply_down, if_pos rfl]
 
 /-- Operator content of (11.2.4): the hole-filling hopping term

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HopConfig.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HopConfig.lean
@@ -25,11 +25,6 @@ def hubbardSpinMove (N : ℕ) (σ : Fin (N + 1) → Bool) (x y : Fin (N + 1)) :
     Fin (N + 1) → Bool :=
   Function.update σ x (σ y)
 
-/-- A `Fin 2` value that is not `0` is `1`. -/
-theorem fin_two_ne_zero {v : Fin 2} (h : v ≠ 0) : v = 1 := by
-  have h2 := v.isLt
-  exact Fin.ext (by have : v.val ≠ 0 := fun hv => h (Fin.ext hv); omega)
-
 /-- Spatial content of (11.2.4): filling the hole `x` with an electron of spin
 `s` hopped from `y` turns the configuration of `|Φ_{x,σ}⟩` into that of
 `|Φ_{y, σ_{y→x}}⟩`. The hypothesis `hs` says the `s`-orbital at `y` is
@@ -51,7 +46,7 @@ theorem hubbardOneHoleConfig_hop
       rw [hubbardOneHoleConfig_apply_up, if_neg (Ne.symm hxy')] at hs
       refine ⟨fun _ => rfl, fun _ => ?_⟩
       by_cases hσ : σ y <;> simp_all
-    · obtain rfl : s = 1 := fin_two_ne_zero hs0
+    · obtain rfl : s = 1 := Fin.eq_one_of_ne_zero _ hs0
       rw [hubbardOneHoleConfig_apply_down, if_neg (Ne.symm hxy')] at hs
       refine ⟨fun hσ => ?_, fun h => absurd h (by decide)⟩
       rw [hσ] at hs; simp at hs
@@ -63,11 +58,11 @@ theorem hubbardOneHoleConfig_hop
   have hrs : (r = 0) ∨ (r = 1) := by
     rcases eq_or_ne r 0 with h | h
     · exact Or.inl h
-    · exact Or.inr (fin_two_ne_zero h)
+    · exact Or.inr (Fin.eq_one_of_ne_zero _ h)
   have hss : (s = 0) ∨ (s = 1) := by
     rcases eq_or_ne s 0 with h | h
     · exact Or.inl h
-    · exact Or.inr (fin_two_ne_zero h)
+    · exact Or.inr (Fin.eq_one_of_ne_zero _ h)
   rcases eq_or_ne a x with rfl | hax
   · -- former hole site x (note a = x ≠ y)
     rcases hrs with rfl | rfl <;> rcases hss with rfl | rfl <;>

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaGroundStateCore.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaGroundStateCore.lean
@@ -347,10 +347,6 @@ theorem isOneHoleHardcore_of_noDouble_count (N : ℕ) (c : Fin (2 * N + 2) → F
     rw [hh, Finset.mem_singleton] at hmem
     exact hmem
 
-/-- A `Fin 2` value that is not `0` equals `1`. -/
-private theorem fin2_eq_one_of_ne_zero {a : Fin 2} (h : a ≠ 0) : a = 1 :=
-  Fin.ext (by have := a.isLt; have : a.val ≠ 0 := fun hv => h (Fin.ext hv); omega)
-
 /-- **Support of a hard-core number eigenstate.** If `v` lies in the hard-core
 subspace and is an `N`-electron eigenstate (`N̂ v = N • v`), then `v(w) = 0` at
 every configuration `w` that is not one-hole hard-core. So `v` is supported on
@@ -367,7 +363,7 @@ theorem mulVec_apply_eq_zero_of_not_oneHole (N : ℕ)
       intro i
       by_contra hcon
       rw [not_or] at hcon
-      exact hd ⟨i, fin2_eq_one_of_ne_zero hcon.1, fin2_eq_one_of_ne_zero hcon.2⟩
+      exact hd ⟨i, Fin.eq_one_of_ne_zero _ hcon.1, Fin.eq_one_of_ne_zero _ hcon.2⟩
     refine mulVec_apply_eq_zero_of_number_ne N v (N : ℂ) hN w (fun heq => hw ?_)
     refine isOneHoleHardcore_of_noDouble_count N w hnd ?_
     exact_mod_cast heq


### PR DESCRIPTION
Part of #4914

## Purpose

Group C-1 of the duplicate-declaration cleanup (#4914 PR8): replace the
repo's hand-written `fin_two_ne_zero` lemma with the mathlib lemma that
already states the same fact, removing the hand-rolled re-proof.

## Background

`fin_two_ne_zero {v : Fin 2} (h : v ≠ 0) : v = 1` in `HopConfig.lean` is a
re-proof of a fact mathlib already provides as `Fin.eq_one_of_ne_zero`. Per
the no-duplicate-declarations-ever policy (#4914), the repo copy is removed
and call sites are switched to the mathlib name. Design reference:
`.self-local/reports/design-pr6-fermion-rest.md` (Group C-1).

Unrelated to Tasaki §10.2 (current book-order frontier); this is a
refactor-only cleanup PR in the #4914 thread.

## Changes

- Remove `fin_two_ne_zero` from `HopConfig.lean`.
- Rewire call sites (`HopConfig.lean`, `HopAction.lean`, `HardcoreSpan.lean`)
  to use mathlib's `Fin.eq_one_of_ne_zero` instead.

## Checklist

- [ ] `lake build` clean, zero warnings.
- [ ] `grep -rn "sorry"` clean in touched files.
- [ ] `audit_gate.py --diff main` pass.
- [ ] codex review verdict recorded before merge.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
