### PR TITLE
Eliminate final V2 duplicates: spinfulIndex + star_dotProduct 3-way (PR15) — #4914

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/AllDownState.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/AllDownState.lean
@@ -1,4 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.SpinSymmetry
+import LatticeSystem.Fermion.JordanWigner.Hubbard.AllUpState
 
 /-!
 # Hubbard all-down-spin state: no double occupancy (mirror of `AllUpState`)
@@ -40,18 +41,6 @@ noncomputable def hubbardAllDownState (N : ℕ) :
     (Fin (2 * N + 2) → Fin 2) → ℂ :=
   basisVec (fun k : Fin (2 * N + 2) => if k.val % 2 = 0 then 0 else 1)
 
-/-! ## Auxiliary: parity of spinful JW indices -/
-
-/-- The spin-up JW index `spinfulIndex N i 0` has even value. -/
-private theorem spinfulIndex_up_even' (N : ℕ) (i : Fin (N + 1)) :
-    (spinfulIndex N i 0).val % 2 = 0 := by
-  simp [spinfulIndex]
-
-/-- The spin-down JW index `spinfulIndex N i 1` has odd value. -/
-private theorem spinfulIndex_down_odd' (N : ℕ) (i : Fin (N + 1)) :
-    (spinfulIndex N i 1).val % 2 = 1 := by
-  simp [spinfulIndex]
-
 /-! ## Number-operator action on the all-down state -/
 
 /-- The spin-down number operator at site `i` acts as the
@@ -64,7 +53,7 @@ theorem fermionDownNumber_mulVec_allDownState (N : ℕ) (i : Fin (N + 1)) :
   funext τ
   -- spin-down site is odd, so the all-down configuration has occupation 1.
   have hodd : ¬(spinfulIndex N i 1).val % 2 = 0 := by
-    have := spinfulIndex_down_odd' N i; omega
+    have := spinfulIndex_down_odd N i; omega
   simp only [if_neg hodd]
   rw [Fin.sum_univ_two]
   have h0 : (spinHalfOpMinus * spinHalfOpPlus) (0 : Fin 2) (1 : Fin 2) = 0 := by
@@ -94,7 +83,7 @@ theorem fermionUpNumber_mulVec_allDownState (N : ℕ) (i : Fin (N + 1)) :
     basisVec (Function.update (fun j : Fin (2 * N + 2) =>
         if j.val % 2 = 0 then (0 : Fin 2) else 1)
       (spinfulIndex N i 0) k) τ = 0
