### PR TITLE
Remove zero-reference decorative lemmas cluster3 (DressedHeisenbergMarshallCore/MultiSiteMatrixElement) — #4930

### DIFF
--- a/LatticeSystem/Quantum/SpinS/DressedHeisenbergMarshallCore.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedHeisenbergMarshallCore.lean
@@ -93,26 +93,6 @@ theorem dressedHeisenbergS_apply_eq_zero_of_one_site_diff
     (Λ := V) J N hagree hz]
   ring
 
-/-- The dressed Heisenberg matrix (as a `ManyBodyOpS`) vanishes on
-one-site differences. -/
-theorem dressedHeisenbergSMatrix_apply_eq_zero_of_one_site_diff
-    (A : V → Bool) (J : V → V → ℂ) (N : ℕ)
-    {σ' σ : V → Fin (N + 1)}
-    {z : V} (hagree : ∀ k, k ≠ z → σ' k = σ k) (hz : σ' z ≠ σ z) :
-    dressedHeisenbergSMatrix A J N σ' σ = 0 :=
-  dressedHeisenbergS_apply_eq_zero_of_one_site_diff A J N hagree hz
-
-/-- The real-part dressed Heisenberg matrix vanishes on one-site
-differences. -/
-theorem dressedHeisenbergSReMatrix_apply_eq_zero_of_one_site_diff
-    (A : V → Bool) (J : V → V → ℂ) (N : ℕ)
-    {σ' σ : V → Fin (N + 1)}
-    {z : V} (hagree : ∀ k, k ≠ z → σ' k = σ k) (hz : σ' z ≠ σ z) :
-    dressedHeisenbergSReMatrix A J N σ' σ = 0 := by
-  rw [dressedHeisenbergSReMatrix_apply,
-    dressedHeisenbergS_apply_eq_zero_of_one_site_diff A J N hagree hz]
-  simp
-
 /-- Dressed Heisenberg matrix vanishes on three-site differences. -/
 theorem dressedHeisenbergS_apply_eq_zero_of_three_diff
     (A : V → Bool) (J : V → V → ℂ) (N : ℕ)
@@ -125,29 +105,6 @@ theorem dressedHeisenbergS_apply_eq_zero_of_three_diff
   rw [heisenbergHamiltonianS_apply_eq_zero_of_three_diff (Λ := V) J N
     h12 h13 h23 hz1 hz2 hz3]
   ring
-
-/-- Dressed Heisenberg `Matrix` vanishes on three-site differences. -/
-theorem dressedHeisenbergSMatrix_apply_eq_zero_of_three_diff
-    (A : V → Bool) (J : V → V → ℂ) (N : ℕ)
-    {σ' σ : V → Fin (N + 1)}
-    {z₁ z₂ z₃ : V}
-    (h12 : z₁ ≠ z₂) (h13 : z₁ ≠ z₃) (h23 : z₂ ≠ z₃)
-    (hz1 : σ' z₁ ≠ σ z₁) (hz2 : σ' z₂ ≠ σ z₂) (hz3 : σ' z₃ ≠ σ z₃) :
-    dressedHeisenbergSMatrix A J N σ' σ = 0 :=
-  dressedHeisenbergS_apply_eq_zero_of_three_diff A J N h12 h13 h23 hz1 hz2 hz3
-
-/-- Real-part dressed Heisenberg matrix vanishes on three-site differences. -/
-theorem dressedHeisenbergSReMatrix_apply_eq_zero_of_three_diff
-    (A : V → Bool) (J : V → V → ℂ) (N : ℕ)
-    {σ' σ : V → Fin (N + 1)}
-    {z₁ z₂ z₃ : V}
-    (h12 : z₁ ≠ z₂) (h13 : z₁ ≠ z₃) (h23 : z₂ ≠ z₃)
-    (hz1 : σ' z₁ ≠ σ z₁) (hz2 : σ' z₂ ≠ σ z₂) (hz3 : σ' z₃ ≠ σ z₃) :
-    dressedHeisenbergSReMatrix A J N σ' σ = 0 := by
-  rw [dressedHeisenbergSReMatrix_apply,
-    dressedHeisenbergS_apply_eq_zero_of_three_diff A J N
-      h12 h13 h23 hz1 hz2 hz3]
-  simp
 
 /-- Symmetric: bipartite case `x ∉ A, y ∈ A`, raising at `x`. -/
 theorem marshallSignS_mul_spinSDot_apply_re_nonpos_bipartite_y
@@ -203,27 +160,6 @@ theorem marshallSignS_mul_spinSDot_apply_re_nonpos_bipartite_y_lowering
   rw [neg_nonpos]
   exact spinSDot_apply_re_nonneg_of_raising_lowering_y hxy N h hx
 
-/-- The real-part dressed Heisenberg matrix is additive in the
-coupling. -/
-theorem dressedHeisenbergSReMatrix_add_J
-    (A : V → Bool) (J J' : V → V → ℂ) (N : ℕ)
-    (σ σ' : V → Fin (N + 1)) :
-    dressedHeisenbergSReMatrix A (fun x y => J x y + J' x y) N σ σ' =
-      dressedHeisenbergSReMatrix A J N σ σ' +
-        dressedHeisenbergSReMatrix A J' N σ σ' := by
-  rw [dressedHeisenbergSReMatrix_apply, dressedHeisenbergS_add_J]
-  simp [dressedHeisenbergSReMatrix_apply]
-
-/-- The real-part dressed Heisenberg matrix negates with the
-coupling. -/
-theorem dressedHeisenbergSReMatrix_neg_J
-    (A : V → Bool) (J : V → V → ℂ) (N : ℕ)
-    (σ σ' : V → Fin (N + 1)) :
-    dressedHeisenbergSReMatrix A (fun x y => -(J x y)) N σ σ' =
-      -(dressedHeisenbergSReMatrix A J N σ σ') := by
-  rw [dressedHeisenbergSReMatrix_apply, dressedHeisenbergS_neg_J]
-  simp [dressedHeisenbergSReMatrix_apply]
-
 /-- For real coupling, the real-part dressed Heisenberg matrix is
 Hermitian (which for a real-valued matrix is equivalent to
 symmetry). -/
@@ -246,24 +182,6 @@ theorem dressedHeisenbergSReMatrix_couplingOf_isHermitian
   dressedHeisenbergSReMatrix_isHermitian A N
     (LatticeSystem.Lattice.couplingOf_real G hJ)
 
-/-- Real-part dressed Heisenberg matrix on the open chain — Hermiticity. -/
-theorem dressedHeisenbergSReMatrix_chain_isHermitian
-    (M : ℕ) (A : Fin (M + 1) → Bool) (J : ℝ) (N : ℕ) :
-    (dressedHeisenbergSReMatrix A
-        (LatticeSystem.Lattice.couplingOf
-          (SimpleGraph.pathGraph (M + 1)) (-(J : ℂ))) N).IsHermitian :=
-  dressedHeisenbergSReMatrix_couplingOf_isHermitian A _
-    (by simp : star (-(J : ℂ)) = -(J : ℂ)) N
-
-/-- Real-part dressed Heisenberg matrix on the periodic chain — Hermiticity. -/
-theorem dressedHeisenbergSReMatrix_periodicChain_isHermitian
-    (M : ℕ) (A : Fin (M + 2) → Bool) (J : ℝ) (N : ℕ) :
-    (dressedHeisenbergSReMatrix A
-        (LatticeSystem.Lattice.couplingOf
-          (SimpleGraph.cycleGraph (M + 2)) (-(J : ℂ))) N).IsHermitian :=
-  dressedHeisenbergSReMatrix_couplingOf_isHermitian A _
-    (by simp : star (-(J : ℂ)) = -(J : ℂ)) N
-
 /-- The complex dressed matrix entry equals the real-embedded
 real-part: `dressed σ' σ = ((dressedRe σ' σ : ℝ) : ℂ)` for coupling
 with real entries. -/
@@ -278,15 +196,5 @@ theorem dressedHeisenbergSMatrix_apply_eq_ofReal_re
   · rfl
   · rw [Complex.ofReal_im]
     exact dressedHeisenbergS_apply_im_zero A N hreal σ' σ
-
-/-- Matrix-level equality: the complex dressed matrix equals the
-ℂ-embedding of the real-valued dressed matrix entry-wise. -/
-theorem dressedHeisenbergSMatrix_eq_dressedHeisenbergSReMatrix_complex
-    (A : V → Bool) {J : V → V → ℂ} (N : ℕ)
-    (hreal : ∀ x y, (J x y).im = 0) :
-    dressedHeisenbergSMatrix A J N =
-      (dressedHeisenbergSReMatrix A J N).map (fun r : ℝ => (r : ℂ)) := by
-  ext σ' σ
-  rw [Matrix.map_apply, dressedHeisenbergSMatrix_apply_eq_ofReal_re A N hreal]
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/MultiSiteMatrixElement.lean
+++ b/LatticeSystem/Quantum/SpinS/MultiSiteMatrixElement.lean
@@ -43,45 +43,6 @@ theorem onSiteS_spinSOp3_mul_onSiteS_spinSOp3_im_zero
     ring
   · rw [if_neg h]; simp
 
-/-- For distinct sites `x ≠ y`, the product `onSiteS x (S^3) * onSiteS y (S^3)`
-preserves real entries. -/
-theorem onSiteS_spinSOp3_mul_onSiteS_spinSOp3_eq_ofReal_re
-    {x y : Λ} (hxy : x ≠ y) (σ' σ : Λ → Fin (N + 1)) :
-    (onSiteS x (spinSOp3 N) * onSiteS y (spinSOp3 N)
-          : ManyBodyOpS Λ N) σ' σ =
-      ((((onSiteS x (spinSOp3 N) * onSiteS y (spinSOp3 N)
-          : ManyBodyOpS Λ N) σ' σ).re : ℝ) : ℂ) := by
-  apply Complex.ext
-  · simp
-  · rw [Complex.ofReal_im]
-    exact onSiteS_spinSOp3_mul_onSiteS_spinSOp3_im_zero hxy σ' σ
-
-/-- For distinct sites `x ≠ y`, the product `S+_x ⊗ S-_y` matrix
-element equals its real-part embedding. -/
-theorem onSiteS_spinSOpPlus_mul_onSiteS_spinSOpMinus_eq_ofReal_re
-    {x y : Λ} (hxy : x ≠ y) (σ' σ : Λ → Fin (N + 1)) :
-    (onSiteS x (spinSOpPlus N) * onSiteS y (spinSOpMinus N)
-          : ManyBodyOpS Λ N) σ' σ =
-      ((((onSiteS x (spinSOpPlus N) * onSiteS y (spinSOpMinus N)
-          : ManyBodyOpS Λ N) σ' σ).re : ℝ) : ℂ) := by
-  apply Complex.ext
-  · simp
-  · rw [Complex.ofReal_im]
-    exact onSiteS_spinSOpPlus_mul_onSiteS_spinSOpMinus_im_zero hxy σ' σ
-
-/-- For distinct sites `x ≠ y`, the product `S-_x ⊗ S+_y` matrix
-element equals its real-part embedding. -/
-theorem onSiteS_spinSOpMinus_mul_onSiteS_spinSOpPlus_eq_ofReal_re
-    {x y : Λ} (hxy : x ≠ y) (σ' σ : Λ → Fin (N + 1)) :
-    (onSiteS x (spinSOpMinus N) * onSiteS y (spinSOpPlus N)
-          : ManyBodyOpS Λ N) σ' σ =
-      ((((onSiteS x (spinSOpMinus N) * onSiteS y (spinSOpPlus N)
-          : ManyBodyOpS Λ N) σ' σ).re : ℝ) : ℂ) := by
-  apply Complex.ext
-  · simp
-  · rw [Complex.ofReal_im]
-    exact onSiteS_spinSOpMinus_mul_onSiteS_spinSOpPlus_im_zero hxy σ' σ
-
 /-- For distinct sites `x ≠ y`, when configurations agree at every
 site other than `x` and `y`, the matrix element of `S^3_x S^3_y`
 factors into the per-site `S^3` entries. -/
@@ -120,14 +81,6 @@ theorem onSiteS_spinSOpPlus_mul_onSiteS_spinSOpMinus_apply_eq_zero_of_off_two_si
           : ManyBodyOpS Λ N) σ' σ = 0 := by
   rw [onSiteS_mul_onSiteS_apply_eq hxy, if_neg h]
 
-/-- Same for `S-_x ⊗ S+_y`. -/
-theorem onSiteS_spinSOpMinus_mul_onSiteS_spinSOpPlus_apply_eq_zero_of_off_two_site_diff
-    {x y : Λ} (hxy : x ≠ y) {σ' σ : Λ → Fin (N + 1)}
-    (h : ¬ ∀ k, k ≠ x → k ≠ y → σ' k = σ k) :
-    (onSiteS x (spinSOpMinus N) * onSiteS y (spinSOpPlus N)
-          : ManyBodyOpS Λ N) σ' σ = 0 := by
-  rw [onSiteS_mul_onSiteS_apply_eq hxy, if_neg h]
-
 /-- Vanishing with witness difference site: if `z ∉ {x, y}` and
 `σ' z ≠ σ z`, the product `onSiteS x A * onSiteS y B` vanishes at
 `(σ', σ)`. -/
@@ -142,46 +95,7 @@ theorem onSiteS_mul_onSiteS_apply_eq_zero_of_diff_outside_pair
   intro hagree
   exact hz (hagree z hzx hzy)
 
-/-- Same for `S^3_x ⊗ S^3_y`. -/
-theorem onSiteS_spinSOp3_mul_onSiteS_spinSOp3_apply_eq_zero_of_diff_outside_pair
-    {x y : Λ} (hxy : x ≠ y)
-    {σ' σ : Λ → Fin (N + 1)}
-    {z : Λ} (hzx : z ≠ x) (hzy : z ≠ y) (hz : σ' z ≠ σ z) :
-    (onSiteS x (spinSOp3 N) * onSiteS y (spinSOp3 N)
-          : ManyBodyOpS Λ N) σ' σ = 0 :=
-  onSiteS_mul_onSiteS_apply_eq_zero_of_diff_outside_pair hxy _ _ hzx hzy hz
-
-/-- Same for `S+_x ⊗ S-_y`. -/
-theorem onSiteS_spinSOpPlus_mul_onSiteS_spinSOpMinus_apply_eq_zero_of_diff_outside_pair
-    {x y : Λ} (hxy : x ≠ y)
-    {σ' σ : Λ → Fin (N + 1)}
-    {z : Λ} (hzx : z ≠ x) (hzy : z ≠ y) (hz : σ' z ≠ σ z) :
-    (onSiteS x (spinSOpPlus N) * onSiteS y (spinSOpMinus N)
-          : ManyBodyOpS Λ N) σ' σ = 0 :=
-  onSiteS_mul_onSiteS_apply_eq_zero_of_diff_outside_pair hxy _ _ hzx hzy hz
-
-/-- Same for `S-_x ⊗ S+_y`. -/
-theorem onSiteS_spinSOpMinus_mul_onSiteS_spinSOpPlus_apply_eq_zero_of_diff_outside_pair
-    {x y : Λ} (hxy : x ≠ y)
-    {σ' σ : Λ → Fin (N + 1)}
-    {z : Λ} (hzx : z ≠ x) (hzy : z ≠ y) (hz : σ' z ≠ σ z) :
-    (onSiteS x (spinSOpMinus N) * onSiteS y (spinSOpPlus N)
-          : ManyBodyOpS Λ N) σ' σ = 0 :=
-  onSiteS_mul_onSiteS_apply_eq_zero_of_diff_outside_pair hxy _ _ hzx hzy hz
-
 /-! ## `(S^3 ⊗ S^3)` matrix element formulas -/
-
-/-- For `x ≠ y`, when `σ' = σ`, the `S^3_x ⊗ S^3_y` matrix element
-factors into the per-site `S^3` diagonal entries:
-`(N/2 - σ_x.val) * (N/2 - σ_y.val)`. -/
-theorem onSiteS_spinSOp3_mul_onSiteS_spinSOp3_apply_diag
-    {x y : Λ} (hxy : x ≠ y) (σ : Λ → Fin (N + 1)) :
-    (onSiteS x (spinSOp3 N) * onSiteS y (spinSOp3 N)
-          : ManyBodyOpS Λ N) σ σ =
-      ((N : ℂ) / 2 - (σ x).val) * ((N : ℂ) / 2 - (σ y).val) := by
-  rw [onSiteS_spinSOp3_mul_onSiteS_spinSOp3_apply_of_off_two_site_agree hxy
-    (fun _ _ _ => rfl)]
-  rw [spinSOp3_apply_diag, spinSOp3_apply_diag]
 
 /-- For `x ≠ y` and `σ' σ` agreeing off `{x, y}` with `σ' x ≠ σ x`,
 the `S^3_x ⊗ S^3_y` matrix element vanishes (`S^3` is diagonal). -/


### PR DESCRIPTION
## Summary

PR5 (cluster3) of #4930 refactor sweep.

**Removes 17 zero-reference decorative lemmas:**

- `LatticeSystem/Quantum/SpinS/DressedHeisenbergMarshallCore.lean`: **9 decls**
  - `dressedHeisenbergS_*` Matrix/ReMatrix doubled and mirror variants (zero external reference)

- `LatticeSystem/Quantum/SpinS/MultiSiteMatrixElement.lean`: **8 decls**
  - `onSiteS_*` family declarations (file survives, but individual decls are dead code)

**Vetted decl list:** `.self-local/reports/research-v1-cluster3.md`

**Preservation notes:**
- `SublatticeSpin*` / `SpinHalfRotation*` / `HeisenbergLattice companions` retained (fully documented via group-notation shorthands in docs/index.md; avoids cluster2 pitfall)

**Issue:** #4930

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
