### PR TITLE
Tasaki §4.1 Thm 4.2 RP (PR7b-iii-b): two-field pairing Gram Cauchy–Schwarz — #4777

### DIFF
--- a/LatticeSystem/Quantum/SpinS/RingReflection.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflection.lean
@@ -52,3 +52,4 @@ import LatticeSystem.Quantum.SpinS.RingReflectionConcreteGibbs
 import LatticeSystem.Quantum.SpinS.RingReflectionFieldWeight
 import LatticeSystem.Quantum.SpinS.RingReflectionTwoFieldWeight
 import LatticeSystem.Quantum.SpinS.RingReflectionTwoFieldPairing
+import LatticeSystem.Quantum.SpinS.RingReflectionTwoFieldConeCauchySchwarz

--- a/LatticeSystem/Quantum/SpinS/RingReflectionTwoFieldConeCauchySchwarz.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflectionTwoFieldConeCauchySchwarz.lean
@@ -76,4 +76,33 @@ private theorem reflGram_cauchySchwarz {κ : Type} [Fintype κ] (v : κ → ℝ)
     (fun p : κ × Fin 2 => Real.sqrt (v p.1) * ![(Sa p.1).re, (Sa p.1).im] p.2)
     (fun p : κ × Fin 2 => Real.sqrt (v p.1) * ![(Sb p.1).re, (Sb p.1).im] p.2)
 
