### PR TITLE
Tasaki §4.1 Thm 4.2 RP (PR7d-iii): symmetrisation capstone via classical RP averaging — #4777

### DIFF
--- a/LatticeSystem/Quantum/SpinS/RingReflection.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflection.lean
@@ -57,3 +57,4 @@ import LatticeSystem.Quantum.SpinS.RingReflectionTwoFieldCauchySchwarz
 import LatticeSystem.Quantum.SpinS.RingReflectionFieldPartition
 import LatticeSystem.Quantum.SpinS.RingReflectionFieldPartitionSymmetry
 import LatticeSystem.Quantum.SpinS.RingReflectionStaggeredRelabel
+import LatticeSystem.Quantum.SpinS.RingReflectionGaussianDomination

--- a/LatticeSystem/Quantum/SpinS/RingReflectionGaussianDomination.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflectionGaussianDomination.lean
@@ -1,0 +1,160 @@
+/-
+Gaussian-domination capstone: the chessboard bound `Z_β(h)^{2n} ≤ Π_j Z_β(staggered_{g_j})`
+(Tasaki §4.1 Theorem 4.2, reflection-positivity layer: symmetrisation stage PR7d-iii).
+
+This is the symmetrisation capstone that turns PR7c's one reflection step
+`ringFieldPartitionRe_reflection_step : Z_β(h)² ≤ Z_β(h_L)·Z_β(h_R)` (the finite-β matrix form of
+Tasaki's reflection bound (4.1.51)) into the `2n`-fold chessboard bound
+`Z_β(h)^{2n} ≤ Π_{j} Z_β(staggered_{g_j})`, from which PR7e collapses each staggered constant field
+to `Z_β(0)` and concludes the uniform-field bound `Z_β(h) ≤ Z_β(0)` (Tasaki (4.1.49)/(4.1.52)).
+
+The proof **reuses the classical cyclic averaging inequality**
+`LatticeSystem.Math.reflectionPositivity_averaging` (Tasaki Lemma 4.5, (4.1.55)–(4.1.57),
+pp. 87–88; FILS, Comm. Math. Phys. 62 (1978) 1–34) applied to `F g = −log Z_β(P g)` with `P` the
+staggered relabel (PR7d-ii).  The doubling induction that assembles the `2n`-fold bound lives inside
+the classical lemma; PR7d only supplies its two hypotheses from the quantum side:
+
+* `hcyc` (cyclicity (4.1.55)) from the translation invariance `ringFieldPartitionRe_translate` and
+  the spin-flip invariance `ringFieldPartitionRe_neg` of `Z_β` (PR7d-i): the period-2 staggered
+  relabel turns a single one-step shift into a global sign, so a shift of `P (reindexCyclic f)`
+  factors as `spin-flip ∘ translation` of `P f` (`ringStaggeredRelabel_reindexCyclic`).
+* `hrefl` (reflection bound (4.1.56)) from the PR7c one reflection step, the strict positivity
+  `ringFieldPartitionRe_pos` (the `−log` domain, PR7d-i), and the staggered relabel bridge
+  `ringStaggeredRelabel_reflectLeft`/`_reflectRight` (PR7d-ii) carrying the classical mirror
+  reflections onto the quantum signed field copies; `log`-monotonicity converts `Z_β(h)² ≤ Z_β(h_L)
+  ·Z_β(h_R)` to `2 log Z_β(h) ≤ log Z_β(h_L) + log Z_β(h_R)`.
+
+Exponentiating the resulting `(1/2n) Σ_j (−log Z_β(staggered_{g_j})) ≤ −log Z_β(h)` gives the
+multiplicative capstone (the `−log`/`exp` rearrangement is inline; no separate multiplicative
+averaging lemma is introduced).
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems* (1st ed., Springer,
+2020), §4.1, reflection bound (4.1.51) and uniform-field bound (4.1.49)/(4.1.52), pp. 85–86;
+chessboard estimate Lemma 4.5, (4.1.55)–(4.1.57), pp. 87–88; translation-invariance wiring
+(4.1.58)–(4.1.61), pp. 88–89; FILS, Comm. Math. Phys. 62 (1978) 1–34.
+-/
+import LatticeSystem.Quantum.SpinS.RingReflectionFieldPartitionSymmetry
+import LatticeSystem.Quantum.SpinS.RingReflectionStaggeredRelabel
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+
+namespace LatticeSystem.Quantum
+
+open LatticeSystem.Math
+
+variable {n N : ℕ}
+
+/-- **Value of the one-step ring rotation.**  On a nonempty `Fin M` the rotation `finRotate M z`
+has value `(z + 1) mod M`; this rephrases `finRotate_succ_apply` (`finRotate (m+1) z = z + 1`) with
+`Fin.val_add`/`Fin.val_one'`.  Used to compute the staggered sign carried by the cyclic shift. -/
+private lemma finRotate_val {M : ℕ} [NeZero M] (z : Fin M) :
+    ((finRotate M z : Fin M) : ℕ) = ((z : ℕ) + 1) % M := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne M)
+  rw [finRotate_succ_apply, Fin.val_add, Fin.val_one', Nat.add_mod_mod]
+
+/-- **The staggered sign flips under the one-step ring rotation.**  On the even ring `Fin (2n)`,
+`(−1)^{(finRotate z).val} = −(−1)^{z.val}`, because `(finRotate z).val ≡ z.val + 1 (mod 2)`
+(`2 ∣ 2n`, so the wrap-around at the last site preserves parity).  This is the global sign that the
+period-2 staggered relabel `P` produces from a single cyclic shift (Tasaki §4.1, cyclicity source
+(4.1.60), p. 88). -/
+private lemma neg_one_pow_finRotate (n : ℕ) [NeZero (2 * n)] (z : Fin (2 * n)) :
+    (-1 : ℝ) ^ ((finRotate (2 * n) z : Fin (2 * n)) : ℕ) = -(-1 : ℝ) ^ (z : ℕ) := by
+  have hdvd : (2 : ℕ) ∣ 2 * n := ⟨n, rfl⟩
+  rw [finRotate_val z, neg_one_pow_eq_pow_mod_two, Nat.mod_mod_of_dvd _ hdvd,
+    ← neg_one_pow_eq_pow_mod_two, pow_succ]
+  ring
+
+/-- **The staggered relabel turns the cyclic shift into a signed shift.**
+`P (reindexCyclic f) = fun z => −(P f)(finRotate z)` (Tasaki §4.1, cyclicity source (4.1.60),
+p. 88).  Since `P h z = (−1)^z h z` has period 2, the one-step shift `reindexCyclic f = f ∘
+finRotate` acquires the global sign of `neg_one_pow_finRotate`.  Feeding this through the spin-flip
+and translation invariances of `Z_β` yields the cyclicity hypothesis of the chessboard estimate. -/
+private lemma ringStaggeredRelabel_reindexCyclic (n : ℕ) [NeZero (2 * n)]
+    (f : Fin (2 * n) → ℝ) :
+    ringStaggeredRelabel n (reindexCyclic n f)
+      = fun z => - ringStaggeredRelabel n f (finRotate (2 * n) z) := by
+  funext z
+  simp only [ringStaggeredRelabel, reindexCyclic]
+  rw [neg_one_pow_finRotate n z]
+  ring
+
+/-- **Gaussian-domination capstone.**  For the physical field partition function
+`Z_β(h) = ringFieldPartitionRe n N β h` on the even ring `Fin (2n)` (`n ≥ 1`, `β ≥ 0`),
+`Z_β(h)^{2n} ≤ Π_{j} Z_β(staggered_{g_j})`, where `g = P h` is the staggered relabel of `h` and
+`staggered_c z = (−1)^z c` is the staggered constant field (`ringStaggeredConstField`).  This is the
+finite-β chessboard bound obtained from Tasaki's reflection bound (4.1.51) by the cyclic averaging
+inequality (Lemma 4.5, (4.1.55)–(4.1.57), pp. 87–88): applying
+`LatticeSystem.Math.reflectionPositivity_averaging` to `F g = −log Z_β(P g)` — with cyclicity from
+the translation and spin-flip invariances of `Z_β` (PR7d-i), and the reflection bound from PR7c's
+one reflection step, the strict positivity of `Z_β`, and the staggered relabel bridge (PR7d-ii) —
+gives `(1/2n) Σ_j (−log Z_β(staggered_{g_j})) ≤ −log Z_β(h)`, which exponentiates to the product
+bound.  PR7e collapses each `Z_β(staggered_c)` to `Z_β(0)` to reach the uniform-field bound
+`Z_β(h) ≤ Z_β(0)` (Tasaki (4.1.49)/(4.1.52), pp. 85–86; FILS, Comm. Math. Phys. 62 (1978) 1–34). -/
+theorem ringFieldPartition_gaussianDomination (G : AxisTwoPiRotS N) (n : ℕ) (hn : 1 ≤ n) {β : ℝ}
+    (hβ : 0 ≤ β) (h : Fin (2 * n) → ℝ) :
+    ringFieldPartitionRe n N β h ^ (2 * n)
+      ≤ ∏ j : Fin (2 * n),
+          ringFieldPartitionRe n N β (ringStaggeredConstField n (ringStaggeredRelabel n h j)) := by
+  haveI : NeZero n := ⟨by omega⟩
+  haveI : NeZero (2 * n) := ⟨by omega⟩
+  set F : (Fin (2 * n) → ℝ) → ℝ :=
+    fun g => - Real.log (ringFieldPartitionRe n N β (ringStaggeredRelabel n g)) with hFdef
+  -- Cyclicity (4.1.55): translation + spin-flip invariance of `Z_β`.
+  have hcyc : ∀ f, F (reindexCyclic n f) = F f := by
+    intro f
+    simp only [hFdef]
+    refine congrArg (fun t => - Real.log t) ?_
+    rw [ringStaggeredRelabel_reindexCyclic n f]
+    calc ringFieldPartitionRe n N β
+            (fun z => - ringStaggeredRelabel n f (finRotate (2 * n) z))
+        = ringFieldPartitionRe n N β
+            (fun z => ringStaggeredRelabel n f (finRotate (2 * n) z)) :=
+          ringFieldPartitionRe_neg G n β
+            (fun z => ringStaggeredRelabel n f (finRotate (2 * n) z))
+      _ = ringFieldPartitionRe n N β (ringStaggeredRelabel n f) :=
+          (ringFieldPartitionRe_translate n N β (ringStaggeredRelabel n f)).symm
+  -- Reflection bound (4.1.56): PR7c reflection step + strict positivity + staggered bridge.
+  have hrefl : ∀ f, (F (reflectLeft n f) + F (reflectRight n f)) / 2 ≤ F f := by
+    intro f
+    simp only [hFdef, ringStaggeredRelabel_reflectLeft n f, ringStaggeredRelabel_reflectRight n f]
+    set g := ringStaggeredRelabel n f with hg
+    have hpg := ringFieldPartitionRe_pos n N β g
+    have hpL := ringFieldPartitionRe_pos n N β (ringFieldReflectLeft n g)
+    have hpR := ringFieldPartitionRe_pos n N β (ringFieldReflectRight n g)
+    have hstep := ringFieldPartitionRe_reflection_step G n hβ g
+    have hlog := (Real.log_le_log_iff (pow_pos hpg 2) (mul_pos hpL hpR)).mpr hstep
+    rw [Real.log_pow, Real.log_mul (ne_of_gt hpL) (ne_of_gt hpR)] at hlog
+    push_cast at hlog
+    linarith
+  -- Apply the classical averaging inequality at `f = P h` and rewrite `F` via the bridge lemmas.
+  have key := reflectionPositivity_averaging n hn F hcyc hrefl (ringStaggeredRelabel n h)
+  simp only [hFdef, ringStaggeredRelabel_involutive n h, ringStaggeredRelabel_const n] at key
+  -- Strict positivity of the base and the staggered-constant partition functions.
+  have ha : 0 < ringFieldPartitionRe n N β h := ringFieldPartitionRe_pos n N β h
+  have hw : ∀ j : Fin (2 * n), 0 < ringFieldPartitionRe n N β
+      (ringStaggeredConstField n (ringStaggeredRelabel n h j)) :=
+    fun j => ringFieldPartitionRe_pos n N β _
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast (show 0 < n by omega)
+  have h2n : (0 : ℝ) < 2 * (n : ℝ) := by linarith
+  -- Turn the averaged `−log` inequality into `2n · log Z_β(h) ≤ Σ_j log Z_β(staggered_{g_j})`.
+  rw [div_le_iff₀ h2n, Finset.sum_neg_distrib] at key
+  have hlogpow : Real.log (ringFieldPartitionRe n N β h ^ (2 * n))
+      = 2 * (n : ℝ) * Real.log (ringFieldPartitionRe n N β h) := by
+    rw [Real.log_pow]; push_cast; ring
+  have hlogprod : Real.log (∏ j : Fin (2 * n),
+        ringFieldPartitionRe n N β (ringStaggeredConstField n (ringStaggeredRelabel n h j)))
+      = ∑ j : Fin (2 * n),
+          Real.log (ringFieldPartitionRe n N β
+            (ringStaggeredConstField n (ringStaggeredRelabel n h j))) :=
+    Real.log_prod (fun j _ => (hw j).ne')
+  have hle : Real.log (ringFieldPartitionRe n N β h ^ (2 * n))
+      ≤ Real.log (∏ j : Fin (2 * n),
+          ringFieldPartitionRe n N β (ringStaggeredConstField n (ringStaggeredRelabel n h j))) := by
+    rw [hlogpow, hlogprod]
+    nlinarith [key]
+  have hXpos : 0 < ringFieldPartitionRe n N β h ^ (2 * n) := pow_pos ha _
+  have hYpos : 0 < ∏ j : Fin (2 * n),
+      ringFieldPartitionRe n N β (ringStaggeredConstField n (ringStaggeredRelabel n h j)) :=
+    Finset.prod_pos (fun j _ => hw j)
+  exact (Real.log_le_log_iff hXpos hYpos).mp hle
+
+end LatticeSystem.Quantum

--- a/scripts/audit/capstones.txt
+++ b/scripts/audit/capstones.txt
@@ -127,34 +127,38 @@ ringReflectionThetaS_ringDLSFieldWeightSym
 # PR7d-i. It (with its exclusive sub-tips `ringTwoFieldWeight_self` /
 # `ringDLSFieldWeightSym_rpTraceWeight`) is retained for the PR7e collapse `Z_β(staggered_c) = Z_β(0)`
 # (diagonal reflection-symmetric case); RE-EVALUATE at PR7e — delete the whole diagonal sub-chain if
-# still unconsumed when the arc completes. `ringFieldPartitionRe_reflection_step` is DELISTED by
-# PR7d-iii (consumed by the Gaussian-domination capstone), not by PR7d-i.
+# still unconsumed when the arc completes.
+# NOTE (PR7d-iii, #4986): the PR7c one reflection step `ringFieldPartitionRe_reflection_step`
+# (`RingReflectionFieldPartition.lean`), the finite-β partition-function reflection bound
+# `Z_β(h)² ≤ Z_β(h_L)·Z_β(h_R)`, is now DELISTED — it is genuinely CONSUMED by the PR7d-iii
+# Gaussian-domination capstone `ringFieldPartition_gaussianDomination`
+# (`RingReflectionGaussianDomination.lean`) as the `hrefl` reflection bound of the classical
+# averaging lemma. Its decl stays in place (same delist lifecycle as the Theorem 4.8 / 4.9 arc tips).
 ringTwoFieldWeight_self_trace_re_nonneg
-ringFieldPartitionRe_reflection_step
 
-# TEMPORARY — §4.1 Theorem 4.2 (#4777) Gaussian-domination sub-arc (design v2), PR7d-i tips (#4984,
-# `RingReflectionFieldPartitionSymmetry.lean`). The three symmetries of the field partition function
-# viewed as a function of the field `h`: translation invariance `Z_β(h) = Z_β(h ∘ finRotate)`,
-# spin-flip invariance `Z_β(−h) = Z_β(h)`, and strict positivity `0 < Z_β(h)` (Tasaki (4.1.49)–
-# (4.1.52), pp. 85–86; chessboard estimate Lemma 4.5, pp. 87–88). Zero-referenced ONLY until the
-# PR7d-iii Gaussian-domination capstone `ringFieldPartition_gaussianDomination` consumes them as the
-# cyclicity (A, B) and `−log Z` domain (C) hypotheses of the classical averaging lemma. DELIST when
-# PR7d-iii lands (same temporary-then-delist lifecycle as the Theorem 4.8 / Theorem 4.9 arc tips).
-ringFieldPartitionRe_translate
-ringFieldPartitionRe_neg
-ringFieldPartitionRe_pos
+# NOTE (PR7d-iii, #4986): the PR7d-i field-partition symmetries
+# (`RingReflectionFieldPartitionSymmetry.lean`) — translation invariance `ringFieldPartitionRe_translate`,
+# spin-flip invariance `ringFieldPartitionRe_neg`, and strict positivity `ringFieldPartitionRe_pos` —
+# are now DELISTED — all three are genuinely CONSUMED by the PR7d-iii Gaussian-domination capstone
+# `ringFieldPartition_gaussianDomination` (`RingReflectionGaussianDomination.lean`): translation +
+# spin-flip supply its `hcyc` cyclicity hypothesis and strict positivity is the `−log Z` domain
+# condition of its `hrefl`. Their decls stay in place (same delist lifecycle as the Theorem 4.8 /
+# Theorem 4.9 arc tips).
 
-# TEMPORARY — §4.1 Theorem 4.2 (#4777) Gaussian-domination sub-arc (design v2), PR7d-ii tips (#4985,
-# `RingReflectionStaggeredRelabel.lean`). The staggered relabel `P h z = (−1)^z·h z` bridge lemmas
-# reconciling the classical sign-free mirror reflections with the quantum signed field copies
-# (Tasaki staggered field Hamiltonian (4.1.48) / reflected field copies (4.1.50), pp. 85–86): its
-# involutivity, `P (reflectLeft g) = ringFieldReflectLeft (P g)`, `P (reflectRight g) =
-# ringFieldReflectRight (P g)`, and `P (const c) = staggered_c`. Zero-referenced ONLY until the
-# PR7d-iii Gaussian-domination capstone `ringFieldPartition_gaussianDomination` consumes them as the
-# `hcyc`/`hrefl` bridge that carries the classical averaging lemma (Lemma 4.5, pp. 87–88) onto the
-# quantum reflected copies. DELIST when PR7d-iii lands (same temporary-then-delist lifecycle as the
-# Theorem 4.8 / Theorem 4.9 arc tips).
-ringStaggeredRelabel_involutive
-ringStaggeredRelabel_reflectLeft
-ringStaggeredRelabel_reflectRight
-ringStaggeredRelabel_const
+# NOTE (PR7d-iii, #4986): the PR7d-ii staggered relabel bridge lemmas
+# (`RingReflectionStaggeredRelabel.lean`) — `ringStaggeredRelabel_involutive`,
+# `ringStaggeredRelabel_reflectLeft`, `ringStaggeredRelabel_reflectRight`,
+# `ringStaggeredRelabel_const` — are now DELISTED — all four are genuinely CONSUMED by the PR7d-iii
+# Gaussian-domination capstone `ringFieldPartition_gaussianDomination`
+# (`RingReflectionGaussianDomination.lean`) as the `hcyc`/`hrefl` bridge carrying the classical
+# averaging lemma onto the quantum reflected copies (and `const` identifies the product terms). Their
+# decls stay in place (same delist lifecycle as the Theorem 4.8 / Theorem 4.9 arc tips).
+
+# TEMPORARY — §4.1 Theorem 4.2 (#4777) Gaussian-domination sub-arc (design v2), PR7d-iii capstone
+# (#4986, `RingReflectionGaussianDomination.lean`). The chessboard bound
+# `Z_β(h)^{2n} ≤ Π_j Z_β(staggered_{g_j})` obtained from Tasaki's reflection bound (4.1.51) by the
+# cyclic averaging inequality (Lemma 4.5, (4.1.55)–(4.1.57), pp. 87–88; FILS, Comm. Math. Phys. 62
+# (1978) 1–34). Zero-referenced ONLY until PR7e collapses each `Z_β(staggered_c)` to `Z_β(0)` and
+# concludes the uniform-field bound `Z_β(h) ≤ Z_β(0)` (Tasaki (4.1.49)/(4.1.52), pp. 85–86). DELIST
+# when PR7e lands (same temporary-then-delist lifecycle as the Theorem 4.8 / Theorem 4.9 arc tips).
+ringFieldPartition_gaussianDomination


### PR DESCRIPTION
## Summary

Apply classical `reflectionPositivity_averaging` to the free energy form `F = −log(Z∘P)` to construct the symmetrisation capstone inequality. Supply:
- **Reflection hypothesis** `hrefl` from one quantum-reflection step (`ringFieldPartitionRe_reflection_step`) + strict positivity (`ringFieldPartitionRe_pos`) + logarithm
- **Cyclicity** from translation (`ringFieldPartitionRe_translate`) + spin-flip (`ringFieldPartitionRe_neg`) invariance

Yields the capstone form: `Z(h)^{2n} ≤ Π_j Z(staggered_{g_j})` (precise statement per design §7d-iii).

## Changes
- Delist 8 consumed tips (capstone-input module #4 infrastructure)
- Temp ADD new capstone decl (scheduled for delist in PR7e per design)
- Reference `#4777` throughout

## Design & Math
- **Design**: `.self-local/reports/design-thm-4-2-pr7d.md`
- **Math (§1 / §5)**: `.self-local/docs/math-tasaki-4-1-52-symmetrisation-uniform-field.md`

## Test Plan
- Lake build full root (warning-free)
- Verify capstone statement matches design exact form

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
