### PR TITLE
docs: correct Theorem 10.4 axiom scope documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -150,10 +150,10 @@ functional-analysis development; such a development may well be carried out
 perturbation theory) and singular-perturbation arguments in Chapter 10): the analytic
 proofs of weak-coupling continuation and adiabatic following for eigenstate families
 are **not undertaken** as an active project goal; such techniques naturally belong to
-a separate analytic-perturbation development. Results whose only missing link is a
-perturbation-theoretic proof — such as the total-spin values in Lieb's repulsive-Hubbard
-theorem (Theorem 10.4) — are recorded as documented axioms while their companion
-finite-coupling combinatorial bounds are proved axiom-free.
+a separate analytic-perturbation development. **Theorem 10.4** (Lieb's repulsive-Hubbard
+half-filling ground state) currently has its entire content axiomatized: the global minimum
+energy, ground-state degeneracy, and total-spin values are all undischarged. (The fixed-Ŝ³-sector
+ground-state uniqueness has been proved; full theorem discharge is tracked in Issue #5004.)
 
 - **Book theorems that Tasaki states without proof** (results he quotes from the
 external literature rather than proving in the text): **Theorem 10.11** (Kubo–Kishi


### PR DESCRIPTION
## Summary

Corrects mistaken documentation claiming only Theorem 10.4's total-spin values are axiomatized. **Reality**: Entire theorem (global minimum energy E₀, ground-state degeneracy |A|−|B|+1, and total-spin Casimir eigenvalue S₀=||A|−|B||/2) is currently axiomatized.

Only the fixed-Ŝ³=m sector ground-state uniqueness has been proved (`repulsiveSpinZSector_ground_unique`, LiebRepulsiveBalancedGround.lean:92).

## Audit Finding

2026-07-11 completeness audit identified this documentation as a misstatement of the axiom scope. This PR updates docs/index.md §10 to correctly reflect that Theorem 10.4 is held in its entirety as an axiom pending finite-dimensional Reflection-Positivity machinery discharge.

## Related

Refs #5004 (Issue: Thm 10.4/10.6/10.8 bundle discharge)  
Refs #4718 (Master axiom tracker)

## Test Plan

- [x] Verify docs/index.md update correctly describes Thm 10.4 axiom scope
- [x] No Lean code changes (docs only)
- [x] Commit message references related issues with Refs (not Fixes/Closes)