### PR TITLE
Eliminate square_commutator Leibniz duplicates; register 1 gate false-positive (PR12) — #4914

### DIFF
--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpinCore.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpinCore.lean
@@ -409,16 +409,6 @@ theorem sublatticeSpinHalfOp3_commutator_sublatticeSpinHalfOp1 (A : Λ → Bool)
 
 /-! ## Sublattice Casimir self-invariance `[(Ŝ_A)², Ŝ_A^(α)] = 0` -/
 
-/-- Internal Leibniz: `[X·X, C] = X·[X,C] + [X,C]·X`. Pure ring identity,
-the sublattice analog of `square_commutator_totalSpin`. -/
-private lemma square_commutator_sublattice (X C : ManyBodyOp Λ) :
-    X * X * C - C * (X * X) = X * (X * C - C * X) + (X * C - C * X) * X := by
-  rw [mul_sub, sub_mul]
-  have h1 : X * (C * X) = X * C * X := (mul_assoc X C X).symm
-  have h2 : X * X * C = X * (X * C) := mul_assoc X X C
-  have h3 : C * (X * X) = C * X * X := (mul_assoc C X X).symm
-  rw [h1, h2, h3]; abel
-
 /-- Sublattice Casimir invariance: `[(Ŝ_A)², Ŝ_A^(1)] = 0`. -/
 theorem sublatticeSpinHalfSquared_commutator_sublatticeSpinHalfOp1 (A : Λ → Bool) :
     sublatticeSpinHalfSquared A * sublatticeSpinHalfOp1 A
