### PR TITLE
Tasaki §4.1 Thm 4.2 RP (PR7d-ii): staggered relabel bridge for classical RP averaging — #4777

### DIFF
--- a/LatticeSystem/Quantum/SpinS/RingReflection.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflection.lean
@@ -56,3 +56,4 @@ import LatticeSystem.Quantum.SpinS.RingReflectionTwoFieldConeCauchySchwarz
 import LatticeSystem.Quantum.SpinS.RingReflectionTwoFieldCauchySchwarz
 import LatticeSystem.Quantum.SpinS.RingReflectionFieldPartition
 import LatticeSystem.Quantum.SpinS.RingReflectionFieldPartitionSymmetry
+import LatticeSystem.Quantum.SpinS.RingReflectionStaggeredRelabel

--- a/LatticeSystem/Quantum/SpinS/RingReflectionStaggeredRelabel.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflectionStaggeredRelabel.lean
@@ -1,0 +1,126 @@
+/-
+Staggered relabel bridging the classical mirror reflections to the quantum signed field copies
+(Tasaki §4.1 Theorem 4.2, reflection-positivity layer: symmetrisation stage PR7d-ii).
+
+The classical cyclic averaging inequality `reflectionPositivity_averaging` (Tasaki Lemma 4.5,
+(4.1.55)–(4.1.57), pp. 87–88) is stated for the **sign-free** mirror reflections
+`reflectLeft`/`reflectRight` (`LatticeSystem/Math/ReflectionPositivityAveraging.lean`).  The quantum
+one reflection step (PR7c) instead produces the **signed** reflected field copies
+`ringFieldReflectLeft n h = physFieldOf n h h`, whose right half carries a minus sign
+`h_L z = −h (r z)` (DLS/Marshall structure).  Reconciling these two conventions is the point Tasaki
+§4.1 explicitly defers at the field Hamiltonian (4.1.48), book pp. 85–86, where the field enters as
+`Ŝ⁽³⁾ₓ − (−1)ˣ h_x` with a **staggered** `(−1)ˣ` factor.
+
+This file discharges that `−(−1)ˣ` sign decision once and for all by the **staggered relabel**
+`P h z = (−1)^z · h z`.  It is a period-2 involution whose right-half sign `(−1)^{r z} = −(−1)^z`
+(the bond reflection `r = ringReflect n` maps `z ↦ 2n−1−z`, flipping the staggered sublattice,
+`ringStaggeredSublattice_ringReflect`) exactly cancels the `physFieldOf` minus sign `−h (r z)`.
+Consequently `P` carries the classical mirror reflections onto the quantum signed field copies:
+`P (reflectLeft g) = ringFieldReflectLeft (P g)` and `P (reflectRight g) = ringFieldReflectRight
+(P g)`, and constant strings onto staggered constant fields `P (const c) = staggered_c`.  After this
+relabel the classical Lemma 4.5 applies verbatim (consumed downstream in PR7d-iii).
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems* (1st ed., Springer,
+2020), §4.1, staggered field Hamiltonian (4.1.48) and reflected field copies (4.1.50), pp. 85–86;
+chessboard estimate Lemma 4.5, (4.1.55)–(4.1.57), pp. 87–88.
+-/
+import LatticeSystem.Quantum.SpinS.RingReflectionFieldPartition
+import LatticeSystem.Math.ReflectionPositivityAveraging
+
+namespace LatticeSystem.Quantum
+
+/-- **Bond reflection equals `Fin.rev`.**  On `Fin (2n)` the geometric bond reflection
+`ringReflect n z = 2n−1−z` coincides with the generic reverse `z.rev = 2n−(z+1)` used by the
+classical mirror reflections `reflectLeft`/`reflectRight`; both send `z ↦ 2n−1−z`. -/
+private lemma ringReflect_eq_rev (n : ℕ) (z : Fin (2 * n)) :
+    z.rev = ringReflect n z := by
+  apply Fin.ext
+  rw [Fin.val_rev, ringReflect_val]
+  have := z.isLt
+  omega
+
+/-- **The staggered sign flips under the bond reflection.**  With `r = ringReflect n`,
+`(−1)^{r z} = −(−1)^z`, because `r z = 2n−1−z` and `2n−1` is odd (`ringStaggeredSublattice_
+ringReflect`).  This is the sign that cancels the `physFieldOf` right-half minus sign `−h (r z)`,
+resolving the `−(−1)ˣ` convention of Tasaki's staggered field Hamiltonian (4.1.48), pp. 85–86. -/
+private lemma neg_one_pow_ringReflect (n : ℕ) (z : Fin (2 * n)) :
+    (-1 : ℝ) ^ (ringReflect n z : ℕ) = -(-1 : ℝ) ^ (z : ℕ) := by
+  have hval : (ringReflect n z : ℕ) = 2 * n - 1 - (z : ℕ) := ringReflect_val n z
+  have hlt : (z : ℕ) < 2 * n := z.isLt
+  rw [hval]
+  have hsum : (2 * n - 1 - (z : ℕ)) + (z : ℕ) = 2 * n - 1 := by omega
+  have hodd : (-1 : ℝ) ^ (2 * n - 1) = -1 := Odd.neg_one_pow ⟨n - 1, by omega⟩
+  have h1 : (-1 : ℝ) ^ (2 * n - 1 - (z : ℕ)) * (-1 : ℝ) ^ (z : ℕ) = -1 := by
+    rw [← pow_add, hsum, hodd]
+  have hsq : (-1 : ℝ) ^ (z : ℕ) * (-1 : ℝ) ^ (z : ℕ) = 1 := by
+    rw [← pow_add, ← two_mul, pow_mul, neg_one_sq, one_pow]
+  have step : (-1 : ℝ) ^ (2 * n - 1 - (z : ℕ)) * ((-1 : ℝ) ^ (z : ℕ) * (-1 : ℝ) ^ (z : ℕ))
+      = -(-1 : ℝ) ^ (z : ℕ) := by
+    rw [← mul_assoc, h1]; ring
+  rwa [hsq, mul_one] at step
+
+/-- **Staggered relabel** `P h z = (−1)^z · h z` (Tasaki §4.1, staggered field factor of (4.1.48),
+pp. 85–86).  A period-2 involution (`ringStaggeredRelabel_involutive`) whose right-half sign flip
+carries the classical sign-free mirror reflections onto the quantum signed field copies. -/
+def ringStaggeredRelabel (n : ℕ) (h : Fin (2 * n) → ℝ) : Fin (2 * n) → ℝ :=
+  fun z => (-1 : ℝ) ^ (z : ℕ) * h z
+
+/-- **Staggered constant field** `staggered_c z = (−1)^z · c` (Tasaki §4.1, (4.1.48), pp. 85–86):
+the staggered relabel of the constant string `fun _ => c` (`ringStaggeredRelabel_const`).  PR7d-iii
+Gaussian domination bounds `Z_β(h)^{2n}` by a product of these staggered constant-field partition
+functions, each collapsed to `Z_β(0)` in PR7e. -/
+def ringStaggeredConstField (n : ℕ) (c : ℝ) : Fin (2 * n) → ℝ :=
+  fun z => (-1 : ℝ) ^ (z : ℕ) * c
+
+/-- **The staggered relabel is an involution:** `P (P h) = h`, since `(−1)^z · (−1)^z = 1`.  This
+lets PR7d-iii recover an arbitrary physical field `h` as `P g` with `g = P h`, feeding it into the
+classical averaging inequality (Tasaki Lemma 4.5, pp. 87–88). -/
+theorem ringStaggeredRelabel_involutive (n : ℕ) :
+    Function.Involutive (ringStaggeredRelabel n) := by
+  intro h
+  funext z
+  simp only [ringStaggeredRelabel]
+  rw [← mul_assoc, ← pow_add, ← two_mul, pow_mul, neg_one_sq, one_pow, one_mul]
+
+/-- **Left mirror ↔ signed left field copy.**  `P (reflectLeft g) = ringFieldReflectLeft (P g)`
+(Tasaki §4.1, reflected field copies (4.1.50), pp. 85–86).  On the left half both sides are
+`(−1)^z g z`; on the right half the classical mirror gives `(−1)^z g (r z)` while the signed copy
+gives `−(P g)(r z) = −(−1)^{r z} g (r z) = (−1)^z g (r z)` — equal because `(−1)^{r z} = −(−1)^z`
+(`neg_one_pow_ringReflect`) cancels the `physFieldOf` minus sign. -/
+theorem ringStaggeredRelabel_reflectLeft (n : ℕ) (g : Fin (2 * n) → ℝ) :
+    ringStaggeredRelabel n (LatticeSystem.Math.reflectLeft n g)
+      = ringFieldReflectLeft n (ringStaggeredRelabel n g) := by
+  funext z
+  simp only [ringStaggeredRelabel, ringFieldReflectLeft, physFieldOf,
+    LatticeSystem.Math.reflectLeft]
+  by_cases hz : (z : ℕ) < n
+  · rw [if_pos hz, if_pos hz]
+  · rw [if_neg hz, if_neg hz, ringReflect_eq_rev n z, neg_one_pow_ringReflect]
+    ring
+
+/-- **Right mirror ↔ signed right field copy.**  `P (reflectRight g) = ringFieldReflectRight (P g)`
+(Tasaki §4.1, reflected field copies (4.1.50), pp. 85–86).  Symmetric to the left case: on the right
+half both sides are `(−1)^z g z` (via involutivity of `r`), and on the left half the two right-half
+minus signs cancel through `(−1)^{r z} = −(−1)^z` (`neg_one_pow_ringReflect`). -/
+theorem ringStaggeredRelabel_reflectRight (n : ℕ) (g : Fin (2 * n) → ℝ) :
+    ringStaggeredRelabel n (LatticeSystem.Math.reflectRight n g)
+      = ringFieldReflectRight n (ringStaggeredRelabel n g) := by
+  funext z
+  simp only [ringStaggeredRelabel, ringFieldReflectRight, physFieldOf,
+    LatticeSystem.Math.reflectRight]
+  by_cases hz : (z : ℕ) < n
+  · rw [if_pos hz, if_pos hz, ringReflect_eq_rev n z, neg_one_pow_ringReflect]
+    ring
+  · rw [if_neg hz, if_neg hz, ringReflect_involutive n z]
+    ring
+
+/-- **Constant string ↔ staggered constant field.**  `P (fun _ => c) = staggered_c`, i.e.
+`ringStaggeredRelabel n (fun _ => c) = ringStaggeredConstField n c` (Tasaki §4.1, (4.1.48),
+pp. 85–86).  Identifies each constant-string argument of the classical averaging inequality with the
+staggered constant field whose partition function PR7e collapses to `Z_β(0)`. -/
+theorem ringStaggeredRelabel_const (n : ℕ) (c : ℝ) :
+    ringStaggeredRelabel n (fun _ => c) = ringStaggeredConstField n c := by
+  funext z
+  simp only [ringStaggeredRelabel, ringStaggeredConstField]
+
+end LatticeSystem.Quantum