+/-- **Two-field pairing finite reflection Cauchy–Schwarz.**  For the doubled Dyson–Lieb–Simon
+approximant `U_{m}(x,y) = (g(x)·θ(g(y))·∑ᵢ wᵢ·(θ(Cᵢ)·Cᵢ))^m` — left-supported kinetic family `g`,
+nonnegative cone weights `wᵢ ≥ 0`, left-supported cone generators `Cᵢ` — the real part of the trace
+pairing obeys the finite Gram Cauchy–Schwarz bound
+
+    `(Re Tr U_{m}(x,y))² ≤ Re Tr U_{m}(x,x) · Re Tr U_{m}(y,y)`.
+
+Obtained by extracting the single crossing family `(κ, v, 𝓛)` of the two-field pairing trace
+identity (†) `twoField_product_pairing_trace` — whose diagonal instances `Tr U_{m}(x,x)`,
+`Tr U_{m}(y,y)` share that SAME family — and closing the resulting weighted ℓ² Gram bound with
+`reflGram_cauchySchwarz`.  This is the finite `(m,r)` inequality streamed to the `r→∞`, `m→∞` double
+limit in the next PR of the Theorem 4.2 arc. -/
+theorem twoField_product_pairing_cauchySchwarz (m : ℕ)
+    (g : (Fin (2 * n) → ℝ) → ManyBodyOpS (Fin (2 * n)) N)
+    (hg : ∀ x, SupportedOnLeftS n N (g x)) {ι : Type} [Fintype ι] (w : ι → ℝ)
+    (hw : ∀ i, 0 ≤ w i) (C : ι → ManyBodyOpS (Fin (2 * n)) N)
+    (hC : ∀ i, SupportedOnLeftS n N (C i)) (x y : Fin (2 * n) → ℝ) :
+    (((g x * ringReflectionThetaS n N (g y)
+        * ∑ i, (w i : ℂ) • (ringReflectionThetaS n N (C i) * C i)) ^ m).trace.re) ^ 2
+      ≤ ((g x * ringReflectionThetaS n N (g x)
+          * ∑ i, (w i : ℂ) • (ringReflectionThetaS n N (C i) * C i)) ^ m).trace.re
+        * ((g y * ringReflectionThetaS n N (g y)
+          * ∑ i, (w i : ℂ) • (ringReflectionThetaS n N (C i) * C i)) ^ m).trace.re := by
+  obtain ⟨κ, instκ, v, 𝓛, hv, hsupp, heq⟩ :=
+    twoField_product_pairing_trace m g hg w hw C hC
+  rw [heq x y, heq x x, heq y y]
+  exact reflGram_cauchySchwarz v hv (fun k => refLeftSum n N (𝓛 k x))
+    (fun k => refLeftSum n N (𝓛 k y))
+
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/RingReflectionTwoFieldConeCauchySchwarz.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflectionTwoFieldConeCauchySchwarz.lean
@@ -1,0 +1,79 @@
+/-
+The finite reflection Cauchy–Schwarz on the two-field pairing (†)
+(Tasaki §4.1 Theorem 4.2, reflection-positivity layer, p. 86).
+
+The two-field product pairing trace identity (†) of `RingReflectionTwoFieldPairing`,
+
+    `Tr(U_{m}(x,y)) = ∑ₖ vₖ · conj(refLeftSum 𝓛ₖ(y)) · refLeftSum 𝓛ₖ(x)`   (vₖ ≥ 0),
+
+exhibits the doubled Dyson–Lieb–Simon approximant `U_{m}(x,y) = (g(x)·θ(g(y))·∑ᵢ wᵢ·(θ(Cᵢ)·Cᵢ))^m`
+as a finite weighted ℓ² Gram form indexed by the crossing family `κ`, with the SAME family serving
+the diagonal instances `Tr(U_{m}(x,x))` and `Tr(U_{m}(y,y))`.  This file mounts the abstract finite
+Gram Cauchy–Schwarz on that form:
+
+    `(Re Tr U_{m}(x,y))² ≤ Re Tr U_{m}(x,x) · Re Tr U_{m}(y,y)`.
+
+The pure ingredient is the weighted complex Gram inequality `reflGram_cauchySchwarz`, proved by the
+ℂ→ℝ² √v-fold that reduces the weighted sum to mathlib's real Cauchy–Schwarz
+`Finset.sum_mul_sq_le_sq_mul_sq`.  The inequality is phrased at the finite `(m,r)` level so the next
+PR of the arc (the `r→∞`, `m→∞` double limit) streams it directly to the limit.
+-/
+import LatticeSystem.Quantum.SpinS.RingReflectionTwoFieldPairing
+import Mathlib.Algebra.Order.BigOperators.Ring.Finset
+import Mathlib.Data.Complex.BigOperators
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+
+variable {n N : ℕ}
+
+/-- **Weighted complex Gram Cauchy–Schwarz.**  For a nonnegative real weight `v ≥ 0` and two
+ℂ-valued families `Sa`, `Sb` indexed by a finite type `κ`, the real part of the weighted Gram
+pairing `∑ₖ vₖ·conj(Sb k)·Sa k` obeys the Cauchy–Schwarz bound against the two diagonal Gram sums:
+
+    `(Re ∑ₖ vₖ·conj(Sb k)·Sa k)² ≤ (Re ∑ₖ vₖ·conj(Sa k)·Sa k) · (Re ∑ₖ vₖ·conj(Sb k)·Sb k)`.
+
+Proved by the ℂ→ℝ² √v-fold: each complex weight `vₖ` is split as `√vₖ·√vₖ`, turning the weighted
+Gram sum over `κ` into the real inner product of the two `κ × Fin 2` sequences
+`(√vₖ·(Sa k).re, √vₖ·(Sa k).im)` and `(√vₖ·(Sb k).re, √vₖ·(Sb k).im)`, whereupon the classical real
+Cauchy–Schwarz `Finset.sum_mul_sq_le_sq_mul_sq` closes the bound.  The summand shape matches the
+two-field pairing trace identity (†) verbatim, so the assembled tip mounts on it directly. -/
+private theorem reflGram_cauchySchwarz {κ : Type} [Fintype κ] (v : κ → ℝ)
+    (hv : ∀ k, 0 ≤ v k) (Sa Sb : κ → ℂ) :
+    ((∑ k, (v k : ℂ) * (starRingEnd ℂ (Sb k) * Sa k)).re) ^ 2
+      ≤ (∑ k, (v k : ℂ) * (starRingEnd ℂ (Sa k) * Sa k)).re
+        * (∑ k, (v k : ℂ) * (starRingEnd ℂ (Sb k) * Sb k)).re := by
+  have key : ∀ (c : ℝ), 0 ≤ c → ∀ z w : ℂ,
+      ((c : ℂ) * (starRingEnd ℂ w * z)).re
+        = Real.sqrt c * z.re * (Real.sqrt c * w.re)
+          + Real.sqrt c * z.im * (Real.sqrt c * w.im) := by
+    intro c hc z w
+    have hs : Real.sqrt c * Real.sqrt c = c := Real.mul_self_sqrt hc
+    rw [Complex.re_ofReal_mul, Complex.mul_re, Complex.conj_re, Complex.conj_im]
+    linear_combination (-(z.re * w.re + z.im * w.im)) * hs
+  have hmid : (∑ k, (v k : ℂ) * (starRingEnd ℂ (Sb k) * Sa k)).re
+      = ∑ p : κ × Fin 2, (Real.sqrt (v p.1) * ![(Sa p.1).re, (Sa p.1).im] p.2)
+          * (Real.sqrt (v p.1) * ![(Sb p.1).re, (Sb p.1).im] p.2) := by
+    rw [Complex.re_sum, Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl (fun k _ => ?_)
+    rw [Fin.sum_univ_two, key (v k) (hv k) (Sa k) (Sb k)]
+    simp
+  have hda : (∑ k, (v k : ℂ) * (starRingEnd ℂ (Sa k) * Sa k)).re
+      = ∑ p : κ × Fin 2, (Real.sqrt (v p.1) * ![(Sa p.1).re, (Sa p.1).im] p.2) ^ 2 := by
+    rw [Complex.re_sum, Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl (fun k _ => ?_)
+    rw [Fin.sum_univ_two, key (v k) (hv k) (Sa k) (Sa k)]
+    simp [pow_two]
+  have hdb : (∑ k, (v k : ℂ) * (starRingEnd ℂ (Sb k) * Sb k)).re
+      = ∑ p : κ × Fin 2, (Real.sqrt (v p.1) * ![(Sb p.1).re, (Sb p.1).im] p.2) ^ 2 := by
+    rw [Complex.re_sum, Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl (fun k _ => ?_)
+    rw [Fin.sum_univ_two, key (v k) (hv k) (Sb k) (Sb k)]
+    simp [pow_two]
+  rw [hmid, hda, hdb]
+  exact Finset.sum_mul_sq_le_sq_mul_sq Finset.univ
+    (fun p : κ × Fin 2 => Real.sqrt (v p.1) * ![(Sa p.1).re, (Sa p.1).im] p.2)
+    (fun p : κ × Fin 2 => Real.sqrt (v p.1) * ![(Sb p.1).re, (Sb p.1).im] p.2)
+
+end LatticeSystem.Quantum

--- a/scripts/audit/capstones.txt
+++ b/scripts/audit/capstones.txt
@@ -97,12 +97,17 @@ ringReflectionThetaS_ringDLSFieldWeightSym
 ringTwoFieldWeight_self
 ringTwoFieldWeight_isLimit
 
-# TEMPORARY — §4.1 Theorem 4.2 (#4777) Gaussian-domination sub-arc (design v2), PR7b-iii-a tips
-# (#4978). The two-field product pairing (SWEEP) identity and its trace corollary (†)
-# (`RingReflectionTwoFieldPairing.lean`): the m-fold doubled DLS approximant collapses to a single
-# nonnegative reflection Gram pairing `∑ₖ vₖ·conj(refLeftSum 𝓛ₖ(y))·refLeftSum 𝓛ₖ(x)`.
-# Zero-referenced ONLY until PR7b-iii-b assembles the finite reflection Cauchy–Schwarz from this
-# Gram form, which CONSUMES both. DELIST when PR7b-iii-b lands (same temporary-then-delist lifecycle
-# as the delisted Theorem 4.8 PR-A…PR-D / Theorem 4.9 arc tips).
-twoField_product_pairing
-twoField_product_pairing_trace
+# NOTE (PR7b-iii-b, #4979): the PR7b-iii-a tips `twoField_product_pairing` and
+# `twoField_product_pairing_trace` (`RingReflectionTwoFieldPairing.lean`) are now DELISTED — both are
+# genuinely CONSUMED: `twoField_product_pairing_trace` is a real term reference in the assembled tip
+# `twoField_product_pairing_cauchySchwarz`, and `twoField_product_pairing` was already referenced by
+# `twoField_product_pairing_trace`. Their decls stay in place (same delist lifecycle as the Theorem
+# 4.8 PR-A…PR-D / Theorem 4.9 arc tips).
+
+# TEMPORARY — §4.1 Theorem 4.2 (#4777) Gaussian-domination sub-arc (design v2), PR7b-iii-b tip
+# (#4979). The finite reflection Cauchy–Schwarz on the two-field pairing (†)
+# (`RingReflectionTwoFieldConeCauchySchwarz.lean`): the doubled DLS approximant trace pairing obeys
+# `(Re Tr U(x,y))² ≤ Re Tr U(x,x)·Re Tr U(y,y)`.  Zero-referenced ONLY until PR7b-iii-c streams it to
+# the r→∞, m→∞ double limit, which CONSUMES it. DELIST when PR7b-iii-c lands (same temporary-then-
+# delist lifecycle as the delisted Theorem 4.8 PR-A…PR-D / Theorem 4.9 arc tips).
+twoField_product_pairing_cauchySchwarz


### PR DESCRIPTION
## Summary

Discharge Tasaki §4.1 Theorem 4.2 RP, substep **PR7b-iii-b**: prove the finite-volume **two-field pairing Gram Cauchy–Schwarz** using the weighted ℓ² Gram trace form `twoField_product_pairing_trace` ((†)) introduced in PR #4978.

## Goal

Given finite integers m, r, establish the **pure Gram Cauchy–Schwarz inequality**:
```
(Re Tr T_m(x,y))² ≤ Re Tr T_m(x,x) · Re Tr T_m(y,y)
```
where `T_m(·,·)` is the two-field pairing Gram matrix over (weighted) correlation products. This identity is the algebraic foundation for the momentum-sum bound in the next substep (PR7b-iii-c, double-limit bound).

## Context & Connection

- **Tracking issues**: #4777 (Thm 4.2 RP infrastructure) / #4769 (Ch.4/5 axioms frontier) / #4718 (master book-order axiom discharge)
- **Prior step (PR #4978 / PR7b-iii-a)**: `twoField_product_pairing_trace` (†) — the finite m,r two-field weighted pairing identity
- **Successor (PR7b-iii-c)**: double-limit bound — will consume this Gram CS lemma to extract the uniform infrared bound
- **Application**: Step toward Shastry 1D no-SSB (Cor 4.3 / Thm 4.2)

## Plan

1. State `twoFieldPairingGramCauchySchwarz` (or similar name) for finite m, r
2. Assume form of T_m(·,·) via `twoField_product_pairing_trace`
3. Prove the pure (non-weighted) Cauchy–Schwarz on the real part of trace
4. Verify zero-axiom status before review

## Issue Closure

This PR will not close issues directly; it advances checklist items in #4777 and #4769 (status update at merge time via issue-manager).

🤖 Generated with [Claude Code](https://claude.com/claude-code)