### PR TITLE
Remove zero-reference decorative lemmas (MultiSite/Magnetization/MultiSiteDot) — #4930

### DIFF
--- a/LatticeSystem/Quantum/SpinS/Magnetization.lean
+++ b/LatticeSystem/Quantum/SpinS/Magnetization.lean
@@ -50,18 +50,6 @@ theorem magSumS_real_nonneg (σ : Λ → Fin (N + 1)) :
   exact_mod_cast magSumS_nonneg σ
 
 omit [DecidableEq Λ] in
-/-- The cast `(magSumS σ : ℂ).re = (magSumS σ : ℝ)`. -/
-theorem magSumS_complex_re (σ : Λ → Fin (N + 1)) :
-    ((magSumS σ : ℂ)).re = (magSumS σ : ℝ) := by
-  simp
-
-omit [DecidableEq Λ] in
-/-- The cast `(magSumS σ : ℂ).im = 0`. -/
-theorem magSumS_complex_im (σ : Λ → Fin (N + 1)) :
-    ((magSumS σ : ℂ)).im = 0 := by
-  simp
-
-omit [DecidableEq Λ] in
 /-- `magSumS σ ≤ |Λ| · N`. -/
 theorem magSumS_le (σ : Λ → Fin (N + 1)) :
     magSumS σ ≤ Fintype.card Λ * N := by
@@ -129,38 +117,6 @@ theorem mem_magSubspaceS_iff (M : ℂ) (v : (Λ → Fin (N + 1)) → ℂ) :
 theorem zero_mem_magSubspaceS (M : ℂ) :
     (0 : (Λ → Fin (N + 1)) → ℂ) ∈ magSubspaceS Λ N M :=
   (magSubspaceS Λ N M).zero_mem