--- a/scripts/audit/capstones.txt
+++ b/scripts/audit/capstones.txt
@@ -143,3 +143,18 @@ ringFieldPartitionRe_reflection_step
 ringFieldPartitionRe_translate
 ringFieldPartitionRe_neg
 ringFieldPartitionRe_pos
+
+# TEMPORARY — §4.1 Theorem 4.2 (#4777) Gaussian-domination sub-arc (design v2), PR7d-ii tips (#4985,
+# `RingReflectionStaggeredRelabel.lean`). The staggered relabel `P h z = (−1)^z·h z` bridge lemmas
+# reconciling the classical sign-free mirror reflections with the quantum signed field copies
+# (Tasaki staggered field Hamiltonian (4.1.48) / reflected field copies (4.1.50), pp. 85–86): its
+# involutivity, `P (reflectLeft g) = ringFieldReflectLeft (P g)`, `P (reflectRight g) =
+# ringFieldReflectRight (P g)`, and `P (const c) = staggered_c`. Zero-referenced ONLY until the
+# PR7d-iii Gaussian-domination capstone `ringFieldPartition_gaussianDomination` consumes them as the
+# `hcyc`/`hrefl` bridge that carries the classical averaging lemma (Lemma 4.5, pp. 87–88) onto the
+# quantum reflected copies. DELIST when PR7d-iii lands (same temporary-then-delist lifecycle as the
+# Theorem 4.8 / Theorem 4.9 arc tips).
+ringStaggeredRelabel_involutive
+ringStaggeredRelabel_reflectLeft
+ringStaggeredRelabel_reflectRight
+ringStaggeredRelabel_const