-  simp only [if_pos (spinfulIndex_up_even' N i)]
+  simp only [if_pos (spinfulIndex_up_even N i)]
   fin_cases k <;> simp [spinHalfOpMinus, spinHalfOpPlus]
 
 /-! ## Interaction on all-down state -/
@@ -135,7 +124,7 @@ theorem fermionUpAnnihilation_mulVec_allDownState (N : ℕ) (i : Fin (N + 1)) :
       basisVec (Function.update (fun j : Fin (2 * N + 2) =>
           if j.val % 2 = 0 then (0 : Fin 2) else 1)
         (spinfulIndex N i 0) k) τ = 0
-    simp only [if_pos (spinfulIndex_up_even' N i)]
+    simp only [if_pos (spinfulIndex_up_even N i)]
     fin_cases k <;> simp [spinHalfOpPlus]
   rw [hinner, Matrix.mulVec_zero]
 
@@ -159,7 +148,7 @@ theorem fermionDownCreation_mulVec_allDownState (N : ℕ) (i : Fin (N + 1)) :
           if j.val % 2 = 0 then (0 : Fin 2) else 1)
         (spinfulIndex N i 1) k) τ = 0
     have hodd : ¬(spinfulIndex N i 1).val % 2 = 0 := by
-      have := spinfulIndex_down_odd' N i; omega
+      have := spinfulIndex_down_odd N i; omega
     simp only [if_neg hodd]
     fin_cases k <;> simp [spinHalfOpMinus]
   rw [hinner, Matrix.mulVec_zero]

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/AllUpState.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/AllUpState.lean
@@ -52,12 +52,12 @@ noncomputable def hubbardAllUpState (N : ℕ) :
 /-! ## Auxiliary: parity of spinful JW indices -/
 
 /-- The spin-up JW index `spinfulIndex N i 0` has even value. -/
-private theorem spinfulIndex_up_even (N : ℕ) (i : Fin (N + 1)) :
+theorem spinfulIndex_up_even (N : ℕ) (i : Fin (N + 1)) :
     (spinfulIndex N i 0).val % 2 = 0 := by
   simp [spinfulIndex]
 
 /-- The spin-down JW index `spinfulIndex N i 1` has odd value. -/
-private theorem spinfulIndex_down_odd (N : ℕ) (i : Fin (N + 1)) :
+theorem spinfulIndex_down_odd (N : ℕ) (i : Fin (N + 1)) :
     (spinfulIndex N i 1).val % 2 = 1 := by
   simp [spinfulIndex]
 

--- a/LatticeSystem/Math/ComplexVectorKernel.lean
+++ b/LatticeSystem/Math/ComplexVectorKernel.lean
@@ -38,4 +38,22 @@ theorem star_mulVec_dotProduct {m n : Type*} [Fintype m] [Fintype n] (M : Matrix
     star (M.mulVec v) ⬝ᵥ w = star v ⬝ᵥ M.conjTranspose.mulVec w := by
   rw [Matrix.star_mulVec, Matrix.dotProduct_mulVec]
 
+/-- `star v ⬝ᵥ v = ∑ ‖v i‖²` as a real cast into `ℂ` (the self inner product is a
+non-negative real). -/
+theorem star_dotProduct_self_eq {n : Type*} [Fintype n] (v : n → ℂ) :
+    star v ⬝ᵥ v = ((∑ i, Complex.normSq (v i) : ℝ) : ℂ) := by
+  rw [dotProduct, Complex.ofReal_sum]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
+
+/-- The conjugated quadratic form `⟨v, Mᴴ M v⟩ = ‖M v‖²` is a non-negative real. -/
+theorem star_dotProduct_conjTranspose_mul_mulVec_eq {n : Type*} [Fintype n]
+    (M : Matrix n n ℂ) (v : n → ℂ) :
+    star v ⬝ᵥ (M.conjTranspose * M).mulVec v =
+      ((∑ i, Complex.normSq ((M.mulVec v) i) : ℝ) : ℂ) := by
+  rw [← Matrix.mulVec_mulVec, Matrix.dotProduct_mulVec, ← Matrix.star_mulVec, dotProduct,
+    Complex.ofReal_sum]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
+
 end LatticeSystem

--- a/LatticeSystem/Quantum/SpinS/SU2ExpectationLadderInvariant.lean
+++ b/LatticeSystem/Quantum/SpinS/SU2ExpectationLadderInvariant.lean
@@ -40,15 +40,6 @@ open Matrix
 
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
-/-- `star v ⬝ᵥ v = ∑ ‖v i‖²` as a real cast into `ℂ`.  Local copy of the (private)
-helper `star_dotProduct_self_eq'` of `Theorem23TotalLoweringNonvanishing`, duplicated
-here because `private` declarations are not visible across module boundaries. -/
-private theorem star_dotProduct_self_eq'' {n : Type*} [Fintype n] (v : n → ℂ) :
-    star v ⬝ᵥ v = ((∑ i, Complex.normSq (v i) : ℝ) : ℂ) := by
-  rw [dotProduct, Complex.ofReal_sum]
-  refine Finset.sum_congr rfl (fun i _ => ?_)
-  rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
-
 /-- **Scalar action of `Ŝ⁺_tot Ŝ⁻_tot` on a joint eigenvector.** If
 `Ŝ³_tot v = m • v` and `(Ŝ_tot)² v = γ • v`, then
 `(Ŝ⁺_tot Ŝ⁻_tot) *ᵥ v = (γ − m·m + m) • v`, the Casimir-rearrangement eigenvalue. -/
@@ -125,9 +116,9 @@ theorem su2_expectationRatioRe_ladder_invariant (O : ManyBodyOpS V N)
   have hnum := su2_expectation_ladder_cross O hOplus hOminus hz hcas
   -- Recast `‖·‖²` casts back into `star · ⬝ᵥ ·` form.
   have hSm_self : star Sm ⬝ᵥ Sm =
-      ((∑ i, Complex.normSq (Sm i) : ℝ) : ℂ) := star_dotProduct_self_eq'' Sm
+      ((∑ i, Complex.normSq (Sm i) : ℝ) : ℂ) := star_dotProduct_self_eq Sm
   have hv_self : star v ⬝ᵥ v = ((∑ i, Complex.normSq (v i) : ℝ) : ℂ) :=
-    star_dotProduct_self_eq'' v
+    star_dotProduct_self_eq v
   -- The complex scalar factor `c = γ − m² + m`.
   set c : ℂ := γ - m * m + m with hcdef
   -- Denominator scaling rewritten in `star · ⬝ᵥ ·` form.

--- a/LatticeSystem/Quantum/SpinS/Theorem23SublatticeCasimirSzBound.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23SublatticeCasimirSzBound.lean
@@ -1,5 +1,6 @@
 import LatticeSystem.Quantum.SpinS.SublatticeSpinLadder
 import LatticeSystem.Quantum.SpinS.Theorem23PFCasimirPredicted
+import LatticeSystem.Math.ComplexVectorKernel
 
 /-!
 # Sublattice Casimir dominates `S^3(S^3 ± 1)` (magnitude bound)
@@ -24,23 +25,6 @@ namespace LatticeSystem.Quantum
 open Matrix
 
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
-
-/-- The conjugated quadratic form `⟨v, Mᴴ M v⟩ = ‖M v‖²` is a non-negative real. -/
-private theorem star_dotProduct_conjTranspose_mul_mulVec_eq
-    {n : Type*} [Fintype n] (M : Matrix n n ℂ) (v : n → ℂ) :
-    star v ⬝ᵥ (M.conjTranspose * M).mulVec v =
-      ((∑ i, Complex.normSq ((M.mulVec v) i) : ℝ) : ℂ) := by
-  rw [← Matrix.mulVec_mulVec, Matrix.dotProduct_mulVec, ← Matrix.star_mulVec, dotProduct,
-    Complex.ofReal_sum]
-  refine Finset.sum_congr rfl (fun i _ => ?_)
-  rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
-
-/-- `(star v ⬝ᵥ v)` is a positive real for `v ≠ 0`. -/
-private theorem star_dotProduct_self_eq {n : Type*} [Fintype n] (v : n → ℂ) :
-    star v ⬝ᵥ v = ((∑ i, Complex.normSq (v i) : ℝ) : ℂ) := by
-  rw [dotProduct, Complex.ofReal_sum]
-  refine Finset.sum_congr rfl (fun i _ => ?_)
-  rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
 
 private theorem star_dotProduct_self_re_pos {n : Type*} [Fintype n]
     {v : n → ℂ} (hv : v ≠ 0) : 0 < (star v ⬝ᵥ v).re := by

--- a/LatticeSystem/Quantum/SpinS/Theorem23TotalLoweringNonvanishing.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23TotalLoweringNonvanishing.lean
@@ -1,6 +1,7 @@
 import LatticeSystem.Quantum.SpinS.CasimirRearrangement
 import LatticeSystem.Quantum.SpinS.TotalSpin
 import LatticeSystem.Quantum.SpinS.Magnetization
+import LatticeSystem.Math.ComplexVectorKernel
 
 /-!
 # Non-vanishing of one total-spin lowering/raising step on a weight vector
@@ -30,23 +31,6 @@ open Matrix
 
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
-/-- The conjugated quadratic form `⟨v, Mᴴ M v⟩ = ‖M v‖²` is a non-negative real. -/
-private theorem star_dotProduct_conjTranspose_mul_mulVec_eq'
-    {n : Type*} [Fintype n] (M : Matrix n n ℂ) (v : n → ℂ) :
-    star v ⬝ᵥ (M.conjTranspose * M).mulVec v =
-      ((∑ i, Complex.normSq ((M.mulVec v) i) : ℝ) : ℂ) := by
-  rw [← Matrix.mulVec_mulVec, Matrix.dotProduct_mulVec, ← Matrix.star_mulVec, dotProduct,
-    Complex.ofReal_sum]
-  refine Finset.sum_congr rfl (fun i _ => ?_)
-  rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
-
-/-- `star v ⬝ᵥ v = ∑ ‖v i‖²` as a real cast into `ℂ`. -/
-private theorem star_dotProduct_self_eq' {n : Type*} [Fintype n] (v : n → ℂ) :
-    star v ⬝ᵥ v = ((∑ i, Complex.normSq (v i) : ℝ) : ℂ) := by
-  rw [dotProduct, Complex.ofReal_sum]
-  refine Finset.sum_congr rfl (fun i _ => ?_)
-  rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
-
 /-- **Total-spin lowering magnitude identity** on a weight-`w` vector:
 `‖Ŝ⁻_tot Φ‖² = ‖Ŝ⁺_tot Φ‖² + 2 w ‖Φ‖²` (all as the real squared norms cast to `ℂ`). -/
 theorem totalSpinSOpMinus_mulVec_normSq_eq (V : Type*) [Fintype V] [DecidableEq V] (N : ℕ)
@@ -66,12 +50,12 @@ theorem totalSpinSOpMinus_mulVec_normSq_eq (V : Type*) [Fintype V] [DecidableEq 
   have hM : star Φ ⬝ᵥ (totalSpinSOpPlus V N * totalSpinSOpMinus V N).mulVec Φ =
       ((∑ i, Complex.normSq ((totalSpinSOpMinus V N).mulVec Φ i) : ℝ) : ℂ) := by
     rw [← totalSpinSOpMinus_conjTranspose (Λ := V) (N := N)]
-    exact star_dotProduct_conjTranspose_mul_mulVec_eq' _ Φ
+    exact star_dotProduct_conjTranspose_mul_mulVec_eq _ Φ
   -- `‖Ŝ⁺Φ‖²` via `(Ŝ⁺)† = Ŝ⁻`.
   have hP : star Φ ⬝ᵥ (totalSpinSOpMinus V N * totalSpinSOpPlus V N).mulVec Φ =
       ((∑ i, Complex.normSq ((totalSpinSOpPlus V N).mulVec Φ i) : ℝ) : ℂ) := by
     rw [← totalSpinSOpPlus_conjTranspose (Λ := V) (N := N)]
-    exact star_dotProduct_conjTranspose_mul_mulVec_eq' _ Φ
+    exact star_dotProduct_conjTranspose_mul_mulVec_eq _ Φ
   -- Expand `star Φ ⬝ᵥ (Ŝ⁺Ŝ⁻) Φ` through `hPM`.
   have hexp : star Φ ⬝ᵥ (totalSpinSOpPlus V N * totalSpinSOpMinus V N).mulVec Φ =
       star Φ ⬝ᵥ (totalSpinSOpMinus V N * totalSpinSOpPlus V N).mulVec Φ +
@@ -81,7 +65,7 @@ theorem totalSpinSOpMinus_mulVec_normSq_eq (V : Type*) [Fintype V] [DecidableEq 
     congr 1
     rw [hz, dotProduct_smul, smul_eq_mul]
     ring
-  rw [hM, hP, star_dotProduct_self_eq'] at hexp
+  rw [hM, hP, star_dotProduct_self_eq] at hexp
   exact hexp
 
 /-- **One lowering step is non-zero on a positive-weight vector.** For `Φ ≠ 0` with

--- a/LatticeSystem/Quantum/SpinS/Theorem24SU2GlobalUniquenessFromMLMCoreSectors.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem24SU2GlobalUniquenessFromMLMCoreSectors.lean
@@ -4,6 +4,7 @@ import LatticeSystem.Quantum.SpinS.EigenspaceFinrankLeOneTransfer
 import LatticeSystem.Quantum.SpinS.HermitianMinEigenvalueEigenvector
 import LatticeSystem.Quantum.SpinS.HermitianMinLeOfEigenvector
 import LatticeSystem.Quantum.SpinS.Theorem24SectorPFFromTheorem23
+import LatticeSystem.Math.ComplexVectorKernel
 /-!
 # SU(2)-point global uniqueness from the MLM endpoint — core lemmas
 
@@ -285,18 +286,6 @@ theorem heisenbergHamiltonianS_totalSpinSSquared_mulVec_raise_landed_eq_zero_of_
 /-! ## Zero-Casimir singlet image obstruction -/
 
 omit [DecidableEq V] in
-/-- The conjugate-symmetric norm identity
-`⟪M v, M v⟫ = ⟪v, Mᴴ M v⟫`, written as a sum of complex norm squares. -/
-private theorem star_dotProduct_conjTranspose_mul_mulVec_eq_normSq
-    {n : Type*} [Fintype n] (M : Matrix n n ℂ) (v : n → ℂ) :
-    star v ⬝ᵥ (M.conjTranspose * M).mulVec v =
-      ((∑ i, Complex.normSq ((M.mulVec v) i) : ℝ) : ℂ) := by
-  rw [← Matrix.mulVec_mulVec, Matrix.dotProduct_mulVec, ← Matrix.star_mulVec, dotProduct,
-    Complex.ofReal_sum]
-  refine Finset.sum_congr rfl (fun i _ => ?_)
-  rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
-
-omit [DecidableEq V] in
 /-- If a vector is in the range of `M` and is killed by `Mᴴ`, then the vector is
 zero.  This is the finite-dimensional Hilbert-space fact `range M ⟂ ker Mᴴ`. -/
 private theorem eq_zero_of_eq_mulVec_and_conjTranspose_mulVec_eq_zero
@@ -309,7 +298,7 @@ private theorem eq_zero_of_eq_mulVec_and_conjTranspose_mulVec_eq_zero
     calc
       ((∑ i, Complex.normSq (w i) : ℝ) : ℂ) =
           star u ⬝ᵥ (M.conjTranspose * M).mulVec u := by
-            rw [star_dotProduct_conjTranspose_mul_mulVec_eq_normSq]
+            rw [star_dotProduct_conjTranspose_mul_mulVec_eq]
             simp [hw_eq]
       _ = star u ⬝ᵥ M.conjTranspose.mulVec w := by
             rw [hw_eq, ← Matrix.mulVec_mulVec]


### PR DESCRIPTION
Part of #4914

Final PR of the #4914 duplicate-elimination series. Eliminates the last remaining
true V2 duplicates, which were deferred pending completion of the §10.2 branch
(#4852, now merged with no open PR and no conflict on the touched files).

## Scope (design: `.self-local/reports/design-pr12plus-quantum-dups.md` items #1/#2/#14/#21)

### #1/#2 — `spinfulIndex` parity helpers (Fermion/JordanWigner)
- `AllDownState.lean` primed duplicates `spinfulIndex_up_even'` /
  `spinfulIndex_down_odd'` are identical-statement copies of the canonical
  `AllUpState.lean` lemmas `spinfulIndex_up_even` / `spinfulIndex_down_odd`.
- Delete the primed copies, add the missing import, and rewire all call sites
  to the canonical names.

### #14/#21 — `star_dotProduct` triplicate families
- `star_dotProduct_self_eq` (3 copies across `ProofCore`,
  `Theorem23SublatticeCasimirSzBound`, `Theorem23TotalLoweringNonvanishing`)
  and `star_dotProduct_conjTranspose_mul_mulVec_eq` (3 copies, same-theme
  consumers) are generic complex-vector-kernel facts, not book theorems.
- Extract each to a single canonical implementation in
  `LatticeSystem/Math/ComplexVectorKernel.lean` (mind the existing import
  cycle noted in the design doc) and rewire all six call sites to import it.

This closes out all currently-known true V2 duplicates tracked by #4914.

## Checklist
- [ ] Remove `spinfulIndex_up_even'` / `spinfulIndex_down_odd'`, rewire to canonical.
- [ ] Extract `star_dotProduct_self_eq` to `Math/ComplexVectorKernel.lean`, rewire 3 sites.
- [ ] Extract `star_dotProduct_conjTranspose_mul_mulVec_eq` to `Math/ComplexVectorKernel.lean`, rewire 3 sites.
- [ ] `lake build` clean, zero lint warnings, `audit_gate.py --diff main` pass.
- [ ] docs/index.md sync if any touched decl is docs-tracked (else note override rationale).
- [ ] codex review verdict.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
