### PR TITLE
Tasaki §4.2.2 Theorem 4.8 crux PR-C: [N2] telescoping (eq 4.2.71) + charge 3-piece decomposition — #4958

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -123,6 +123,7 @@ import LatticeSystem.Quantum.SpinS.AndersonTowerNumerator
 import LatticeSystem.Quantum.SpinS.AndersonTowerTheorem46
 import LatticeSystem.Quantum.SpinS.AndersonTowerOrderSumExpansion
 import LatticeSystem.Quantum.SpinS.AndersonTowerTanakaDenominator
+import LatticeSystem.Quantum.SpinS.AndersonTowerTanakaNumeratorCore
 import LatticeSystem.Quantum.SpinS.AndersonTowerEigenstates
 import LatticeSystem.Quantum.SpinS.QuasiLocalSupport
 import LatticeSystem.Quantum.SpinS.QuasiLocalInductiveLimit

--- a/LatticeSystem/Math/CommutatorTelescope.lean
+++ b/LatticeSystem/Math/CommutatorTelescope.lean
@@ -1,0 +1,104 @@
+/-
+Generic commutator power-telescoping identities in an associative (noncommutative) ring.
+
+For a ring `R` and `H, A : R`, the single commutator of a power expands as a telescoping sum
+`[H, Aᴹ] = Σ_{j<M} Aʲ [H, A] A^{M-1-j}` (`commutator_pow_eq_sum`), and its mirror
+`[Aᴹ, X] = Σ_{j<M} Aʲ [A, X] A^{M-1-j}` (`commutator_pow_eq_sum'`).  Applying these twice yields the
+**double** telescoping identity `[Aᴹ, [H, Aᴹ]] = Σ_{j,l<M} A^{j+l} [A, [H, A]] A^{2(M-1)-j-l}`
+(`double_commutator_pow_eq_double_sum`): the `M²` insertion positions of the single physical double
+commutator `d̃ = [A, [H, A]]` between powers of `A`.
+
+This is the generic algebra behind Tasaki's Anderson-tower numerator identity (eq. (4.2.71) in Hal
+Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*, 1st ed., Springer 2020, §4.2.2,
+p. 112), pulled out here as a source-agnostic ring lemma.
+-/
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Ring.Basic
+import Mathlib.Tactic.NoncommRing
+
+namespace LatticeSystem
+
+/-- **Commutator power telescope** `[H, Aᴹ] = Σ_{j<M} Aʲ [H, A] A^{M-1-j}` in any ring. -/
+theorem commutator_pow_eq_sum {R : Type*} [Ring R] (H A : R) (M : ℕ) :
+    H * A ^ M - A ^ M * H
+      = ∑ j ∈ Finset.range M, A ^ j * (H * A - A * H) * A ^ (M - 1 - j) := by
+  induction M with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_range_succ]
+    have hsplit : H * A ^ (m + 1) - A ^ (m + 1) * H
+        = (H * A ^ m - A ^ m * H) * A + A ^ m * (H * A - A * H) := by
+      rw [pow_succ]; noncomm_ring
+    rw [hsplit, ih, Finset.sum_mul,
+      show A ^ (m + 1 - 1 - m) = (1 : R) by simp, mul_one]
+    congr 1
+    refine Finset.sum_congr rfl fun j hj => ?_
+    rw [Finset.mem_range] at hj
+    rw [mul_assoc, ← pow_succ]
+    congr 2
+    omega
+
+/-- **Mirror commutator power telescope** `[Aᴹ, X] = Σ_{j<M} Aʲ [A, X] A^{M-1-j}` in any ring (the
+outer power on the left, needed for the second telescoping in the double commutator). -/
+theorem commutator_pow_eq_sum' {R : Type*} [Ring R] (X A : R) (M : ℕ) :
+    A ^ M * X - X * A ^ M
+      = ∑ j ∈ Finset.range M, A ^ j * (A * X - X * A) * A ^ (M - 1 - j) := by
+  induction M with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_range_succ]
+    have hsplit : A ^ (m + 1) * X - X * A ^ (m + 1)
+        = (A ^ m * X - X * A ^ m) * A + A ^ m * (A * X - X * A) := by
+      rw [pow_succ]; noncomm_ring
+    rw [hsplit, ih, Finset.sum_mul,
+      show A ^ (m + 1 - 1 - m) = (1 : R) by simp, mul_one]
+    congr 1
+    refine Finset.sum_congr rfl fun j hj => ?_
+    rw [Finset.mem_range] at hj
+    rw [mul_assoc, ← pow_succ]
+    congr 2
+    omega
+
+/-- **Bracketed commutator power telescope** `[A, [H, Aᴹ]] = Σ_{j<M} Aʲ d̃ A^{M-1-j}` with the
+single physical double commutator `d̃ = [A, [H, A]] = A (H A − A H) − (H A − A H) A`.  Obtained
+from `commutator_pow_eq_sum` by distributing the outer `[A, ·]` across the telescoping sum. -/
+theorem commutator_pow_bracket_eq_sum {R : Type*} [Ring R] (H A : R) (M : ℕ) :
+    A * (H * A ^ M - A ^ M * H) - (H * A ^ M - A ^ M * H) * A
+      = ∑ j ∈ Finset.range M,
+          A ^ j * (A * (H * A - A * H) - (H * A - A * H) * A) * A ^ (M - 1 - j) := by
+  rw [commutator_pow_eq_sum H A M, Finset.mul_sum, Finset.sum_mul, ← Finset.sum_sub_distrib]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  have hL : A * A ^ j = A ^ j * A := ((Commute.refl A).pow_right j).eq
+  have hR : A ^ (M - 1 - j) * A = A * A ^ (M - 1 - j) :=
+    (((Commute.refl A).pow_right (M - 1 - j)).eq).symm
+  rw [show A * (A ^ j * (H * A - A * H) * A ^ (M - 1 - j))
+        = A * A ^ j * (H * A - A * H) * A ^ (M - 1 - j) from by noncomm_ring, hL,
+    show A ^ j * (H * A - A * H) * A ^ (M - 1 - j) * A
+        = A ^ j * (H * A - A * H) * (A ^ (M - 1 - j) * A) from by noncomm_ring, hR]
+  noncomm_ring
+
+/-- **Double commutator power telescope** (Tasaki eq. (4.2.71)): the double commutator of a power
+`[Aᴹ, [H, Aᴹ]]` is the `M²`-fold sum, over insertion positions `j, l < M`, of the single physical
+double commutator `d̃ = [A, [H, A]]` sandwiched between powers of `A`,
+`[Aᴹ, [H, Aᴹ]] = Σ_{j,l<M} A^{j+l} d̃ A^{2(M-1)-j-l}`.  Proved by telescoping the outer power with
+`commutator_pow_eq_sum'` and each resulting inner bracket with `commutator_pow_bracket_eq_sum`. -/
+theorem double_commutator_pow_eq_double_sum {R : Type*} [Ring R] (A H : R) (M : ℕ) :
+    A ^ M * (H * A ^ M - A ^ M * H) - (H * A ^ M - A ^ M * H) * A ^ M
+      = ∑ j ∈ Finset.range M, ∑ l ∈ Finset.range M,
+          A ^ (j + l) * (A * (H * A - A * H) - (H * A - A * H) * A)
+            * A ^ (2 * (M - 1) - j - l) := by
+  rw [commutator_pow_eq_sum' (H * A ^ M - A ^ M * H) A M]
+  refine Finset.sum_congr rfl fun j hj => ?_
+  rw [Finset.mem_range] at hj
+  rw [commutator_pow_bracket_eq_sum H A M, Finset.mul_sum, Finset.sum_mul]
+  refine Finset.sum_congr rfl fun l hl => ?_
+  rw [Finset.mem_range] at hl
+  rw [show A ^ j
+        * (A ^ l * (A * (H * A - A * H) - (H * A - A * H) * A) * A ^ (M - 1 - l))
+        * A ^ (M - 1 - j)
+        = (A ^ j * A ^ l) * (A * (H * A - A * H) - (H * A - A * H) * A)
+          * (A ^ (M - 1 - l) * A ^ (M - 1 - j)) from by noncomm_ring,
+    ← pow_add, ← pow_add,
+    show (M - 1 - l) + (M - 1 - j) = 2 * (M - 1) - j - l from by omega]
+
+end LatticeSystem

--- a/LatticeSystem/Quantum/SpinS/AndersonTowerAssembly.lean
+++ b/LatticeSystem/Quantum/SpinS/AndersonTowerAssembly.lean
@@ -139,28 +139,6 @@ theorem tower_numerator_double_commutator_le (d L N : ℕ) [NeZero L]
 
 /-! ### Numerator expansion (P9-7) -/
 
-/-- **Commutator power telescope**: `[H, Aᴹ] = Σ_{j<M} Aʲ [H,A] A^{M-1-j}`. -/
-theorem commutator_pow_eq_sum {n : Type*} [Fintype n] [DecidableEq n]
-    (H A : Matrix n n ℂ) (M : ℕ) :
-    H * A ^ M - A ^ M * H
-      = ∑ j ∈ Finset.range M, A ^ j * (H * A - A * H) * A ^ (M - 1 - j) := by
-  induction M with
-  | zero => simp
-  | succ m ih =>
-    rw [Finset.sum_range_succ]
-    have hsplit : H * A ^ (m + 1) - A ^ (m + 1) * H
-        = (H * A ^ m - A ^ m * H) * A + A ^ m * (H * A - A * H) := by
-      rw [pow_succ]; noncomm_ring
-    rw [hsplit, ih, Finset.sum_mul]
-    rw [show A ^ (m + 1 - 1 - m) = (1 : Matrix n n ℂ) by simp]
-    rw [mul_one]
-    congr 1
-    refine Finset.sum_congr rfl (fun j hj => ?_)
-    rw [Finset.mem_range] at hj
-    rw [mul_assoc, ← pow_succ]
-    congr 2
-    omega
-
 /-- The `false`-outer double commutator `[ô⁻,[Ĥ,ô⁺]]` is the conjugate transpose of the `true`-outer
 one, hence carries the same `g₀/V` bound: `‖[ô⁻,[Ĥ,ô⁺]]‖ ≤ 96 d N⁴ / V`. -/
 theorem orderDensity_double_commutator_false_norm_le (d L N : ℕ) [NeZero L] (hL : 2 ≤ L)

--- a/LatticeSystem/Quantum/SpinS/AndersonTowerNumerator.lean
+++ b/LatticeSystem/Quantum/SpinS/AndersonTowerNumerator.lean
@@ -8,6 +8,7 @@ the `[ô⁺, ô⁻]` terms (second/third sums, `O(M⁴/V²)`).
 -/
 import LatticeSystem.Quantum.SpinS.AndersonTowerLocalDecay
 import LatticeSystem.Quantum.SpinS.AndersonTowerAssembly
+import LatticeSystem.Math.CommutatorTelescope
 
 namespace LatticeSystem.Quantum
 

--- a/LatticeSystem/Quantum/SpinS/AndersonTowerOrderSumExpansion.lean
+++ b/LatticeSystem/Quantum/SpinS/AndersonTowerOrderSumExpansion.lean
@@ -107,7 +107,7 @@ theorem tanakaTowerTerm_expectationRatioRe_eq (d L N k : ℕ) [NeZero L]
 charges `a` and `b` (`[A, X] = a X`, `[A, Y] = b Y`), then it commutes with the product `X Y` up to
 the summed charge, `[A, X Y] = (a + b) (X Y)`.  This is the derivation identity for the commutator
 `[A, ·]`. -/
-private theorem commutator_smul_of_smul {n : Type*} [Fintype n]
+theorem commutator_smul_of_smul {n : Type*} [Fintype n]
     {A X Y : Matrix n n ℂ} {a b : ℂ} (hX : A * X - X * A = a • X) (hY : A * Y - Y * A = b • Y) :
     A * (X * Y) - (X * Y) * A = (a + b) • (X * Y) := by
   have hderiv : A * (X * Y) - (X * Y) * A = (A * X - X * A) * Y + X * (A * Y - Y * A) := by

--- a/LatticeSystem/Quantum/SpinS/AndersonTowerSameSignDecay.lean
+++ b/LatticeSystem/Quantum/SpinS/AndersonTowerSameSignDecay.lean
@@ -222,4 +222,48 @@ theorem orderDoubleCommSameSignAggregate_le [NeZero L] (hL : 2 ≤ L) (hN : 1 �
   field_simp
   ring
 
+/-! ### The charge-neutral mirror double commutator `[ô⁻, [Ĥ, ô⁺]]` in the local-decay class -/
+
+/-- The per-volume **mirror** double commutator `d̂' = [ô⁻, [Ĥ, ô⁺]]`, the missing charge-neutral
+partner of the Theorem 4.6 mixed-sign piece `orderDoubleComm = [ô⁺, [Ĥ, ô⁻]]`.  Together they form
+the charge-`0` block `G₀` of the `1`-axis double commutator `d̃ = [ô^{(1)}, [Ĥ, ô^{(1)}]]`. -/
+noncomputable def orderDoubleCommMirror (d L N : ℕ) [NeZero L] :
+    ManyBodyOpS (HypercubicTorus d L) N :=
+  staggeredOrderDensityOpS d L N false * heisenbergSignComm d L N true
+    - heisenbergSignComm d L N true * staggeredOrderDensityOpS d L N false
+
+/-- The ℓ¹-aggregate for the mirror double commutator: one extra `orderComm` decay factor
+`2ζo₀/V = 2·2·N/V` times the single raising-commutator aggregate (mirror of
+`orderDoubleCommSameSignAggregate`). -/
+noncomputable def orderDoubleCommMirrorAggregate (d L N : ℕ) [NeZero L] : ℝ :=
+  (2 * 2 * (N : ℝ)) / (L : ℝ) ^ d * heisenbergSignCommAggregate d L N true
+
+/-- **The mirror double commutator lies in the local-decay class** (`ζ = 2`, `o₀ = N`, `g₀` its
+aggregate).  Obtained from `[Ĥ, ô⁺] ∈` class (at depth `K + 1`) by the recursion
+`IsR2LocalUpTo.orderComm_mem` with a lowering `orderComm false` step. -/
+theorem isR2LocalUpTo_orderDoubleCommMirror [NeZero L] (hL : 2 ≤ L) (hN : 1 ≤ N) (K : ℕ) :
+    IsR2LocalUpTo K 2 (N : ℝ) (orderDoubleCommMirrorAggregate d L N)
+      (orderDoubleCommMirror d L N) := by
+  have hVpos : (0 : ℝ) < (L : ℝ) ^ d := by
+    have : (0 : ℝ) < (L : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne L)
+    positivity
+  have hdecay : (0 : ℝ) ≤ (2 * 2 * (N : ℝ)) / (L : ℝ) ^ d := by positivity
+  exact (isR2LocalUpTo_heisenbergSignComm hL hN true (K + 1)).orderComm_mem false hdecay
+
+/-- **The mirror double-commutator aggregate is `≤ 96 d N⁴ / V`** — the same `O(1/V)` bound as the
+mixed-sign and same-sign pieces. -/
+theorem orderDoubleCommMirrorAggregate_le [NeZero L] (hL : 2 ≤ L) (hN : 1 ≤ N) :
+    orderDoubleCommMirrorAggregate d L N ≤ 96 * (d : ℝ) * (N : ℝ) ^ 4 / (L : ℝ) ^ d := by
+  have hVpos : (0 : ℝ) < (L : ℝ) ^ d := by
+    have : (0 : ℝ) < (L : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne L)
+    positivity
+  have hsingle := heisenbergSignCommAggregate_le (d := d) hL hN true
+  rw [orderDoubleCommMirrorAggregate]
+  have hkey : (2 * 2 * (N : ℝ)) / (L : ℝ) ^ d * heisenbergSignCommAggregate d L N true
+      ≤ (2 * 2 * (N : ℝ)) / (L : ℝ) ^ d * (24 * (d : ℝ) * (N : ℝ) ^ 3) :=
+    mul_le_mul_of_nonneg_left hsingle (by positivity)
+  refine hkey.trans (le_of_eq ?_)
+  field_simp
+  ring
+
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/AndersonTowerTanakaNumeratorCore.lean
+++ b/LatticeSystem/Quantum/SpinS/AndersonTowerTanakaNumeratorCore.lean
@@ -1,0 +1,142 @@
+/-
+Tasaki §4.2.2 Theorem 4.8 (Tanaka symmetry-breaking state), crux sub-arc PR-C — the charge
+`{−2, 0, +2}` decomposition of the `1`-axis double commutator.
+
+The Anderson-tower numerator inserts, at each of the `M²` telescoping positions
+(`double_commutator_pow_eq_double_sum`, eq. (4.2.71)), the single physical double commutator
+`d̃ = [ô^{(1)}, [Ĥ, ô^{(1)}]]` of the `1`-axis order density `ô^{(1)} = ô⁺ + ô⁻` (working with the
+scale-invariant summed density `Ã = ô⁺ + ô⁻`, the volume factor already dropped in PR-A).  Because
+`Ã = ô⁺ + ô⁻` mixes the two magnetization charges, `d̃` is *not* charge homogeneous; it splits into
+four physical pieces, grouped by net `Ŝ_tot^{(3)}`-charge into three blocks (eq. (4.2.67)):
+
+* charge `+2`: `G₊ = [ô⁺, [Ĥ, ô⁺]]` (`orderDoubleCommSameSign true`);
+* charge `−2`: `G₋ = [ô⁻, [Ĥ, ô⁻]]` (`orderDoubleCommSameSign false`);
+* charge `0`:  `G₀ = [ô⁺, [Ĥ, ô⁻]] + [ô⁻, [Ĥ, ô⁺]]` (`orderDoubleComm + orderDoubleCommMirror`).
+
+Each piece is charge homogeneous, so the crux (PR-D) can apply the cross-charge selection rule
+(`dotProduct_word_sandwich_eq_zero_of_charge_ne`) block by block and count the surviving words with
+a central binomial coefficient.  Every piece already lies in the local-decay class (its
+`IsR2LocalUpTo` membership was built in PR2/PR-B: `isR2LocalUpTo_orderDoubleCommSameSign`,
+`isR2LocalUpTo_orderDoubleComm`, `isR2LocalUpTo_orderDoubleCommMirror`), so PR-D reuses the
+word-generic leaf bound verbatim.
+
+This file provides only the charge decomposition and its per-piece charge homogeneity; it touches
+none of the crux core (the `Nat.choose` counting / Pascal ratio, deferred to PR-D).
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems* (1st ed., Springer,
+2020), §4.2.2, eqs. (4.2.67)/(4.2.71), pp. 111–112 (Tanaka [62]).
+-/
+import LatticeSystem.Quantum.SpinS.AndersonTowerSameSignDecay
+import LatticeSystem.Quantum.SpinS.AndersonTowerOrderSumExpansion
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {d L N : ℕ}
+
+/-! ### Charge homogeneity of a commutator bracket -/
+
+/-- **Charge homogeneity of a bracket.**  If a charge operator `S` commutes with `X` and `Y` up to
+the scalar charges `a` and `b` (`[S, X] = a X`, `[S, Y] = b Y`), then it commutes with the bracket
+`X Y − Y X` up to the summed charge, `[S, X Y − Y X] = (a + b)(X Y − Y X)`.  Applies
+`commutator_smul_of_smul` to each of the two products. -/
+private theorem commutator_bracket_smul {n : Type*} [Fintype n]
+    {S X Y : Matrix n n ℂ} {a b : ℂ} (hX : S * X - X * S = a • X) (hY : S * Y - Y * S = b • Y) :
+    S * (X * Y - Y * X) - (X * Y - Y * X) * S = (a + b) • (X * Y - Y * X) := by
+  have hXY := commutator_smul_of_smul hX hY
+  have hYX := commutator_smul_of_smul hY hX
+  rw [show S * (X * Y - Y * X) - (X * Y - Y * X) * S
+        = (S * (X * Y) - (X * Y) * S) - (S * (Y * X) - (Y * X) * S) from by noncomm_ring,
+    hXY, hYX, add_comm b a, smul_sub]
+
+/-- **Charge of the single Heisenberg–order commutator** `[Ŝ_tot^{(3)}, [Ĥ, ô^c]] = ε_c [Ĥ, ô^c]`
+(`ε_true = +1`, `ε_false = −1`): since `Ĥ` is charge neutral (`[Ŝ_tot^{(3)}, Ĥ] = 0`) and `ô^c`
+carries charge `ε_c`, the commutator `[Ĥ, ô^c]` inherits charge `ε_c`. -/
+theorem totalSpinSOp3_commutator_heisenbergSignComm (d L N : ℕ) [NeZero L] (c : Bool) :
+    totalSpinSOp3 (HypercubicTorus d L) N * heisenbergSignComm d L N c
+        - heisenbergSignComm d L N c * totalSpinSOp3 (HypercubicTorus d L) N
+      = (if c then (1 : ℂ) else (-1 : ℂ)) • heisenbergSignComm d L N c := by
+  have hH : totalSpinSOp3 (HypercubicTorus d L) N * heisenbergHamiltonianS (torusNNCoupling d L) N
+        - heisenbergHamiltonianS (torusNNCoupling d L) N * totalSpinSOp3 (HypercubicTorus d L) N
+      = (0 : ℂ) • heisenbergHamiltonianS (torusNNCoupling d L) N := by
+    have h := heisenbergHamiltonianS_commutator_totalSpinSOp3 (torusNNCoupling d L) N
+    rw [zero_smul, ← neg_sub, h, neg_zero]
+  have h := commutator_bracket_smul hH (totalSpinSOp3_commutator_orderDensity d L N c)
+  rw [zero_add] at h
+  exact h
+
+/-! ### The charge decomposition of `d̃ = [Ã, [Ĥ, Ã]]` -/
+
+/-- The **`1`-axis double commutator** `d̃ = [Ã, [Ĥ, Ã]]` of the scale-invariant summed order
+density `Ã = ô⁺ + ô⁻`, `d̃ = Ã (Ĥ Ã − Ã Ĥ) − (Ĥ Ã − Ã Ĥ) Ã`.  This is exactly the middle operator
+inserted at each telescoping position of `double_commutator_pow_eq_double_sum` (eq. (4.2.71)) with
+`A = Ã`, `H = Ĥ`. -/
+noncomputable def orderDensitySumDoubleComm (d L N : ℕ) [NeZero L] :
+    ManyBodyOpS (HypercubicTorus d L) N :=
+  (staggeredOrderDensityOpS d L N true + staggeredOrderDensityOpS d L N false)
+      * (heisenbergHamiltonianS (torusNNCoupling d L) N
+          * (staggeredOrderDensityOpS d L N true + staggeredOrderDensityOpS d L N false)
+        - (staggeredOrderDensityOpS d L N true + staggeredOrderDensityOpS d L N false)
+          * heisenbergHamiltonianS (torusNNCoupling d L) N)
+    - (heisenbergHamiltonianS (torusNNCoupling d L) N
+          * (staggeredOrderDensityOpS d L N true + staggeredOrderDensityOpS d L N false)
+        - (staggeredOrderDensityOpS d L N true + staggeredOrderDensityOpS d L N false)
+          * heisenbergHamiltonianS (torusNNCoupling d L) N)
+      * (staggeredOrderDensityOpS d L N true + staggeredOrderDensityOpS d L N false)
+
+/-- **Charge `{−2, 0, +2}` decomposition** (eq. (4.2.67)): the `1`-axis double commutator splits
+into its four physical pieces `d̃ = G₊ + [ô⁺, [Ĥ, ô⁻]] + [ô⁻, [Ĥ, ô⁺]] + G₋`, grouped by net charge
+into `G₊` (charge `+2`), `G₀ = orderDoubleComm + orderDoubleCommMirror` (charge `0`), and `G₋`
+(charge `−2`).  Proved by bilinear expansion of `Ã = ô⁺ + ô⁻`. -/
+theorem orderDensitySumDoubleComm_eq_charge_pieces (d L N : ℕ) [NeZero L] :
+    orderDensitySumDoubleComm d L N
+      = orderDoubleCommSameSign d L N true + orderDoubleComm d L N
+        + orderDoubleCommMirror d L N + orderDoubleCommSameSign d L N false := by
+  rw [orderDensitySumDoubleComm, orderDoubleCommSameSign, orderDoubleCommSameSign, orderDoubleComm,
+    orderDoubleCommMirror, heisenbergSignComm, heisenbergSignComm]
+  noncomm_ring
+
+/-! ### Per-piece charge homogeneity -/
+
+/-- **`G₊ = [ô⁺, [Ĥ, ô⁺]]` and `G₋ = [ô⁻, [Ĥ, ô⁻]]` are charge homogeneous**:
+`[Ŝ_tot^{(3)}, orderDoubleCommSameSign b] = (2 ε_b) orderDoubleCommSameSign b` (`+2` for `b = true`,
+`−2` for `b = false`).  Both `ô^b` and `[Ĥ, ô^b]` carry charge `ε_b`, so the bracket carries
+`2 ε_b`. -/
+theorem totalSpinSOp3_commutator_orderDoubleCommSameSign (d L N : ℕ) [NeZero L] (b : Bool) :
+    totalSpinSOp3 (HypercubicTorus d L) N * orderDoubleCommSameSign d L N b
+        - orderDoubleCommSameSign d L N b * totalSpinSOp3 (HypercubicTorus d L) N
+      = (if b then (2 : ℂ) else (-2 : ℂ)) • orderDoubleCommSameSign d L N b := by
+  have h := commutator_bracket_smul (totalSpinSOp3_commutator_orderDensity d L N b)
+    (totalSpinSOp3_commutator_heisenbergSignComm d L N b)
+  have hscalar : (if b then (2 : ℂ) else (-2 : ℂ))
+      = (if b then (1 : ℂ) else (-1 : ℂ)) + (if b then (1 : ℂ) else (-1 : ℂ)) := by
+    cases b <;> norm_num
+  rw [hscalar]
+  exact h
+
+/-- **`orderDoubleComm = [ô⁺, [Ĥ, ô⁻]]` is charge neutral**:
+`[Ŝ_tot^{(3)}, orderDoubleComm] = 0`.  Charge `ε_true + ε_false = 1 + (−1) = 0`. -/
+theorem totalSpinSOp3_commutator_orderDoubleComm (d L N : ℕ) [NeZero L] :
+    totalSpinSOp3 (HypercubicTorus d L) N * orderDoubleComm d L N
+        - orderDoubleComm d L N * totalSpinSOp3 (HypercubicTorus d L) N
+      = 0 := by
+  have h := commutator_bracket_smul (totalSpinSOp3_commutator_orderDensity d L N true)
+    (totalSpinSOp3_commutator_heisenbergSignComm d L N false)
+  rw [show ((if true then (1 : ℂ) else (-1 : ℂ)) + (if false then (1 : ℂ) else (-1 : ℂ)))
+      = 0 from by norm_num, zero_smul] at h
+  exact h
+
+/-- **`orderDoubleCommMirror = [ô⁻, [Ĥ, ô⁺]]` is charge neutral**:
+`[Ŝ_tot^{(3)}, orderDoubleCommMirror] = 0`.  Charge `ε_false + ε_true = (−1) + 1 = 0`. -/
+theorem totalSpinSOp3_commutator_orderDoubleCommMirror (d L N : ℕ) [NeZero L] :
+    totalSpinSOp3 (HypercubicTorus d L) N * orderDoubleCommMirror d L N
+        - orderDoubleCommMirror d L N * totalSpinSOp3 (HypercubicTorus d L) N
+      = 0 := by
+  have h := commutator_bracket_smul (totalSpinSOp3_commutator_orderDensity d L N false)
+    (totalSpinSOp3_commutator_heisenbergSignComm d L N true)
+  rw [show ((if false then (1 : ℂ) else (-1 : ℂ)) + (if true then (1 : ℂ) else (-1 : ℂ)))
+      = 0 from by norm_num, zero_smul] at h
+  exact h
+
+end LatticeSystem.Quantum

--- a/scripts/audit/capstones.txt
+++ b/scripts/audit/capstones.txt
@@ -81,3 +81,15 @@ dotProduct_orderWord_singlet_eq_zero_of_charge_ne
 dotProduct_word_sandwich_eq_zero_of_charge_ne
 # PR-B [N3] denominator lower bound tip (#4958); terminal until PR-E capstone consumes it, then delist.
 orderSum_pow_two_denom_lower
+
+# Tasaki §4.2.2 Theorem 4.8 crux sub-arc (#4958) PR-C: [N2] generic double-commutator power
+# telescope (eq. 4.2.71) + charge {-2,0,+2} decomposition of d̃ = [Ã,[Ĥ,Ã]] + per-piece Ŝ³-charge
+# homogeneity + mirror piece [ô⁻,[Ĥ,ô⁺]] local-decay membership. Terminal tips consumed by the
+# [N2] assembly (PR-D) / [N5] capstone (PR-E); temporarily allowlisted, to be delisted at PR-E.
+double_commutator_pow_eq_double_sum
+orderDensitySumDoubleComm_eq_charge_pieces
+totalSpinSOp3_commutator_orderDoubleCommSameSign
+totalSpinSOp3_commutator_orderDoubleComm
+totalSpinSOp3_commutator_orderDoubleCommMirror
+isR2LocalUpTo_orderDoubleCommMirror
+orderDoubleCommMirrorAggregate_le


### PR DESCRIPTION
## Tasaki §4.2.2 Theorem 4.8 crux PR-C: [N2] telescoping + charge 3-piece decomposition

Tracked under #4958 (Thm 4.8 crux sub-arc A–E) / #4769 / #4718. After PR-A #4962, PR-B #4963.

### 内容 (crux telescoping + charge 分解; 芯 [N2]-assembly は PR-D)
- **telescoping (generic)**: 新規 `Math/CommutatorTelescope.lean` — `double_commutator_pow_eq_double_sum` (`[Aᴹ,[H,Aᴹ]] = Σ_{j,l<M} A^{j+l} d̃ A^{2(M-1)-j-l}`, eq 4.2.71, generic Ring)。**既存の matrix 版 `commutator_pow_eq_sum`(Assembly/Numerator に重複)を generic Ring 化して移設・統合(dedup)**、Numerator は新 generic を import。
- **charge 3-片分解**: 新規 `AndersonTowerTanakaNumeratorCore.lean` — `orderDensitySumDoubleComm_eq_charge_pieces` (d̃ = G₊ + d̂ + mirror + G₋, eq 4.2.67)、各片の Ŝ³-charge homogeneity (±2/0/0)。
- **mirror d̂' `[ô⁻,[Ĥ,ô⁺]]`**: 既存に無 → `AndersonTowerSameSignDecay.lean` に小追加(既存 `orderComm_mem` 再利用の欠落半分; dup なし; `≤96dN⁴/V`)。
- `OrderSumExpansion` の private helper を非 private 化して import 再利用。

crux 芯(Pascal 比 `C(2M-2,M-1)/C(2M,M)` + `Nat.choose` 二重和カウント)は PR-D。build green (root 4285 jobs), warning ゼロ, `#print axioms`=標準3, axiom 4.8 据え置き, gate OK, 7 tip 一時 allowlist(PR-E delist), sorry/新 axiom/dup なし。

Refs #4958, #4769, #4718.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