### PR DESCRIPTION
## Summary

Bridge classical and quantum field relabeling via **staggered relabel** `P h z = (−1)^z · h z` to enable reuse of the existing classical reflection-positivity averaging lemma (`reflectionPositivity_averaging`, Math/ReflectionPositivityAveraging.lean) at the partition function level (−log Z).

### Context
- **Aim**: Discharge Tasaki §4.1 Theorem 4.2 (RP-bounded uniform-field bound, equation 4.1.49) via reflection positivity
- **Strategy**: Classical averaging (additive) + Z symmetries (A,B,C from §§7d design) → capstone `Z(h)^{2n} ≤ ∏_j Z(staggered_{g_j})` via `F = −log Z ∘ P`
- **This PR (PR7d-ii)**: Combinatorial correspondence layer settling Tasaki (4.1.48) sign convention (−(−1)^x h_x)

### Motivation: Why staggered relabel?
- Quantum field on right half has sign flip: `h_L z = if z < n then h z else −h(r z)` (Marshall/DLS structure)
- Classical reflection mirror is unsigned: `reflectLeft g z = if z < n then g z else g(z.rev)`
- **Bridge**: `P h z := (−1)^z · h z` (period-2 staggered involution, ringReflect = Fin.rev consistent)
- Consequence: `P(reflectLeft g) = ringFieldReflectLeft n (P g)` (right-half sign becomes −1^z staggered factor)
- This makes `F(reflectLeft g) = −log Z(h_L)` properly align with classical `hrefl` input to averaging

