### PR TITLE
Consolidate Fin 2/3 case-split utilities into Math/FinCases (C-2+C-3) — #4914

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -1,5 +1,6 @@
 import LatticeSystem.Math.AnticommuteCommute
 import LatticeSystem.Math.ComplexVectorKernel
+import LatticeSystem.Math.FinCases
 import LatticeSystem.Math.GramEigenspaceCorrespondence
 import LatticeSystem.Math.ListProdMulVec
 import LatticeSystem.Math.EigenspaceWeightFinrank

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/EffectiveHamiltonianMatrix.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/EffectiveHamiltonianMatrix.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiHopAction
+import LatticeSystem.Math.FinCases
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonian
 
 /-!
@@ -68,16 +69,10 @@ private theorem hardcore_proj_apply (N : ℕ) (y : Fin (N + 1)) (τ : Fin (N + 1
 
 /-! ## Auxiliary facts about one-hole configurations -/
 
-/-- A `Fin 2` value is `0` or `1`. -/
-private theorem fin_two_cases (r : Fin 2) : r = 0 ∨ r = 1 := by
-  rcases r with ⟨rv, hrv⟩; interval_cases rv
-  · exact Or.inl rfl
-  · exact Or.inr rfl
-
 /-- The one-hole configuration is empty on both orbitals of its hole site. -/
 private theorem oneHole_hole_zero (N : ℕ) (y : Fin (N + 1)) (τ : Fin (N + 1) → Bool)
     (r : Fin 2) : hubbardOneHoleConfig N y τ (spinfulIndex N y r) = 0 := by
-  rcases fin_two_cases r with rfl | rfl
+  rcases fin2_eq_zero_or_one r with rfl | rfl
   · rw [hubbardOneHoleConfig_apply_up, if_pos rfl]
   · rw [hubbardOneHoleConfig_apply_down, if_pos rfl]
 
@@ -131,7 +126,7 @@ private theorem hop_config_forces (N : ℕ) (x y i j : Fin (N + 1))
     intro h; exact hxy ((spinfulIndex_eq_iff N x y _ _).mp h).1
   rw [if_neg hxne,
     show hubbardOneHoleConfig N x σ (spinfulIndex N x (if τ x then 0 else 1)) = 0 from
-      by rcases fin_two_cases (if τ x then (0 : Fin 2) else 1) with h | h <;>
+      by rcases fin2_eq_zero_or_one (if τ x then (0 : Fin 2) else 1) with h | h <;>
         rw [h] <;> [rw [hubbardOneHoleConfig_apply_up, if_pos rfl];
           rw [hubbardOneHoleConfig_apply_down, if_pos rfl]],
     oneHole_occupied N y τ x hxy] at e2
@@ -286,7 +281,7 @@ private theorem hop_diag_forces (N : ℕ) (x i j : Fin (N + 1))
   have hjx' : j.val ≠ x.val := fun h => hjx (Fin.ext h)
   -- `s` is the occupied orbital of `j`.
   have hsoj : s = (if σ j then 0 else 1) := by
-    rcases fin_two_cases s with rfl | rfl
+    rcases fin2_eq_zero_or_one s with rfl | rfl
     · rw [hubbardOneHoleConfig_apply_up, if_neg hjx'] at hvj
       by_cases hσ : σ j
       · simp [hσ]
@@ -307,7 +302,7 @@ private theorem hop_diag_forces (N : ℕ) (x i j : Fin (N + 1))
         rw [← hsoj]; exact fun h => h2 (by rw [h])
       have hz : hubbardOneHoleConfig N x σ
           (spinfulIndex N j (if τ j then 0 else 1)) = 0 := by
-        rcases fin_two_cases (if τ j then (0 : Fin 2) else 1) with hoτ | hoτ
+        rcases fin2_eq_zero_or_one (if τ j then (0 : Fin 2) else 1) with hoτ | hoτ
         · rw [hoτ, hubbardOneHoleConfig_apply_up, if_neg hjx',
             if_neg (show ¬ σ j from fun hσ => hoτs (by rw [hoτ, if_pos hσ]))]
         · rw [hoτ, hubbardOneHoleConfig_apply_down, if_neg hjx',

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/GeneralFlatBandSpinConfigRep.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/GeneralFlatBandSpinConfigRep.lean
@@ -1,5 +1,6 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandSpinConfigRepCore
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralBasisHN
+import LatticeSystem.Math.FinCases
 
 /-!
 # Spin-configuration capstone, eq. (11.3.47) (Tasaki §11.3.4, toward Theorem 11.17)
@@ -85,9 +86,6 @@ theorem flatBand_groundState_mem_spinConfigSpan
 theorem fin2_ne_cases {a b : Fin 2} (h : a ≠ b) :
     (a = 0 ∧ b = 1) ∨ (a = 1 ∧ b = 0) := by
   fin_cases a <;> fin_cases b <;> simp_all
-
-/-- Every `Fin 2` value is `0` or `1`. -/
-theorem fin2_eq_zero_or_one (a : Fin 2) : a = 0 ∨ a = 1 := by revert a; decide
 
 /-- **One spin per index (the pigeonhole behind eq. (11.3.47))**: a spin-configuration occupation
 `g` (`idx(I)`-supported, no doubly occupied index mode, exactly `D₀` occupied) occupies **every**

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJAdjacentSwap.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJAdjacentSwap.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJStepRelation
+import LatticeSystem.Math.FinCases
 import Mathlib.Logic.Relation
 
 /-!
@@ -29,9 +30,6 @@ open Matrix LatticeSystem.Quantum LatticeSystem.Lattice SimpleGraph
 
 variable {N : ℕ}
 
-/-- A `Fin 3` value is `0`, `1`, or `2`. -/
-private theorem fin3_cases (v : Fin 3) : v = 0 ∨ v = 1 ∨ v = 2 := by fin_cases v <;> simp
-
 /-- **An adjacent-value swap step.**  `s'` is obtained from `s` by exchanging the values at an
 adjacent pair `a, b` of *distinct* values (precomposition with `Equiv.swap a b`). -/
 def AdjacentSwapStep (N : ℕ) (s s' : Fin (N + 1) → Fin 3) : Prop :=
@@ -45,11 +43,11 @@ theorem adjacentSwapStep_to_TJStep (s s' : Fin (N + 1) → Fin 3) (h : AdjacentS
   obtain ⟨a, b, hAdj, hne, hs'⟩ := h
   have hswapcomm : s' = fun k => s (Equiv.swap b a k) := by
     rw [hs']; funext k; rw [Equiv.swap_comm]
-  rcases fin3_cases (s a) with ha | ha | ha
+  rcases fin3_eq_zero_or_one_or_two (s a) with ha | ha | ha
   · -- s a = ∅: hop b → a
     refine Or.inl ⟨b, a, hAdj.symm, fun hb => hne (ha.trans hb.symm), ha, ?_⟩
     rw [hswapcomm, tJSiteHop_eq_comp_swap s b a ha]
-  · rcases fin3_cases (s b) with hb | hb | hb
+  · rcases fin3_eq_zero_or_one_or_two (s b) with hb | hb | hb
     · -- s b = ∅: hop a → b
       refine Or.inl ⟨a, b, hAdj, by rw [ha]; decide, hb, ?_⟩
       rw [hs', tJSiteHop_eq_comp_swap s a b hb]
@@ -57,7 +55,7 @@ theorem adjacentSwapStep_to_TJStep (s s' : Fin (N + 1) → Fin 3) (h : AdjacentS
     · -- s a = ↑, s b = ↓: exchange b, a
       refine Or.inr ⟨b, a, hAdj.symm, hb, ha, ?_⟩
       rw [hswapcomm, tJSpinSwap_eq_comp_swap s b a]
-  · rcases fin3_cases (s b) with hb | hb | hb
+  · rcases fin3_eq_zero_or_one_or_two (s b) with hb | hb | hb
     · -- s b = ∅: hop a → b
       refine Or.inl ⟨a, b, hAdj, by rw [ha]; decide, hb, ?_⟩
       rw [hs', tJSiteHop_eq_comp_swap s a b hb]

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJCompleteness.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJCompleteness.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJExpansion
+import LatticeSystem.Math.FinCases
 
 /-!
 # Tasaki 11.5: completeness of the sector basis (Prop 11.24 PR-E1b-A)
@@ -24,9 +25,6 @@ open Matrix LatticeSystem.Quantum
 open scoped BigOperators
 
 variable {N : ℕ}
-
-/-- A `Fin 2` value is `0` or `1`. -/
-private theorem fin2_eq (r : Fin 2) : r = 0 ∨ r = 1 := by fin_cases r <;> simp
 
 /-- **Completeness of the sector basis.**  If `v` vanishes off the sector configurations (the image
 of `tJConfigOf` over the sector), then `v` equals its own sector expansion
@@ -63,9 +61,9 @@ theorem tJConfigOf_tJSiteStateOf_of_hardcore (N : ℕ) (w : Fin (2 * N + 2) → 
   funext k
   obtain ⟨i, r, rfl⟩ := exists_spinfulIndex N k
   have hhci := hhc i
-  rcases fin2_eq (w (spinfulIndex N i 0)) with h0 | h0 <;>
-    rcases fin2_eq (w (spinfulIndex N i 1)) with h1 | h1 <;>
-    rcases fin2_eq r with rfl | rfl <;>
+  rcases fin2_eq_zero_or_one (w (spinfulIndex N i 0)) with h0 | h0 <;>
+    rcases fin2_eq_zero_or_one (w (spinfulIndex N i 1)) with h1 | h1 <;>
+    rcases fin2_eq_zero_or_one r with rfl | rfl <;>
     simp only [tJConfigOf_apply_up, tJConfigOf_apply_down, tJSiteStateOf, h0, h1] <;>
     simp_all
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSummand.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJKineticSummand.lean
@@ -2,6 +2,7 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.TJKineticNonneg
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJKineticMatrixElement
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJOffDiagonal
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopBackwardWrap
+import LatticeSystem.Math.FinCases
 
 /-!
 # Tasaki 11.5: each cyclic kinetic summand is `0` or `1` (Prop 11.24 PR-B7-3f)
@@ -28,16 +29,12 @@ open scoped BigOperators
 
 variable {N : ℕ}
 
-/-- A `Fin 3` site value is `0`, `1`, or `2`. -/
-theorem tJ_fin3_cases (v : Fin 3) : v = 0 ∨ v = 1 ∨ v = 2 := by
-  fin_cases v <;> simp
-
 /-- An occupied `σ`-orbital forces the site spin: `tJConfigOf s (spinfulIndex i σ) = 1` gives
 `s i = 1` for `σ = ↑` and `s i = 2` for `σ = ↓`. -/
 private theorem tJ_site_of_orbital (N : ℕ) (s : Fin (N + 1) → Fin 3) (i : Fin (N + 1)) (σ : Fin 2)
     (h : tJConfigOf N s (spinfulIndex N i σ) = 1) :
     s i = if σ = 0 then 1 else 2 := by
-  rcases tJ_fin2_eq σ with rfl | rfl
+  rcases fin2_eq_zero_or_one σ with rfl | rfl
   · rw [tJConfigOf_apply_up] at h; split at h
     · simpa using ‹s i = 1›
     · exact absurd h (by decide)
@@ -91,9 +88,9 @@ theorem tJ_kinetic_summand_zero_or_one (N : ℕ) (hpos : 0 < N) (s s' : Fin (N +
     rw [hcoup, one_mul]
     by_cases hsrc : tJConfigOf N s (spinfulIndex N j σ) = 1
     · have hsj : s j = if σ = 0 then 1 else 2 := tJ_site_of_orbital N s j σ hsrc
-      rcases tJ_fin3_cases (s i) with hsi0 | hsi1 | hsi2
+      rcases fin3_eq_zero_or_one_or_two (s i) with hsi0 | hsi1 | hsi2
       · -- target site empty: fully allowed
-        rcases tJ_fin2_eq σ with rfl | rfl
+        rcases fin2_eq_zero_or_one σ with rfl | rfl
         · rw [if_pos rfl] at hsj
           rcases cycleGraph_adj_val_cases N hpos i j hAdj with hd | hd | ⟨hiN, hj0⟩ | ⟨hjN, hi0v⟩
           · rw [tJ_uphop_backward_nn_matrixElement N s s' i j hd hsj hsi0]
@@ -114,7 +111,7 @@ theorem tJ_kinetic_summand_zero_or_one (N : ℕ) (hpos : 0 < N) (s s' : Fin (N +
               hodd]
             split_ifs <;> simp
       · -- target site ↑
-        rcases tJ_fin2_eq σ with rfl | rfl
+        rcases fin2_eq_zero_or_one σ with rfl | rfl
         · rw [tJ_hop_matrixElement_eq_zero_of_target N s s' i j 0 hij
             (by rw [tJConfigOf_apply_up, if_pos hsi1])]
           exact Or.inl rfl
@@ -122,7 +119,7 @@ theorem tJ_kinetic_summand_zero_or_one (N : ℕ) (hpos : 0 < N) (s s' : Fin (N +
             (by rw [tJConfigOf_apply_up, if_pos hsi1])]
           exact Or.inl rfl
       · -- target site ↓
-        rcases tJ_fin2_eq σ with rfl | rfl
+        rcases fin2_eq_zero_or_one σ with rfl | rfl
         · rw [tJ_hop_matrixElement_eq_zero_of_target_other N s s' i j 0 1 (by decide) hij
             (by rw [tJConfigOf_apply_down, if_pos hsi2])]
           exact Or.inl rfl
@@ -131,7 +128,7 @@ theorem tJ_kinetic_summand_zero_or_one (N : ℕ) (hpos : 0 < N) (s s' : Fin (N +
           exact Or.inl rfl
     · -- source empty
       have hsrc0 : tJConfigOf N s (spinfulIndex N j σ) = 0 := by
-        rcases tJ_fin2_eq σ with rfl | rfl
+        rcases fin2_eq_zero_or_one σ with rfl | rfl
         · rw [tJConfigOf_apply_up]; split
           · exact absurd (by rw [tJConfigOf_apply_up, if_pos ‹_›] at hsrc; exact hsrc) (by simp_all)
           · rfl

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorExchange.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorExchange.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopConfig
+import LatticeSystem.Math.FinCases
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HopSignBetween
 import LatticeSystem.Fermion.JordanWigner.Hubbard.FermionSiteSpin
 
@@ -47,7 +48,7 @@ theorem tJConfigOf_tJSpinSwap (N : ℕ) (s : Fin (N + 1) → Fin 3) (i j : Fin (
   funext k
   obtain ⟨t, r, rfl⟩ := exists_spinfulIndex N k
   simp only [Function.update_apply, spinfulIndex_eq_iff]
-  rcases (show r = 0 ∨ r = 1 from tJ_fin2_eq r) with rfl | rfl <;>
+  rcases (show r = 0 ∨ r = 1 from fin2_eq_zero_or_one r) with rfl | rfl <;>
     rcases eq_or_ne t i with rfl | hti <;> rcases eq_or_ne t j with rfl | htj <;>
     simp_all [tJConfigOf_apply_up, tJConfigOf_apply_down, tJSpinSwap]
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackwardWrap.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopBackwardWrap.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJOccupationCount
+import LatticeSystem.Math.FinCases
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopBackward
 
 /-!
@@ -37,7 +38,7 @@ private theorem tJ_bwrap_le_eq_zero (N : ℕ) (s : Fin (N + 1) → Fin 3) (a : F
     rw [h2] at hk
     exact Fin.ext (by omega)
   subst hi
-  rcases tJ_fin2_eq r with rfl | rfl
+  rcases fin2_eq_zero_or_one r with rfl | rfl
   · rw [tJConfigOf_apply_up, if_neg (by rw [hsa]; decide)]; rfl
   · rw [tJConfigOf_apply_down, if_neg (by rw [hsa]; decide)]; rfl
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopConfig.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopConfig.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHop
+import LatticeSystem.Math.FinCases
 
 /-!
 # Tasaki 11.5: the hop config identity for the t-J sector basis (Prop 11.24 PR3c-2)
@@ -32,14 +33,6 @@ private theorem tJ_hop_ne_down (s : Fin (N + 1) → Fin 3) (a b : Fin (N + 1)) (
     (hb : s b = 0) : a ≠ b := by
   rintro rfl; rw [ha] at hb; exact absurd hb (by decide)
 
-/-- A spin label is `0` or `1` (the two-element dichotomy used throughout the t-J sector files). -/
-theorem tJ_fin2_eq (r : Fin 2) : r = 0 ∨ r = 1 := by
-  rcases eq_or_ne r 0 with h | h
-  · exact Or.inl h
-  · refine Or.inr (Fin.ext ?_)
-    have h0 : r.val ≠ 0 := fun hh => h (Fin.ext hh)
-    have := r.isLt; omega
-
 /-- **Up-hop config identity**: when site `a` is ↑ and site `b` is empty, the spinful occupation of
 `tJSiteHop s a b` is `tJConfigOf s` with the up-orbital of `a` emptied and the up-orbital of `b`
 filled.  The down-orbitals are untouched. -/
@@ -52,7 +45,7 @@ theorem tJConfigOf_tJSiteHop_up (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b : Fin
   funext k
   obtain ⟨i, r, rfl⟩ := exists_spinfulIndex N k
   simp only [Function.update_apply, spinfulIndex_eq_iff]
-  rcases tJ_fin2_eq r with rfl | rfl <;> rcases eq_or_ne i a with rfl | hia <;>
+  rcases fin2_eq_zero_or_one r with rfl | rfl <;> rcases eq_or_ne i a with rfl | hia <;>
     rcases eq_or_ne i b with rfl | hib <;>
     simp_all [tJConfigOf_apply_up, tJConfigOf_apply_down, tJSiteHop]
 
@@ -68,7 +61,7 @@ theorem tJConfigOf_tJSiteHop_down (N : ℕ) (s : Fin (N + 1) → Fin 3) (a b : F
   funext k
   obtain ⟨i, r, rfl⟩ := exists_spinfulIndex N k
   simp only [Function.update_apply, spinfulIndex_eq_iff]
-  rcases tJ_fin2_eq r with rfl | rfl <;> rcases eq_or_ne i a with rfl | hia <;>
+  rcases fin2_eq_zero_or_one r with rfl | rfl <;> rcases eq_or_ne i a with rfl | hia <;>
     rcases eq_or_ne i b with rfl | hib <;>
     simp_all [tJConfigOf_apply_up, tJConfigOf_apply_down, tJSiteHop]
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopWrap.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorHopWrap.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJOccupationCount
+import LatticeSystem.Math.FinCases
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorHopNN
 
 /-!
@@ -39,7 +40,7 @@ private theorem tJ_wrap_ge_eq_zero (N : ℕ) (s : Fin (N + 1) → Fin 3) (b : Fi
     rw [h2] at hk
     exact Fin.ext (by omega)
   subst hi
-  rcases tJ_fin2_eq r with rfl | rfl
+  rcases fin2_eq_zero_or_one r with rfl | rfl
   · rw [tJConfigOf_apply_up, if_neg (by rw [hsb]; decide)]
     rfl
   · rw [tJConfigOf_apply_down, if_neg (by rw [hsb]; decide)]

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorIrreducible.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorIrreducible.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorShifted
+import LatticeSystem.Math.FinCases
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSwapReachable
 import LatticeSystem.Quantum.MarshallLiebMattis.MatrixPowExtend
 
@@ -28,9 +29,6 @@ open scoped BigOperators
 
 variable {N : ℕ}
 
-/-- A `Fin 3` value is `0`, `1`, or `2`. -/
-private theorem fin3_cases' (v : Fin 3) : v = 0 ∨ v = 1 ∨ v = 2 := by fin_cases v <;> simp
-
 /-- **The three value-counts partition the sites.**  Every site is empty, `↑`, or `↓`, so the
 counts sum to `N + 1`. -/
 theorem tJ_value_count_total (s : Fin (N + 1) → Fin 3) :
@@ -40,7 +38,7 @@ theorem tJ_value_count_total (s : Fin (N + 1) → Fin 3) :
   classical
   have h1 : ∀ k : Fin (N + 1),
       ((if s k = 0 then 1 else 0) + (if s k = 1 then 1 else 0)) + (if s k = 2 then (1 : ℕ) else 0)
-        = 1 := fun k => by rcases fin3_cases' (s k) with h | h | h <;> simp [h]
+        = 1 := fun k => by rcases fin3_eq_zero_or_one_or_two (s k) with h | h | h <;> simp [h]
   simp only [Finset.card_filter]
   rw [← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
   trans (∑ _k : Fin (N + 1), 1)
@@ -57,7 +55,7 @@ theorem tJSector_same_counts (Ne : ℕ) (q p : TJSpinHalfFillingSector N Ne) (v 
   obtain ⟨hp1, hp2⟩ := p.property
   have htq := tJ_value_count_total q.val
   have htp := tJ_value_count_total p.val
-  rcases fin3_cases' v with rfl | rfl | rfl
+  rcases fin3_eq_zero_or_one_or_two v with rfl | rfl | rfl
   · omega
   · omega
   · omega

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorRaise.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJSectorRaise.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJSectorExchange
+import LatticeSystem.Math.FinCases
 
 /-!
 # Tasaki 11.5: the single-site spin-raising operator is sign-free on the sector basis (Prop 11.24)
@@ -30,7 +31,7 @@ theorem tJConfigOf_update_raise (N : ℕ) (s : Fin (N + 1) → Fin 3) (x : Fin (
   funext k
   obtain ⟨t, r, rfl⟩ := exists_spinfulIndex N k
   simp only [Function.update_apply, spinfulIndex_eq_iff]
-  rcases (show r = 0 ∨ r = 1 from tJ_fin2_eq r) with rfl | rfl <;>
+  rcases (show r = 0 ∨ r = 1 from fin2_eq_zero_or_one r) with rfl | rfl <;>
     rcases eq_or_ne t x with rfl | htx <;>
     simp_all [tJConfigOf_apply_up, tJConfigOf_apply_down]
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJStepMatrixEntry.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJStepMatrixEntry.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJExchangeBondSum
+import LatticeSystem.Math.FinCases
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJStepRelation
 
 /-!
@@ -44,7 +45,7 @@ theorem tJ_cycle_hop_kinetic_summand_eq_one (N : ℕ) (hpos : 0 < N)
   have hcoup : couplingOf (cycleGraph (N + 1)) (1 : ℂ) b a = 1 := by
     unfold couplingOf; rw [if_pos hAdj]
   rw [hcoup, one_mul]
-  rcases tJ_fin2_eq σ with rfl | rfl
+  rcases fin2_eq_zero_or_one σ with rfl | rfl
   · rw [if_pos rfl] at hsa
     rcases cycleGraph_adj_val_cases N hpos b a hAdj with hd | hd | ⟨hbN, ha0⟩ | ⟨haN, hb0⟩
     · rw [tJ_uphop_backward_nn_matrixElement N s s' b a hd hsa hsb, if_pos hs']
@@ -224,7 +225,7 @@ theorem tJEffMatrix_re_neg_of_step (N : ℕ) (hpos : 0 < N) (s s' : Fin (N + 1) 
   rcases hstep with ⟨a, b, hAdj, hsa0, hsb, hs'⟩ | ⟨i, j, hAdj, hi, hj, hs'⟩
   · -- hop step: kinetic ≥ 1, interaction ≤ 0
     have hσ : ∃ σ : Fin 2, s a = if σ = 0 then 1 else 2 := by
-      rcases tJ_fin3_cases (s a) with h | h | h
+      rcases fin3_eq_zero_or_one_or_two (s a) with h | h | h
       · exact absurd h hsa0
       · exact ⟨0, by simp [h]⟩
       · exact ⟨1, by simp [h]⟩

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaoka.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaoka.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonianMatrix
+import LatticeSystem.Math.FinCases
 import Mathlib.Analysis.MeanInequalities
 
 /-!
@@ -124,12 +125,6 @@ theorem hubbardEffEnergy_expand (N : ℕ) (t : Fin (N + 1) → Fin (N + 1) → �
 
 /-! ## Bridge between configuration equality and the hole-move bijection -/
 
-/-- A `Fin 2` value is `0` or `1`. -/
-private theorem fin_two_cases' (r : Fin 2) : r = 0 ∨ r = 1 := by
-  rcases r with ⟨rv, hrv⟩; interval_cases rv
-  · exact Or.inl rfl
-  · exact Or.inr rfl
-
 /-- The one-hole configuration depends on the spin assignment only off the hole
 site. -/
 theorem oneHoleConfig_congr (N : ℕ) (x : Fin (N + 1)) (σ₁ σ₂ : Fin (N + 1) → Bool)
@@ -139,11 +134,11 @@ theorem oneHoleConfig_congr (N : ℕ) (x : Fin (N + 1)) (σ₁ σ₂ : Fin (N + 
   obtain ⟨z, r, rfl⟩ := exists_spinfulIndex N k
   by_cases hzx : z = x
   · subst hzx
-    rcases fin_two_cases' r with rfl | rfl
+    rcases fin2_eq_zero_or_one r with rfl | rfl
     · simp [hubbardOneHoleConfig_apply_up]
     · simp [hubbardOneHoleConfig_apply_down]
   · have hzx' : z.val ≠ x.val := fun hh => hzx (Fin.ext hh)
-    rcases fin_two_cases' r with rfl | rfl
+    rcases fin2_eq_zero_or_one r with rfl | rfl
     · rw [hubbardOneHoleConfig_apply_up, hubbardOneHoleConfig_apply_up, h z hzx]
     · rw [hubbardOneHoleConfig_apply_down, hubbardOneHoleConfig_apply_down, h z hzx]
 

--- a/LatticeSystem/Math/FinCases.lean
+++ b/LatticeSystem/Math/FinCases.lean
@@ -1,0 +1,24 @@
+import Mathlib.Data.Fintype.Fin
+import Mathlib.Tactic.FinCases
+
+/-!
+# Case splits for small `Fin` types
+
+Model-agnostic enumeration lemmas for `Fin 2` and `Fin 3`.  These are used
+pervasively in the `t`-`J` / Hubbard sector arguments, where site occupation
+values live in `Fin 2` (empty/occupied) or `Fin 3` (empty/up/down).  They are
+kept in `Math/` so the many consumers share a single copy instead of each
+carrying a private duplicate.
+-/
+
+namespace LatticeSystem
+
+/-- Every element of `Fin 2` is `0` or `1`. -/
+theorem fin2_eq_zero_or_one (r : Fin 2) : r = 0 ∨ r = 1 := by
+  fin_cases r <;> simp
+
+/-- Every element of `Fin 3` is `0`, `1`, or `2`. -/
+theorem fin3_eq_zero_or_one_or_two (v : Fin 3) : v = 0 ∨ v = 1 ∨ v = 2 := by
+  fin_cases v <;> simp
+
+end LatticeSystem


### PR DESCRIPTION
Part of #4914

## Purpose

Group C-2+C-3 of the duplicate-declaration cleanup (#4914 PR9): consolidate
the repo's `Fin 2` and `Fin 3` case-split utility lemmas, which currently
exist as multiple statement-identical copies scattered across Fermion/t-J
modules, into a single new generic module.

## Background

Two families of duplicated case-split lemmas exist:

- `∀ r : Fin 2, r = 0 ∨ r = 1` — 5 duplicate copies (`fin_two_cases`,
  `fin2_eq`, `tJ_fin2_eq`, `fin_two_cases'`, and one more variant).
- `∀ v : Fin 3, v = 0 ∨ v = 1 ∨ v = 2` — 3 duplicate copies (`fin3_cases`,
  `tJ_fin3_cases`, `fin3_cases'`).

mathlib has no equivalent lemma for these (unlike C-1's
`Fin.eq_one_of_ne_zero`), so per the no-duplicate-declarations-ever policy
(#4914) these are consolidated into one canonical implementation each in a
new `LatticeSystem/Math/FinCases.lean` module (generic case-split helpers,
not textbook-specific), and all call sites are rewired to import from there.
Design reference: `.self-local/reports/design-pr6-fermion-rest.md` (Group
C-2/C-3).

Unrelated to Tasaki §10.2 (current book-order frontier); this is a
refactor-only cleanup PR in the #4914 thread.

## Changes

- Add `LatticeSystem/Math/FinCases.lean` with `fin2_eq_zero_or_one` and
  `fin3_eq_zero_or_one_or_two`.
- Remove the 5 duplicate `Fin 2` case-split lemmas and 3 duplicate `Fin 3`
  case-split lemmas from their respective modules.
- Rewire all call sites to the canonical `Math/FinCases` lemmas.

## Checklist

- [ ] `lake build` clean, zero warnings.
- [ ] `grep -rn "sorry"` clean in touched files.
- [ ] `audit_gate.py --diff main` pass.
- [ ] codex review verdict recorded before merge.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