-
-/-- Sum-membership for the magnetization subspace. -/
-theorem add_mem_magSubspaceS (M : ℂ) {v w : (Λ → Fin (N + 1)) → ℂ}
-    (hv : v ∈ magSubspaceS Λ N M) (hw : w ∈ magSubspaceS Λ N M) :
-    v + w ∈ magSubspaceS Λ N M :=
-  (magSubspaceS Λ N M).add_mem hv hw
-
-/-- Scalar multiplication membership. -/
-theorem smul_mem_magSubspaceS (M : ℂ) (c : ℂ)
-    {v : (Λ → Fin (N + 1)) → ℂ} (hv : v ∈ magSubspaceS Λ N M) :
-    c • v ∈ magSubspaceS Λ N M :=
-  (magSubspaceS Λ N M).smul_mem c hv
-
-/-- Negation membership in `magSubspaceS`. -/
-theorem neg_mem_magSubspaceS (M : ℂ)
-    {v : (Λ → Fin (N + 1)) → ℂ} (hv : v ∈ magSubspaceS Λ N M) :
-    -v ∈ magSubspaceS Λ N M :=
-  (magSubspaceS Λ N M).neg_mem hv
-
-/-- Subtraction membership in `magSubspaceS`. -/
-theorem sub_mem_magSubspaceS (M : ℂ)
-    {v w : (Λ → Fin (N + 1)) → ℂ} (hv : v ∈ magSubspaceS Λ N M)
-    (hw : w ∈ magSubspaceS Λ N M) :
-    v - w ∈ magSubspaceS Λ N M :=
-  (magSubspaceS Λ N M).sub_mem hv hw
-
-/-- `Finset.sum` membership in `magSubspaceS`. -/
-theorem finset_sum_mem_magSubspaceS {ι : Type*} (M : ℂ)
-    (s : Finset ι) (f : ι → (Λ → Fin (N + 1)) → ℂ)
-    (hf : ∀ i ∈ s, f i ∈ magSubspaceS Λ N M) :
-    (∑ i ∈ s, f i) ∈ magSubspaceS Λ N M :=
-  (magSubspaceS Λ N M).sum_mem hf
 
 /-- Distinct magnetization eigenvalues give disjoint subspaces. -/
 theorem magSubspaceS_disjoint {M M' : ℂ} (hMM' : M ≠ M') :
@@ -346,19 +302,6 @@ theorem magSumS_const_zero :
   simp
 
 omit [DecidableEq Λ] in
-/-- `magSumS (fun _ => Fin.last N) = |Λ| · N`. -/
-theorem magSumS_const_last :
-    magSumS (fun _ : Λ => (Fin.last N : Fin (N + 1))) =
-      Fintype.card Λ * N := by
-  rw [magSumS_const]
-  rfl
-
-omit [DecidableEq Λ] in
-/-- `magSumS σ = magSumS σ`: trivial reflexivity. -/
-theorem magSumS_refl (σ : Λ → Fin (N + 1)) :
-    magSumS σ = magSumS σ := rfl
-
-omit [DecidableEq Λ] in
 /-- `magSumS σ = 0` iff `σ x = 0` for every `x : Λ`. -/
 theorem magSumS_eq_zero_iff (σ : Λ → Fin (N + 1)) :
     magSumS σ = 0 ↔ ∀ x : Λ, σ x = 0 := by
@@ -372,21 +315,6 @@ theorem magSumS_eq_zero_iff (σ : Λ → Fin (N + 1)) :
   · intro h x _
     rw [h x]
     rfl
-
-omit [DecidableEq Λ] in
-/-- `magEigenvalueS σ = 0` ↔ `magSumS σ = |Λ| · N / 2` (the
-half-occupation condition). For spin-1/2 (`N = 1`) this means the
-configuration has equal numbers of up/down spins. -/
-theorem magEigenvalueS_eq_zero_iff (σ : Λ → Fin (N + 1)) :
-    magEigenvalueS σ = 0 ↔
-      ((Fintype.card Λ : ℂ) * (N : ℂ)) / 2 = (magSumS σ : ℂ) := by
-  unfold magEigenvalueS
-  constructor
-  · intro h
-    exact sub_eq_zero.mp h
-  · intro h
-    rw [← h]
-    ring
 
 omit [DecidableEq Λ] in
 /-- `magEigenvalueS σ ∈ ℝ`: the eigenvalue is real-valued (its
@@ -430,17 +358,6 @@ theorem magEigenvalueS_re_upper_bound (σ : Λ → Fin (N + 1)) :
   linarith
 
 omit [DecidableEq Λ] in
-/-- The absolute value of the magnetization eigenvalue is bounded by
-`(|Λ| · N) / 2`. -/
-theorem magEigenvalueS_re_abs_bound (σ : Λ → Fin (N + 1)) :
-    |(magEigenvalueS σ).re| ≤ ((Fintype.card Λ : ℝ) * (N : ℝ)) / 2 := by
-  rw [abs_le]
-  refine ⟨?_, magEigenvalueS_re_upper_bound σ⟩
-  have := magEigenvalueS_re_lower_bound (Λ := Λ) σ
-  linarith
-
-
-omit [DecidableEq Λ] in
 /-- `magEigenvalueS σ = ((magEigenvalueS σ).re : ℂ)`: its imaginary
 part vanishes, so it equals its embedded real part. -/
 theorem magEigenvalueS_eq_ofReal_re (σ : Λ → Fin (N + 1)) :
@@ -448,13 +365,6 @@ theorem magEigenvalueS_eq_ofReal_re (σ : Λ → Fin (N + 1)) :
   apply Complex.ext
   · simp
   · simp [magEigenvalueS_im_zero]
-
-/-- `Ŝ_tot^{(3)} · |σ⟩ = ((magEigenvalueS σ).re : ℂ) • |σ⟩` — the
-real-eigenvalue form of `totalSpinSOp3_mulVec_basisVecS`. -/
-theorem totalSpinSOp3_mulVec_basisVecS_real (σ : Λ → Fin (N + 1)) :
-    (totalSpinSOp3 Λ N).mulVec (basisVecS σ) =
-      ((magEigenvalueS σ).re : ℂ) • basisVecS σ := by
-  rw [totalSpinSOp3_mulVec_basisVecS, ← magEigenvalueS_eq_ofReal_re]
 
 omit [DecidableEq Λ] in
 /-- `magEigenvalueS σ = magEigenvalueS σ' ↔ magSumS σ = magSumS σ'`:
@@ -479,23 +389,6 @@ theorem magEigenvalueS_eq_iff (σ σ' : Λ → Fin (N + 1)) :
     exact_mod_cast h'
   · intro h
     rw [h]
-
-omit [DecidableEq Λ] in
-/-- `magSumS σ ≥ (σ y).val` at any site `y`. -/
-theorem magSumS_ge_of_exists (σ : Λ → Fin (N + 1)) (y : Λ) :
-    (σ y).val ≤ magSumS σ := by
-  unfold magSumS
-  exact Finset.single_le_sum
-    (f := fun x => (σ x).val) (fun _ _ => Nat.zero_le _) (Finset.mem_univ y)
-
-omit [DecidableEq Λ] in
-/-- `magSumS σ > 0` ↔ there exists `x` with `σ x ≠ 0`. -/
-theorem magSumS_pos_iff (σ : Λ → Fin (N + 1)) :
-    0 < magSumS σ ↔ ∃ x : Λ, σ x ≠ 0 := by
-  rw [Nat.pos_iff_ne_zero]
-  rw [Ne, magSumS_eq_zero_iff]
-  push Not
-  rfl
 
 omit [DecidableEq Λ] in
 /-- For `N = 0` (`S = 0`), `magSumS σ = 0` always (the only Fin 1
@@ -539,48 +432,6 @@ theorem magEigenvalueS_of_isEmpty [IsEmpty Λ] (σ : Λ → Fin (N + 1)) :
   ring
 
 omit [DecidableEq Λ] in
-/-- For `N = 0` (`S = 0`), `(magEigenvalueS σ).re = 0`. -/
-theorem magEigenvalueS_re_of_N_zero (σ : Λ → Fin 1) :
-    (magEigenvalueS (N := 0) σ).re = 0 := by
-  rw [magEigenvalueS_of_N_zero σ]
-  simp
-
-omit [DecidableEq Λ] in
-/-- For an empty lattice, `(magEigenvalueS σ).re = 0`. -/
-theorem magEigenvalueS_re_of_isEmpty [IsEmpty Λ] (σ : Λ → Fin (N + 1)) :
-    (magEigenvalueS σ).re = 0 := by
-  rw [magEigenvalueS_of_isEmpty σ]
-  simp
-
-/-- For trivial spin (`N = 0`), `magSubspaceS Λ 0 0 = ⊤`: every
-vector is in the zero-magnetization subspace because every basis
-state has eigenvalue 0. -/
-theorem magSubspaceS_N_zero_zero_eq_top :
-    magSubspaceS Λ 0 0 = ⊤ := by
-  refine eq_top_iff.mpr (fun v _ => ?_)
-  rw [mem_magSubspaceS_iff]
-  rw [show (totalSpinSOp3 Λ 0 : ManyBodyOpS Λ 0) = 0 from
-    totalSpinSOp3_N_zero (Λ := Λ)]
-  rw [Matrix.zero_mulVec]
-  simp
-
-/-- For trivial spin (`N = 0`) and `M ≠ 0`, `magSubspaceS Λ 0 M = ⊥`:
-no vector has nonzero magnetization since `Ŝ_tot^{(3)} = 0`. -/
-theorem magSubspaceS_N_zero_ne_zero_eq_bot {M : ℂ} (hM : M ≠ 0) :
-    magSubspaceS Λ 0 M = ⊥ := by
-  refine eq_bot_iff.mpr (fun v hv => ?_)
-  rw [mem_magSubspaceS_iff] at hv
-  rw [show (totalSpinSOp3 Λ 0 : ManyBodyOpS Λ 0) = 0 from
-    totalSpinSOp3_N_zero (Λ := Λ)] at hv
-  rw [Matrix.zero_mulVec] at hv
-  -- hv : 0 = M • v
-  rw [Submodule.mem_bot]
-  have : M • v = 0 := hv.symm
-  rcases smul_eq_zero.mp this with hM' | hv'
-  · exact (hM hM').elim
-  · exact hv'
-
-omit [DecidableEq Λ] in
 /-- `magEigenvalueS (fun _ => 0) = (|Λ| · N : ℂ)/2`. -/
 theorem magEigenvalueS_const_zero :
     magEigenvalueS (fun _ : Λ => (0 : Fin (N + 1))) =
@@ -589,7 +440,6 @@ theorem magEigenvalueS_const_zero :
   rw [magSumS_const_zero]
   push_cast
   ring
-
 
 omit [DecidableEq Λ] in
 /-- `magEigenvalueS` of a constant configuration. The maximum value
@@ -613,21 +463,5 @@ theorem magEigenvalueS_const_last :
   rw [magEigenvalueS_const]
   simp [Fin.val_last]
   ring
-
-omit [DecidableEq Λ] in
-/-- `magEigenvalueS_re` at the all-zero config: `(|Λ| · N : ℝ)/2`. -/
-theorem magEigenvalueS_re_const_zero :
-    (magEigenvalueS (fun _ : Λ => (0 : Fin (N + 1)))).re =
-      (Fintype.card Λ : ℝ) * (N : ℝ) / 2 := by
-  rw [magEigenvalueS_const_zero]
-  simp
-
-omit [DecidableEq Λ] in
-/-- `magEigenvalueS_re` at the all-`Fin.last N` config: `-((|Λ| · N : ℝ)/2)`. -/
-theorem magEigenvalueS_re_const_last :
-    (magEigenvalueS (fun _ : Λ => (Fin.last N : Fin (N + 1)))).re =
-      -((Fintype.card Λ : ℝ) * (N : ℝ) / 2) := by
-  rw [magEigenvalueS_const_last]
-  simp
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/MultiSite.lean
+++ b/LatticeSystem/Quantum/SpinS/MultiSite.lean
@@ -55,25 +55,9 @@ noncomputable def spinSSiteOpMinus (i : Λ) (N : ℕ) : ManyBodyOpS Λ N :=
 
 /-! ## Definitional unfoldings for site operators -/
 
-/-- Definitional unfolding of `spinSSiteOp1`. -/
-theorem spinSSiteOp1_def (i : Λ) (N : ℕ) :
-    spinSSiteOp1 (Λ := Λ) i N = onSiteS i (spinSOp1 N) := rfl
-
-/-- Definitional unfolding of `spinSSiteOp2`. -/
-theorem spinSSiteOp2_def (i : Λ) (N : ℕ) :
-    spinSSiteOp2 (Λ := Λ) i N = onSiteS i (spinSOp2 N) := rfl
-
 /-- Definitional unfolding of `spinSSiteOp3`. -/
 theorem spinSSiteOp3_def (i : Λ) (N : ℕ) :
     spinSSiteOp3 (Λ := Λ) i N = onSiteS i (spinSOp3 N) := rfl
-
-/-- Definitional unfolding of `spinSSiteOpPlus`. -/
-theorem spinSSiteOpPlus_def (i : Λ) (N : ℕ) :
-    spinSSiteOpPlus (Λ := Λ) i N = onSiteS i (spinSOpPlus N) := rfl
-
-/-- Definitional unfolding of `spinSSiteOpMinus`. -/
-theorem spinSSiteOpMinus_def (i : Λ) (N : ℕ) :
-    spinSSiteOpMinus (Λ := Λ) i N = onSiteS i (spinSOpMinus N) := rfl
 
 /-! ## Computational basis vectors -/
 
@@ -82,11 +66,6 @@ the function that is `1` at `σ` and `0` elsewhere. Multi-site spin-`S`
 generalisation of `basisVec` (`Quantum/ManyBody.lean`). -/
 def basisVecS (σ : Λ → Fin (N + 1)) : (Λ → Fin (N + 1)) → ℂ :=
   fun τ => if τ = σ then 1 else 0
-
-omit [DecidableEq Λ] in
-/-- Definitional unfolding of `basisVecS`. -/
-theorem basisVecS_def (σ : Λ → Fin (N + 1)) :
-    basisVecS σ = (fun τ => if τ = σ then (1 : ℂ) else 0) := rfl
 
 omit [DecidableEq Λ] in
 /-- Explicit `if`-form of `basisVecS σ τ`. -/
@@ -119,13 +98,6 @@ theorem onSiteS_neg (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
   rw [show ((-1 : ℂ) • onSiteS (N := N) i A : ManyBodyOpS Λ N) =
         -onSiteS i A from by rw [neg_smul, one_smul]]
 
-/-- Triple-product same-site identity:
-`(onSiteS i A) · (onSiteS i A) · (onSiteS i A) = onSiteS i (A * A * A)`. -/
-theorem onSiteS_cube (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    (onSiteS i A : ManyBodyOpS Λ N) * onSiteS i A * onSiteS i A =
-      onSiteS i (A * A * A) := by
-  rw [onSiteS_mul_onSiteS_same, onSiteS_mul_onSiteS_same]
-
 /-- Power identity: `(onSiteS i A)^k = onSiteS i (A^k)`. -/
 theorem onSiteS_pow (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)
     (k : ℕ) :
@@ -138,114 +110,11 @@ theorem onSiteS_pow (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)
     rw [pow_succ, ih, onSiteS_mul_onSiteS_same]
     rw [pow_succ]
 
-/-- `onSiteS i 0 ^ k = 0` for `k > 0` (zero embedding stays zero
-under repeated multiplication). Specialisation of `onSiteS_pow`. -/
-theorem onSiteS_zero_pow (i : Λ) {k : ℕ} (hk : 0 < k) :
-    (onSiteS i (0 : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)
-        : ManyBodyOpS Λ N) ^ k = 0 := by
-  rw [onSiteS_pow]
-  rw [show (0 : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) ^ k = 0 from
-    zero_pow (Nat.pos_iff_ne_zero.mp hk)]
-  exact onSiteS_zero i
-
-/-- The site-embedded sum: `onSiteS i (∑ k, A k) = ∑ k, onSiteS i (A k)`. -/
-theorem onSiteS_finset_sum {ι : Type*} (i : Λ) (s : Finset ι)
-    (f : ι → Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    (onSiteS i (∑ k ∈ s, f k) : ManyBodyOpS Λ N) =
-      ∑ k ∈ s, onSiteS i (f k) := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simp [onSiteS_zero]
-  | @insert a t hat ih =>
-    rw [Finset.sum_insert hat, Finset.sum_insert hat,
-      onSiteS_add, ih]
-
-/-- Convenience: `onSiteS i A = onSiteS i (A + 0)`. -/
-theorem onSiteS_add_zero (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    (onSiteS i (A + 0) : ManyBodyOpS Λ N) = onSiteS i A := by
-  rw [add_zero]
-
-/-- `onSiteS i A^0 = 1` (zero power gives the identity). -/
-theorem onSiteS_pow_zero (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    (onSiteS i A : ManyBodyOpS Λ N) ^ 0 = 1 := by
-  rw [onSiteS_pow]
-  rw [pow_zero]
-  exact onSiteS_one i
-
-/-- `onSiteS i A ^ 1 = onSiteS i A`. -/
-theorem onSiteS_pow_one (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    (onSiteS i A : ManyBodyOpS Λ N) ^ 1 = onSiteS i A := by
-  rw [pow_one]
-
-/-- `onSiteS i A ^ 2 = onSiteS i (A^2)`. -/
-theorem onSiteS_pow_two (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    (onSiteS i A : ManyBodyOpS Λ N) ^ 2 = onSiteS i (A ^ 2) :=
-  onSiteS_pow i A 2
-
-/-- `onSiteS i A ^ 3 = onSiteS i (A^3)`. -/
-theorem onSiteS_pow_three (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    (onSiteS i A : ManyBodyOpS Λ N) ^ 3 = onSiteS i (A ^ 3) :=
-  onSiteS_pow i A 3
-
-/-- `onSiteS i A ^ 4 = onSiteS i (A^4)`. -/
-theorem onSiteS_pow_four (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    (onSiteS i A : ManyBodyOpS Λ N) ^ 4 = onSiteS i (A ^ 4) :=
-  onSiteS_pow i A 4
-
-/-- `onSiteS i A ^ 5 = onSiteS i (A^5)`. -/
-theorem onSiteS_pow_five (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    (onSiteS i A : ManyBodyOpS Λ N) ^ 5 = onSiteS i (A ^ 5) :=
-  onSiteS_pow i A 5
-
-/-- `onSiteS i A` commutes with itself trivially. -/
-theorem onSiteS_self_commute (i : Λ) (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-    Commute (onSiteS i A : ManyBodyOpS Λ N) (onSiteS i A) :=
-  Commute.refl _
-
 /-- Commute version of distinct-site commutativity. -/
 theorem onSiteS_commute_of_ne {i j : Λ} (hij : i ≠ j)
     (A B : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
     Commute (onSiteS i A : ManyBodyOpS Λ N) (onSiteS j B) :=
   onSiteS_mul_onSiteS_of_ne hij A B
-
-/-- The site-`i` zero embedding has every product with anything equal to zero. -/
-theorem onSiteS_zero_mul (i : Λ) (B : ManyBodyOpS Λ N) :
-    (onSiteS i (0 : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) : ManyBodyOpS Λ N) * B = 0 := by
-  rw [onSiteS_zero, zero_mul]
-
-/-- The site-`i` smul embedding: `onSiteS i (c • A) = c • onSiteS i A`,
-restated in matrix form (already proved in `onSiteS_smul`). -/
-theorem onSiteS_smul_apply (i : Λ) (c : ℂ)
-    (A : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)
-    (σ' σ : Λ → Fin (N + 1)) :
-    (onSiteS i (c • A) : ManyBodyOpS Λ N) σ' σ =
-      c * (onSiteS i A : ManyBodyOpS Λ N) σ' σ := by
-  rw [onSiteS_smul, Matrix.smul_apply, smul_eq_mul]
-
-/-- The site-`i` add embedding entry-wise:
-`(onSiteS i (A + B)) σ' σ = (onSiteS i A) σ' σ + (onSiteS i B) σ' σ`. -/
-theorem onSiteS_add_apply (i : Λ)
-    (A B : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)
-    (σ' σ : Λ → Fin (N + 1)) :
-    (onSiteS i (A + B) : ManyBodyOpS Λ N) σ' σ =
-      (onSiteS i A : ManyBodyOpS Λ N) σ' σ +
-      (onSiteS i B : ManyBodyOpS Λ N) σ' σ := by
-  rw [onSiteS_add, Matrix.add_apply]
-
-/-- The site-`i` sub embedding entry-wise. -/
-theorem onSiteS_sub_apply (i : Λ)
-    (A B : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ)
-    (σ' σ : Λ → Fin (N + 1)) :
-    (onSiteS i (A - B) : ManyBodyOpS Λ N) σ' σ =
-      (onSiteS i A : ManyBodyOpS Λ N) σ' σ -
-      (onSiteS i B : ManyBodyOpS Λ N) σ' σ := by
-  rw [onSiteS_sub, Matrix.sub_apply]
-
-/-- The right multiplicative version: `B * onSiteS i 0 = 0`. -/
-theorem mul_onSiteS_zero (i : Λ) (B : ManyBodyOpS Λ N) :
-    B * (onSiteS i (0 : Matrix (Fin (N + 1)) (Fin (N + 1)) ℂ) :
-        ManyBodyOpS Λ N) = 0 := by
-  rw [onSiteS_zero, mul_zero]
 
 /-- Applying `onSiteS i A` to a basis vector and reading the result
 at configuration `τ` yields the matrix element `(onSiteS i A) τ σ`:
@@ -315,19 +184,5 @@ theorem onSiteS_spinSOpMinus_mul_onSiteS_spinSOpPlus_im_zero
     rw [spinSOpMinus_apply_im_zero, spinSOpPlus_apply_im_zero]
     ring
   · rw [if_neg h]; simp
-
-
-/-- For distinct sites `x ≠ y`, the **sum** `(S+_x S-_y) + (S-_x S+_y)`
-matrix element has non-negative real part on every `(σ', σ)` pair. -/
-theorem onSiteS_spinSOpPlus_Minus_plus_Minus_Plus_re_nonneg
-    {x y : Λ} (hxy : x ≠ y) (σ' σ : Λ → Fin (N + 1)) :
-    0 ≤ ((onSiteS x (spinSOpPlus N) * onSiteS y (spinSOpMinus N) +
-          onSiteS x (spinSOpMinus N) * onSiteS y (spinSOpPlus N)
-          : ManyBodyOpS Λ N) σ' σ).re := by
-  rw [Matrix.add_apply, Complex.add_re]
-  have h1 := onSiteS_spinSOpPlus_mul_onSiteS_spinSOpMinus_re_nonneg hxy σ' σ
-  have h2 := onSiteS_spinSOpMinus_mul_onSiteS_spinSOpPlus_re_nonneg hxy σ' σ
-  linarith
-
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/MultiSiteDot.lean
+++ b/LatticeSystem/Quantum/SpinS/MultiSiteDot.lean
@@ -108,44 +108,12 @@ theorem sum_spinSDot_self {Λ : Type*} [Fintype Λ] [DecidableEq Λ] (N : ℕ) :
   rw [← Nat.cast_smul_eq_nsmul ℂ (Fintype.card Λ)]
   rw [smul_smul]
 
-/-- Symmetry of the spin-`S` two-site dot product (alternative form):
-`spinSDot x y N = spinSDot y x N` for any `x, y` (no `≠` required). -/
-theorem spinSDot_swap {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
-    (x y : Λ) (N : ℕ) :
-    spinSDot x y N = spinSDot y x N :=
-  spinSDot_comm x y N
-
-/-- The two-site spin-`S` dot product is Hermitian (`Matrix.IsHermitian`)
-specifically: `(spinSDot x y N).IsHermitian`. Restated form of β-3g
-for direct use. -/
-theorem spinSDot_isHermitian_restated {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
-    (x y : Λ) (N : ℕ) :
-    (spinSDot x y N : ManyBodyOpS Λ N).IsHermitian :=
-  spinSDot_isHermitian x y N
-
-/-- `spinSDot x y N` and `spinSDot y x N` are the same Hermitian
-operator (combining `spinSDot_comm` with Hermiticity). -/
-theorem spinSDot_swap_isHermitian
-    {Λ : Type*} [Fintype Λ] [DecidableEq Λ] (x y : Λ) (N : ℕ) :
-    (spinSDot y x N : ManyBodyOpS Λ N).IsHermitian := by
-  rw [← spinSDot_comm x y N]
-  exact spinSDot_isHermitian x y N
-
-/-- For `x = y`, the same-site dot product equals `(N(N+2)/4) • 1`
-(restated for emphasis). -/
-theorem spinSDot_self_eq {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
-    (x : Λ) (N : ℕ) :
-    (spinSDot x x N : ManyBodyOpS Λ N) =
-      ((N : ℂ) * (N + 2) / 4) • 1 :=
-  spinSDot_self x N
-
 /-- `spinSDot x x 0` (trivial spin) equals zero. -/
 theorem spinSDot_self_N_zero {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
     (x : Λ) :
     (spinSDot x x 0 : ManyBodyOpS Λ 0) = 0 := by
   rw [spinSDot_self]
   simp
-
 
 /-- `spinSDot x x N` is a scalar multiple of the identity, hence
 commutes with every operator. -/
@@ -175,21 +143,6 @@ theorem spinSDot_self_apply_eq_zero_of_ne (x : Λ) (N : ℕ)
 theorem spinSDot_self_apply_diag (x : Λ) (N : ℕ) (σ : Λ → Fin (N + 1)) :
     (spinSDot x x N : ManyBodyOpS Λ N) σ σ = (N : ℂ) * (N + 2) / 4 := by
   rw [spinSDot_self_apply, if_pos rfl, mul_one]
-
-/-- The same-site dot product diagonal value `N(N+2)/4` is non-negative. -/
-theorem spinSDot_self_apply_diag_re_nonneg (x : Λ) (N : ℕ)
-    (σ : Λ → Fin (N + 1)) :
-    0 ≤ ((spinSDot x x N : ManyBodyOpS Λ N) σ σ).re := by
-  rw [spinSDot_self_apply_diag]
-  rw [show (((N : ℂ) * (N + 2) / 4)).re = ((N : ℝ) * (N + 2) / 4) from by simp]
-  positivity
-
-/-- For `σ' ≠ σ`, the same-site dot product real-part vanishes. -/
-theorem spinSDot_self_apply_re_eq_zero_of_ne (x : Λ) (N : ℕ)
-    {σ' σ : Λ → Fin (N + 1)} (hne : σ' ≠ σ) :
-    ((spinSDot x x N : ManyBodyOpS Λ N) σ' σ).re = 0 := by
-  rw [spinSDot_self_apply_eq_zero_of_ne x N hne]
-  simp
 
 /-- For `x ≠ y`, the matrix element of `Ŝ_x · Ŝ_y` between
 configurations differing off the two-site set `{x, y}` is zero
@@ -226,7 +179,6 @@ theorem spinSDot_self_apply_eq_zero_of_diff_at
     {σ' σ : Λ → Fin (N + 1)} {z : Λ} (hz : σ' z ≠ σ z) :
     (spinSDot x x N : ManyBodyOpS Λ N) σ' σ = 0 :=
   spinSDot_self_apply_eq_zero_of_ne x N (fun heq => hz (by rw [heq]))
-
 
 /-- For `x ≠ y`, the diagonal matrix element of `Ŝ_x · Ŝ_y` reduces
 to the product of the two `Ŝ^{(3)}` eigenvalues:
@@ -341,57 +293,6 @@ theorem spinSDot_apply_im_zero (x y : Λ) (N : ℕ)
   · subst hxy; exact spinSDot_self_apply_im_zero x N σ' σ
   · exact spinSDot_apply_im_zero_of_ne hxy N σ' σ
 
-/-- For real coupling, the matrix element of `Ŝ_x · Ŝ_y` always
-equals its own real-part embedding. -/
-theorem spinSDot_apply_eq_ofReal_re (x y : Λ) (N : ℕ)
-    (σ' σ : Λ → Fin (N + 1)) :
-    (spinSDot x y N : ManyBodyOpS Λ N) σ' σ =
-      (((spinSDot x y N : ManyBodyOpS Λ N) σ' σ).re : ℂ) := by
-  apply Complex.ext
-  · simp
-  · rw [Complex.ofReal_im]
-    exact spinSDot_apply_im_zero x y N σ' σ
-
-/-- For `x ≠ y`, when `σ' = σ` the spinSDot value is its own
-real-part embedding (matches the diagonal formula). -/
-theorem spinSDot_apply_diag_eq_ofReal_re_of_ne
-    {x y : Λ} (hxy : x ≠ y) (N : ℕ) (σ : Λ → Fin (N + 1)) :
-    (spinSDot x y N : ManyBodyOpS Λ N) σ σ =
-      ((((spinSDot x y N : ManyBodyOpS Λ N) σ σ).re : ℝ) : ℂ) := by
-  apply Complex.ext
-  · simp
-  · rw [Complex.ofReal_im]
-    exact spinSDot_apply_im_zero_of_ne hxy N σ σ
-
-/-- For `x ≠ y`, the diagonal real part of `spinSDot` equals
-`(N/2 - σ_x.val)(N/2 - σ_y.val)` (a real number). -/
-theorem spinSDot_apply_diag_re_of_ne
-    {x y : Λ} (hxy : x ≠ y) (N : ℕ) (σ : Λ → Fin (N + 1)) :
-    ((spinSDot x y N : ManyBodyOpS Λ N) σ σ).re =
-      ((N : ℝ) / 2 - (σ x).val) * ((N : ℝ) / 2 - (σ y).val) := by
-  rw [spinSDot_apply_diag_of_ne hxy]
-  rw [Complex.mul_re]
-  simp
-
-/-- For the same-site case, the diagonal real part is `N(N+2)/4`. -/
-theorem spinSDot_self_apply_diag_re (x : Λ) (N : ℕ)
-    (σ : Λ → Fin (N + 1)) :
-    ((spinSDot x x N : ManyBodyOpS Λ N) σ σ).re =
-      (N : ℝ) * (N + 2) / 4 := by
-  rw [spinSDot_self_apply_diag]
-  simp
-
-/-- The same-site `spinSDot x x N σ σ` equals its real-part embedding. -/
-theorem spinSDot_self_apply_diag_eq_ofReal_re (x : Λ) (N : ℕ)
-    (σ : Λ → Fin (N + 1)) :
-    (spinSDot x x N : ManyBodyOpS Λ N) σ σ =
-      (((((spinSDot x x N : ManyBodyOpS Λ N) σ σ).re : ℝ) : ℂ)) := by
-  apply Complex.ext
-  · simp
-  · rw [Complex.ofReal_im]
-    exact spinSDot_self_apply_im_zero x N σ σ
-
-
 /-- The matrix-element form of the raising/lowering decomposition of
 `spinSDot`: combines the `(1/2)(S+S- + S-S+)` ladder part with the
 `S^3 ⊗ S^3` diagonal part. -/
@@ -404,18 +305,6 @@ theorem spinSDot_apply_eq_pm_3 (x y : Λ) (N : ℕ)
         onSiteS x (spinSOp3 N) * onSiteS y (spinSOp3 N)
           : ManyBodyOpS Λ N) σ' σ := by
   rw [spinSDot_eq_plus_minus]
-
-/-- For `x ≠ y` and configurations differing off the two-site set
-`{x, y}`, the matrix element of `Ŝ_x · Ŝ_y` is zero (already
-established as `spinSDot_apply_eq_zero_of_off_two_site_diff`). The
-real part trivially has zero. -/
-theorem spinSDot_apply_re_eq_zero_of_off_two_site_diff
-    {x y : Λ} (hxy : x ≠ y) (N : ℕ)
-    {σ' σ : Λ → Fin (N + 1)}
-    (h : ¬ ∀ k, k ≠ x → k ≠ y → σ' k = σ k) :
-    ((spinSDot x y N : ManyBodyOpS Λ N) σ' σ).re = 0 := by
-  rw [spinSDot_apply_eq_zero_of_off_two_site_diff hxy N h]
-  simp
 
 /-- For `x ≠ y` and `σ', σ` agreeing off `{x, y}`, the dot-product
 matrix element factors via the per-site spinSOp_α matrix elements:
@@ -461,6 +350,5 @@ theorem spinSDot_N_zero_total {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
   by_cases hxy : x = y
   · subst hxy; exact spinSDot_self_N_zero x
   · exact spinSDot_N_zero_of_ne hxy
-
 
 end LatticeSystem.Quantum


### PR DESCRIPTION
## Summary
Remove zero-reference decorative lemmas from `Quantum/SpinS/{MultiSite, Magnetization, 
MultiSiteDot}.lean` (55 combined declared lemmas with no external references). This is the 
**Category 2 (V1 decorative triage) Sweep PR3** under Issue #4930, following the #4914 
PR-per-tight-cluster methodology.

Per CLAUDE.local.md: "Tasaki 現定理の証明の最終行から逆向きに必要な補題だけ書く 
(backward chaining). クリティカルパス外の装飾的補題は厳禁."

Each moved/deleted declaration was verified zero-reference via git grep -w at implementation 
time; none are @[simp], capstone theorems, or active in §10.2. Deletions are purely decorative 
(not load-bearing to the proofs they surrounded).

**Issue reference**: #4930 (master refactoring sweep, Category 2 / Sweep PR3)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