@@ -435,8 +425,8 @@ theorem sublatticeSpinHalfSquared_commutator_sublatticeSpinHalfOp1 (A : Λ → B
   rw [show P * P * P + Q * Q * P + R * R * P - (P * (P * P) + P * (Q * Q) + P * (R * R))
         = (P * P * P - P * (P * P)) + (Q * Q * P - P * (Q * Q))
           + (R * R * P - P * (R * R)) from by abel]
-  rw [square_commutator_sublattice P P, square_commutator_sublattice Q P,
-    square_commutator_sublattice R P]
+  rw [square_commutator_totalSpin Λ P P, square_commutator_totalSpin Λ Q P,
+    square_commutator_totalSpin Λ R P]
   have hPP : P * P - P * P = (0 : ManyBodyOp Λ) := sub_self _
   have hQP : Q * P - P * Q = -(Complex.I • R) := by
     rw [show Q * P - P * Q = -(P * Q - Q * P) from by abel, hPQ]
@@ -462,8 +452,8 @@ theorem sublatticeSpinHalfSquared_commutator_sublatticeSpinHalfOp2 (A : Λ → B
   rw [show P * P * Q + Q * Q * Q + R * R * Q - (Q * (P * P) + Q * (Q * Q) + Q * (R * R))
         = (P * P * Q - Q * (P * P)) + (Q * Q * Q - Q * (Q * Q))
           + (R * R * Q - Q * (R * R)) from by abel]
-  rw [square_commutator_sublattice P Q, square_commutator_sublattice Q Q,
-    square_commutator_sublattice R Q]
+  rw [square_commutator_totalSpin Λ P Q, square_commutator_totalSpin Λ Q Q,
+    square_commutator_totalSpin Λ R Q]
   have hQQ : Q * Q - Q * Q = (0 : ManyBodyOp Λ) := sub_self _
   have hRQ : R * Q - Q * R = -(Complex.I • P) := by
     rw [show R * Q - Q * R = -(Q * R - R * Q) from by abel, hQR]
@@ -488,8 +478,8 @@ theorem sublatticeSpinHalfSquared_commutator_sublatticeSpinHalfOp3 (A : Λ → B
   rw [show P * P * R + Q * Q * R + R * R * R - (R * (P * P) + R * (Q * Q) + R * (R * R))
         = (P * P * R - R * (P * P)) + (Q * Q * R - R * (Q * Q))
           + (R * R * R - R * (R * R)) from by abel]
-  rw [square_commutator_sublattice P R, square_commutator_sublattice Q R,
-    square_commutator_sublattice R R]
+  rw [square_commutator_totalSpin Λ P R, square_commutator_totalSpin Λ Q R,
+    square_commutator_totalSpin Λ R R]
   have hPR : P * R - R * P = -(Complex.I • Q) := by
     rw [show P * R - R * P = -(R * P - P * R) from by abel, hRP]
   have hRR : R * R - R * R = (0 : ManyBodyOp Λ) := sub_self _

--- a/LatticeSystem/Quantum/SpinS/SublatticeSpin.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeSpin.lean
@@ -422,15 +422,6 @@ theorem sublatticeSpinSOp3_commutator_sublatticeSpinSOp1 (A : Λ → Bool) :
 /-! ## Sublattice Casimir self-invariance `[(Ŝ_A)², Ŝ_A^(α)] = 0`
 (spin-`S`) -/
 
-/-- Internal Leibniz: `[X·X, C] = X·[X,C] + [X,C]·X`. -/
-private lemma square_commutator_sublatticeS (X C : ManyBodyOpS Λ N) :
-    X * X * C - C * (X * X) = X * (X * C - C * X) + (X * C - C * X) * X := by
-  rw [mul_sub, sub_mul]
-  have h1 : X * (C * X) = X * C * X := (mul_assoc X C X).symm
-  have h2 : X * X * C = X * (X * C) := mul_assoc X X C
-  have h3 : C * (X * X) = C * X * X := (mul_assoc C X X).symm
-  rw [h1, h2, h3]; abel
-
 /-- Sublattice Casimir invariance for spin-`S`: `[(Ŝ_A)², Ŝ_A^(1)] = 0`. -/
 theorem sublatticeSpinSquaredS_commutator_sublatticeSpinSOp1 (A : Λ → Bool) :
     sublatticeSpinSquaredS N A * sublatticeSpinSOp1 N A
@@ -447,8 +438,8 @@ theorem sublatticeSpinSquaredS_commutator_sublatticeSpinSOp1 (A : Λ → Bool) :
   rw [show P * P * P + Q * Q * P + R * R * P - (P * (P * P) + P * (Q * Q) + P * (R * R))
         = (P * P * P - P * (P * P)) + (Q * Q * P - P * (Q * Q))
           + (R * R * P - P * (R * R)) from by abel]
-  rw [square_commutator_sublatticeS N P P, square_commutator_sublatticeS N Q P,
-    square_commutator_sublatticeS N R P]
+  rw [square_commutator_totalSpinS Λ N P P, square_commutator_totalSpinS Λ N Q P,
+    square_commutator_totalSpinS Λ N R P]
   have hPP : P * P - P * P = (0 : ManyBodyOpS Λ N) := sub_self _
   have hQP : Q * P - P * Q = -(Complex.I • R) := by
     rw [show Q * P - P * Q = -(P * Q - Q * P) from by abel, hPQ]
@@ -474,8 +465,8 @@ theorem sublatticeSpinSquaredS_commutator_sublatticeSpinSOp2 (A : Λ → Bool) :
   rw [show P * P * Q + Q * Q * Q + R * R * Q - (Q * (P * P) + Q * (Q * Q) + Q * (R * R))
         = (P * P * Q - Q * (P * P)) + (Q * Q * Q - Q * (Q * Q))
           + (R * R * Q - Q * (R * R)) from by abel]
-  rw [square_commutator_sublatticeS N P Q, square_commutator_sublatticeS N Q Q,
-    square_commutator_sublatticeS N R Q]
+  rw [square_commutator_totalSpinS Λ N P Q, square_commutator_totalSpinS Λ N Q Q,
+    square_commutator_totalSpinS Λ N R Q]
   have hQQ : Q * Q - Q * Q = (0 : ManyBodyOpS Λ N) := sub_self _
   have hRQ : R * Q - Q * R = -(Complex.I • P) := by
     rw [show R * Q - Q * R = -(Q * R - R * Q) from by abel, hQR]
@@ -500,8 +491,8 @@ theorem sublatticeSpinSquaredS_commutator_sublatticeSpinSOp3 (A : Λ → Bool) :
   rw [show P * P * R + Q * Q * R + R * R * R - (R * (P * P) + R * (Q * Q) + R * (R * R))
         = (P * P * R - R * (P * P)) + (Q * Q * R - R * (Q * Q))
           + (R * R * R - R * (R * R)) from by abel]
-  rw [square_commutator_sublatticeS N P R, square_commutator_sublatticeS N Q R,
-    square_commutator_sublatticeS N R R]
+  rw [square_commutator_totalSpinS Λ N P R, square_commutator_totalSpinS Λ N Q R,
+    square_commutator_totalSpinS Λ N R R]
   have hPR : P * R - R * P = -(Complex.I • Q) := by
     rw [show P * R - R * P = -(R * P - P * R) from by abel, hRP]
   have hRR : R * R - R * R = (0 : ManyBodyOpS Λ N) := sub_self _

--- a/LatticeSystem/Quantum/SpinS/TotalSquared.lean
+++ b/LatticeSystem/Quantum/SpinS/TotalSquared.lean
@@ -24,7 +24,7 @@ variable (Λ : Type*) [Fintype Λ] [DecidableEq Λ] (N : ℕ)
 /-! ## Casimir invariance: `[(Ŝ_tot)², Ŝ_tot^{(α)}] = 0` -/
 
 /-- Internal Leibniz: `[X·X, C] = X·[X,C] + [X,C]·X`. -/
-private lemma square_commutator_totalSpinS (X C : ManyBodyOpS Λ N) :
+lemma square_commutator_totalSpinS (X C : ManyBodyOpS Λ N) :
     X * X * C - C * (X * X) = X * (X * C - C * X) + (X * C - C * X) * X := by
   rw [mul_sub, sub_mul]
   have h1 : X * (C * X) = X * C * X := (mul_assoc X C X).symm

--- a/LatticeSystem/Quantum/TotalSpin/Casimir.lean
+++ b/LatticeSystem/Quantum/TotalSpin/Casimir.lean
@@ -39,7 +39,7 @@ theorem totalSpinHalfSquared_isHermitian :
     rw [Matrix.conjTranspose_mul, (totalSpinHalfOp3_isHermitian Λ)]
 
 /-- Internal Leibniz: `[X·X, C] = X·[X,C] + [X,C]·X`. -/
-private lemma square_commutator_totalSpin (X C : ManyBodyOp Λ) :
+lemma square_commutator_totalSpin (X C : ManyBodyOp Λ) :
     X * X * C - C * (X * X) = X * (X * C - C * X) + (X * C - C * X) * X := by
   rw [mul_sub, sub_mul]
   have h1 : X * (C * X) = X * C * X := (mul_assoc X C X).symm

--- a/scripts/audit/capstones.txt
+++ b/scripts/audit/capstones.txt
@@ -5,3 +5,11 @@
 #         matching displayed statement (e.g. distinct ambient `variable` context
 #         that the textual gate cannot see).
 # Add a name only after confirming the finding is a genuine false positive.
+
+# V2 false positive: 60-line truncation artifact. The two theorems below share a
+# long common hypothesis prefix (AnisotropicHeisenbergSpinSCaseIIBlockPFMin.lean
+# :361 and :446); the gate truncates the compared statement at 60 lines before
+# reaching the differing conclusions (finrank ≤ 1 vs `mulVec Φ = 0` with an extra
+# Φ hypothesis), so they are NOT real duplicates.
+anisotropicHeisenbergS_case_ii_target_finrank_le_one_of_reachability_pf_min_path
+anisotropicHeisenbergS_case_ii_target_zero_magnetization_of_reachability_pf_min_path


### PR DESCRIPTION
Part of #4914

## Purpose
PR12 of Issue #4914's PR12-19 batch (design:
`.self-local/reports/design-pr12plus-quantum-dups.md`). Eliminate the two
`square_commutator` generic Leibniz-identity duplicates (items #3, #18 of the
V2 duplicate classification) by publicizing the canonical `TotalSpin`/`SpinS`
implementations and deleting the sublattice-side copies, then register one
audit-gate false-positive so the batch runs clean.

## Scope
- **#3**: `square_commutator_sublattice` (`MarshallLiebMattis/SublatticeSpinCore.lean`)
  duplicates canonical `square_commutator_totalSpin`
  (`TotalSpin/Casimir.lean:42`, currently `private`). `SublatticeSpinCore.lean`
  already imports `TotalSpin.Casimir` (no cycle) → publicize canonical, delete
  the sublattice copy, rewire the in-file use site.
- **#18**: `square_commutator_sublatticeS` (`SpinS/SublatticeSpin.lean`)
  duplicates canonical `square_commutator_totalSpinS`
  (`SpinS/TotalSquared.lean:27`, currently `private`). `SublatticeSpin.lean`
  already imports `SpinS.TotalSquared` (no cycle) → same treatment.
- Both are pure commutator-Leibniz identities with no §10.2 (#4852) overlap
  (§2.5 zone only); safe to land ahead of the §10.2 branch.
- **Gate false-positive registration**: `AnisotropicHeisenbergSpinSCaseIIBlockPFMin.lean:361`
  vs `:446` is a false match from `audit_gate.py`'s 60-line truncation
  heuristic (17 shared hypothesis-prefix lines cause early cutoff before the
  two statements' differing conclusions — finrank≤1 upper bound vs.
  GS-magnetization-zero — are compared). These are genuinely distinct
  theorems. Registering both names in `scripts/audit/capstones.txt` with an
  inline comment documenting the truncation-artifact rationale, per the
  design doc's PR12 recommendation (register early so PR13-19 gate stays
  clean).

## Not in scope
- No new Tasaki theorem is added; this is pure duplicate elimination, so
  `docs/index.md` / `tex/proof-guide.tex` are unaffected (per design doc
  "落とし穴" note).
- PR13-19 (remaining duplicate groups, some gated behind the §10.2 branch
  merge) are separate PRs per the design doc's execution order.

## References
- Design: `.self-local/reports/design-pr12plus-quantum-dups.md` (§ PR12,
  § #5 false-positive registration).
- Classification input: `.self-local/reports/research-v2-final-classification.md`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
