### PR TITLE
Generalize star_mulVec_dotProduct to rectangular; eliminate 2 adjoint duplicates (D(ii)) — #4914

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HubbardImpossibilityLowUVariationalCore.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HubbardImpossibilityLowUVariationalCore.lean
@@ -10,6 +10,7 @@ import LatticeSystem.Quantum.SpinS.HermitianMinEigenvalueEigenvector
 import LatticeSystem.Quantum.SpinS.RayleighOnEigenvector
 import Mathlib.Analysis.Matrix.Spectrum
 import Mathlib.Analysis.Matrix.PosDef
+import LatticeSystem.Math.ComplexVectorKernel
 
 /-!
 # Hubbard low-`U` impossibility (variational lower bound): foundation
@@ -109,15 +110,6 @@ theorem hubbardSector_completeness (Ne : ℕ) (u : (Fin (2 * N + 2) → Fin 2) �
 
 /-! ## The sector compression and its Rayleigh bridge -/
 
-/-- The (rectangular) adjoint identity for the matrix inner product: `⟨c, Tᴴ y⟩ = ⟨T c, y⟩`. -/
-private theorem dotProduct_star_conjTranspose_mulVec' {m n : Type*} [Fintype m] [Fintype n]
-    (T : Matrix m n ℂ) (c : n → ℂ) (y : m → ℂ) :
-    dotProduct (star c) (Tᴴ.mulVec y) = dotProduct (star (T.mulVec c)) y := by
-  simp only [dotProduct, Matrix.mulVec, Matrix.conjTranspose_apply, Pi.star_apply,
-    star_sum, star_mul', Finset.mul_sum, Finset.sum_mul]
-  rw [Finset.sum_comm]
-  exact Finset.sum_congr rfl (fun w _ => Finset.sum_congr rfl (fun s _ => by ring))
-
 /-- **The `W`-compression** `compress(A) = Tᴴ A T`: the matrix of `A` in the `Ne`-electron basis. -/
 noncomputable def hubbardSectorCompress (N Ne : ℕ) (A : ManyBodyOp (Fin (2 * N + 2))) :
     Matrix (hubbardSectorConfig N Ne) (hubbardSectorConfig N Ne) ℂ :=
@@ -143,7 +135,7 @@ theorem hubbardSectorExpansion_dotProduct_self (Ne : ℕ) (c : hubbardSectorConf
     dotProduct (star (hubbardSectorExpansion N Ne c)) (hubbardSectorExpansion N Ne c) =
       dotProduct (star c) c := by
   rw [← hubbardSectorEmbedding_mulVec,
-    ← dotProduct_star_conjTranspose_mulVec' (hubbardSectorEmbedding N Ne) c
+    star_mulVec_dotProduct (hubbardSectorEmbedding N Ne) c
       ((hubbardSectorEmbedding N Ne).mulVec c),
     Matrix.mulVec_mulVec, hubbardSectorEmbedding_conjTranspose_mul_self, Matrix.one_mulVec]
 
@@ -161,7 +153,7 @@ theorem rayleighOnVec_hubbardSectorCompress (Ne : ℕ) (A : ManyBodyOp (Fin (2 *
   have key : dotProduct (star c) ((hubbardSectorCompress N Ne A).mulVec c)
       = dotProduct (star (hubbardSectorExpansion N Ne c))
           (A.mulVec (hubbardSectorExpansion N Ne c)) := by
-    rw [hmv, dotProduct_star_conjTranspose_mulVec', hubbardSectorEmbedding_mulVec]
+    rw [hmv, (star_mulVec_dotProduct _ c _).symm, hubbardSectorEmbedding_mulVec]
   unfold rayleighOnVec
   rw [key]
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingRayleighBridge.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TJFillingRayleighBridge.lean
@@ -1,6 +1,7 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJFillingCompress
 import LatticeSystem.Quantum.SpinS.RayleighInfMatrix
 import LatticeSystem.Quantum.SpinS.RayleighUnitarySimilarity
+import LatticeSystem.Math.ComplexVectorKernel
 
 /-!
 # Tasaki 11.5: the filling embedding is an isometry, and the Rayleigh bridge (Prop 11.24 PR-E2 ≥)
@@ -25,15 +26,6 @@ open scoped BigOperators
 
 variable {N : ℕ}
 
-/-- The (rectangular) adjoint identity for the matrix inner product: `⟨c, Tᴴ y⟩ = ⟨T c, y⟩`. -/
-private theorem dotProduct_star_conjTranspose_mulVec {m n : Type*} [Fintype m] [Fintype n]
-    (T : Matrix m n ℂ) (c : n → ℂ) (y : m → ℂ) :
-    dotProduct (star c) (Tᴴ.mulVec y) = dotProduct (star (T.mulVec c)) y := by
-  simp only [dotProduct, Matrix.mulVec, Matrix.conjTranspose_apply, Pi.star_apply,
-    star_sum, star_mul', Finset.mul_sum, Finset.sum_mul]
-  rw [Finset.sum_comm]
-  exact Finset.sum_congr rfl (fun w _ => Finset.sum_congr rfl (fun s _ => by ring))
-
 /-- **The filling embedding has orthonormal columns:** `Tᴴ T = 1`. -/
 theorem tJFillingEmbedding_conjTranspose_mul_self (Ne : ℕ) :
     (tJFillingEmbedding N Ne)ᴴ * tJFillingEmbedding N Ne = 1 := by
@@ -55,7 +47,7 @@ theorem tJFillingExpansion_dotProduct_self (Ne : ℕ) (c : TJFillingSector N Ne 
     dotProduct (star (tJFillingExpansion N Ne c)) (tJFillingExpansion N Ne c) =
       dotProduct (star c) c := by
   rw [← tJFillingEmbedding_mulVec,
-    ← dotProduct_star_conjTranspose_mulVec (tJFillingEmbedding N Ne) c
+    star_mulVec_dotProduct (tJFillingEmbedding N Ne) c
       ((tJFillingEmbedding N Ne).mulVec c),
     Matrix.mulVec_mulVec, tJFillingEmbedding_conjTranspose_mul_self, Matrix.one_mulVec]
 
@@ -72,7 +64,7 @@ theorem rayleighOnVec_tJFillingCompress (Ne : ℕ) (A : ManyBodyOp (Fin (2 * N +
     rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec]
   have key : dotProduct (star c) ((tJFillingCompress N Ne A).mulVec c)
       = dotProduct (star (tJFillingExpansion N Ne c)) (A.mulVec (tJFillingExpansion N Ne c)) := by
-    rw [hmv, dotProduct_star_conjTranspose_mulVec, tJFillingEmbedding_mulVec]
+    rw [hmv, (star_mulVec_dotProduct _ c _).symm, tJFillingEmbedding_mulVec]
   unfold rayleighOnVec
   rw [key]
 

--- a/LatticeSystem/Math/ComplexVectorKernel.lean
+++ b/LatticeSystem/Math/ComplexVectorKernel.lean
@@ -31,9 +31,10 @@ theorem complexVec_eq_zero_of_star_dotProduct {n : Type*} [Fintype n] {v : n →
       (Finset.mem_univ j)
   exact Complex.normSq_eq_zero.mp hj
 
-/-- For a complex square matrix `M`, `star (M *ᵥ v) ⬝ᵥ w = star v ⬝ᵥ Mᴴ *ᵥ w`
+/-- For a (rectangular) complex matrix `M`, `star (M *ᵥ v) ⬝ᵥ w = star v ⬝ᵥ Mᴴ *ᵥ w`
 (adjoint move across the dot product). -/
-theorem star_mulVec_dotProduct {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) (v w : ι → ℂ) :
+theorem star_mulVec_dotProduct {m n : Type*} [Fintype m] [Fintype n] (M : Matrix m n ℂ)
+    (v : n → ℂ) (w : m → ℂ) :
     star (M.mulVec v) ⬝ᵥ w = star v ⬝ᵥ M.conjTranspose.mulVec w := by
   rw [Matrix.star_mulVec, Matrix.dotProduct_mulVec]
 


### PR DESCRIPTION
Part of #4914

## Purpose
Group D(ii) of the duplicate-declaration elimination sweep (#4914). Generalize the
existing square-matrix lemma `Math/ComplexVectorKernel.star_mulVec_dotProduct` to
rectangular matrices, then eliminate the two `private` adjoint-identity duplicates that
were hand-copied around this same statement.

## Changes
- `LatticeSystem/Math/ComplexVectorKernel.lean`: generalize
  `star_mulVec_dotProduct` from square `{n}` to rectangular `{m n}` matrices. Statement
  content is unchanged (still `dotProduct (star v) (M.mulVec w) = dotProduct
  ((Mᴴ).mulVec (star v)) w`-shape identity), so this is a signature widening, fully
  backward compatible with existing callers instantiated at `m = n`.
- Remove `private dotProduct_star_conjTranspose_mulVec` in
  `TJFillingRayleighBridge.lean` and `private dotProduct_star_conjTranspose_mulVec'` in
  `HubbardImpossibilityLowUVariationalCore.lean` — both are the same statement as the
  canonical lemma, now reachable at the rectangular type they each needed. Replace their
  call sites with the canonical `ComplexVectorKernel.star_mulVec_dotProduct` (adding the
  import where missing).
- No proof content changes elsewhere; downstream consumers (SpinS files, §10.2
  `LiebAttractiveNormFoundation`) only need to rebuild against the widened signature.

## Design reference
`.self-local/reports/design-pr6-fermion-rest.md`, Group D(ii).

## Verification
- `lake build` clean, zero warnings.
- `grep -rn "sorry"` in touched files: none.
- `audit_gate.py --diff main`: no new decorative/duplicate declarations.
- codex review pending before merge (per #4914 policy: no merge without a completed
  codex verdict).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