### New lemmas (D from design, backward-chained from capstone)
| Lemma | Function |
|-------|----------|
| `ringStaggeredRelabel` / `P` | Define staggered relabel `(−1)^z · h z` as involution on field |
| `ringStaggeredRelabel_involutive` | `P ∘ P = id` |
| `ringStaggeredRelabel_reflectLeft` | `P (reflectLeft g) = ringFieldReflectLeft n (P g)` |
| `ringStaggeredRelabel_reflectRight` | `P (reflectRight g) = ringFieldReflectRight n (P g)` |
| `ringStaggeredRelabel_const_eq_staggered` | Bridge const field to staggered field: `P(const c) = fun z => (−1)^z · c` |

All proofs are pure combinatorial (Fin.rev / staggered sign mechanics).

### Reference
- **Design**: `.self-local/reports/design-thm-4-2-pr7d.md` §D (new file location, backward chaining)
- **Math notes**: `.self-local/docs/math-tasaki-4-1-52-symmetrisation-uniform-field.md` §2 (symmetry breakdown & staggered sublattice)
- **Tracking**: #4777 (multi-PR umbrella, Thm 4.2 RP infrastructure)
- **Next**: PR7d-iii will consume these bridging lemmas + PR7d-i (field symmetries) to prove capstone Gaussian domination

🤖 Generated with [Claude Code](https://claude.com/claude-code)
