### PR TITLE
Prop 4.10 L5-b-i: base ratio limit from factor-3 + axis-3 LRO + Conjecture 4.12

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -132,6 +132,7 @@ import LatticeSystem.Quantum.SpinS.AndersonTowerOrderSq
 import LatticeSystem.Quantum.SpinS.AndersonTowerOrderSqIsotropy
 import LatticeSystem.Quantum.SpinS.AndersonTowerOrderSqMoment
 import LatticeSystem.Quantum.SpinS.AndersonTowerOrderSqCollapse
+import LatticeSystem.Quantum.SpinS.AndersonTowerOrderSqBaseRatio
 import LatticeSystem.Quantum.SpinS.AndersonTowerCartWord
 import LatticeSystem.Quantum.SpinS.AndersonTowerLeviCivita
 import LatticeSystem.Quantum.SpinS.AndersonTowerTelescoping

--- a/LatticeSystem/Quantum/SpinS/AndersonTowerOrderSqBaseRatio.lean
+++ b/LatticeSystem/Quantum/SpinS/AndersonTowerOrderSqBaseRatio.lean
@@ -1,0 +1,125 @@
+import LatticeSystem.Quantum.SpinS.AndersonTowerOrderSqIsotropy
+import LatticeSystem.Quantum.SpinS.AndersonTowerOrderSqMoment
+import LatticeSystem.Quantum.SpinS.AndersonTowerSphereAverage
+
+/-!
+# Tasaki §4.2.2 Proposition 4.10 (L5-b-i): the base `ô²`-moment ratio limit
+
+The base (concentration-independent) step of the `ô²`-moment collapse driving Proposition 4.10.
+With the `ô²`-moments `R_k := orderSqMoment d L N Φ k = ⟨Φ, (ô²)^k Φ⟩` and `V² := (L^d)²`, this
+module records the **exact base ratio limit**
+
+`lim_{L → ∞} R_1 / (R_0 · V²) = (m∗)²`   (`orderSqMoment_baseRatio_tendsto`),
+
+for a total-spin-singlet ground-state family `Φ`, conditional on Conjecture 4.12
+(`m∗ = √(3 q∗)`, an explicit hypothesis, never asserted true).
+
+The mechanism combines three ingredients and needs **no** concentration estimate and **no** the
+Theorem 4.9 identity `m∗ = √q₀`:
+
+* **factor-3 diagonal isotropy** (`orderSqOp_expectation_eq_three_mul_axis3`, eqs. (4.2.57)–
+  (4.2.58)): on the singlet, `⟨Φ, ô² Φ⟩ = 3 · ⟨Φ, (ô^{(3)})² Φ⟩`, so `R_1 = 3 · ⟨(ô^{(3)})²⟩`;
+* the **axis-3 long-range-order limit** `⟨(ô^{(3)})²⟩ / (‖Φ‖² V²) → q∗` (an explicit hypothesis,
+  matching the conditioning of `IsTanakaSphereAverageConstants`);
+* **Conjecture 4.12** `(m∗)² = 3 q∗` (from `IsConjecture412Equality`).
+
+Chaining these gives `R_1 / (R_0 · V²) = 3 · ⟨(ô^{(3)})²⟩ / (‖Φ‖² V²) → 3 q∗ = (m∗)²`.
+
+The limit is phrased as an `ε`–`δ` statement over even `L`, matching the axis-3 hypothesis and the
+convergence layers of `IsTanakaSphereAverageConstants`, so it plugs directly into the geometric
+moment squeeze (sequel L5-b-iii).
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems* (1st ed., Springer,
+2020), §4.2.2, Proposition 4.10, eqs. (4.2.25)–(4.2.26), (4.2.57)–(4.2.59), pp. 105–109.
+-/
+
+namespace LatticeSystem.Quantum
+
+open Matrix
+open scoped ComplexOrder
+
+/-- **Base `ô²`-moment ratio limit** (Prop 4.10, L5-b-i): for a total-spin-singlet ground-state
+family `Φ` (eventual singlet `Ŝ³_tot Φ = Ŝ¹_tot Φ = 0`) whose **axis-3** long-range-order ratio
+`⟨(ô^{(3)})²⟩ / (‖Φ‖² V²)` tends to `q∗` (`hlim3`), **conditional on Conjecture 4.12**
+(`m∗ = √(3 q∗)`, `hconj`, never asserted true), the full `ô²`-moment base ratio tends to `(m∗)²`:
+
+`∀ ε > 0, ∃ L₀, ∀ L ≥ L₀ (even, ≥ 2), |R_1 / (R_0 · V²) − (m∗)²| < ε`,
+
+where `R_k = orderSqMoment d L N Φ k` and `V² = (L^d)²`.  The proof uses the factor-3 diagonal
+isotropy `R_1 = 3 · ⟨(ô^{(3)})²⟩` on the singlet, the axis-3 limit `⟨(ô^{(3)})²⟩/(‖Φ‖²V²) → q∗`, and
+`(m∗)² = 3 q∗` (Conjecture 4.12).  The nonnegativity `0 ≤ q∗` is recovered from `hlim3` (a limit of
+nonnegative positive-semidefinite ratios); no concentration estimate and no Theorem 4.9
+`m∗ = √q₀` are used. -/
+theorem orderSqMoment_baseRatio_tendsto (d N : ℕ)
+    (Φ : (L : ℕ) → (HypercubicTorus d L → Fin (N + 1)) → ℂ)
+    (hsinglet : ∃ L₁ : ℕ, ∀ (L : ℕ) [NeZero L], L₁ ≤ L → 2 ≤ L → Even L →
+      (totalSpinSOp3 (HypercubicTorus d L) N).mulVec (Φ L) = 0 ∧
+        (totalSpinSOp1 (HypercubicTorus d L) N).mulVec (Φ L) = 0)
+    (qStar mStar : ℝ)
+    (hlim3 : ∀ ε : ℝ, 0 < ε → ∃ L₀ : ℕ, ∀ (L : ℕ) [NeZero L], L₀ ≤ L → 2 ≤ L → Even L →
+      |(star (Φ L) ⬝ᵥ ((staggeredOrderOpS (torusParitySublattice d L) N *
+          staggeredOrderOpS (torusParitySublattice d L) N).mulVec (Φ L))).re /
+          ((star (Φ L) ⬝ᵥ Φ L).re * ((L : ℝ) ^ d) ^ 2) - qStar| < ε)
+    (hconj : IsConjecture412Equality mStar qStar) :
+    ∀ ε : ℝ, 0 < ε → ∃ L₀ : ℕ, ∀ (L : ℕ) [NeZero L], L₀ ≤ L → 2 ≤ L → Even L →
+      |orderSqMoment d L N (Φ L) 1 /
+          (orderSqMoment d L N (Φ L) 0 * ((L : ℝ) ^ d) ^ 2) - mStar ^ 2| < ε := by
+  -- Step 1: `0 ≤ q∗` — the axis-3 ratios are nonnegative (positive-semidefinite `(ô^{(3)})²`), so
+  -- their limit `q∗` is nonnegative.
+  have hqStar : 0 ≤ qStar := by
+    by_contra hneg
+    rw [not_le] at hneg
+    obtain ⟨L₀, hL₀⟩ := hlim3 (-qStar) (by linarith)
+    set L := 2 * (L₀ + 1) with hLdef
+    haveI : NeZero L := ⟨by omega⟩
+    have hEven : Even L := ⟨L₀ + 1, by omega⟩
+    have hbound := hL₀ L (by omega) (by omega) hEven
+    have hnum : 0 ≤ (star (Φ L) ⬝ᵥ ((staggeredOrderOpS (torusParitySublattice d L) N *
+        staggeredOrderOpS (torusParitySublattice d L) N).mulVec (Φ L))).re := by
+      have hSS : (staggeredOrderOpS (torusParitySublattice d L) N *
+          staggeredOrderOpS (torusParitySublattice d L) N).PosSemidef := by
+        have h := posSemidef_conjTranspose_mul_self
+          (staggeredOrderOpS (torusParitySublattice d L) N)
+        rwa [(staggeredOrderOpS_isHermitian _ N).eq] at h
+      exact (Complex.le_def.mp (hSS.dotProduct_mulVec_nonneg (Φ L))).1
+    have hden : 0 ≤ (star (Φ L) ⬝ᵥ Φ L).re * ((L : ℝ) ^ d) ^ 2 :=
+      mul_nonneg (Complex.le_def.mp (dotProduct_star_self_nonneg _)).1 (by positivity)
+    have hratio : 0 ≤ (star (Φ L) ⬝ᵥ ((staggeredOrderOpS (torusParitySublattice d L) N *
+        staggeredOrderOpS (torusParitySublattice d L) N).mulVec (Φ L))).re /
+        ((star (Φ L) ⬝ᵥ Φ L).re * ((L : ℝ) ^ d) ^ 2) := div_nonneg hnum hden
+    linarith [hratio, (abs_lt.mp hbound).2]
+  -- Step 2: `(m∗)² = 3 q∗` (Conjecture 4.12, `m∗ = √(3 q∗)`).
+  have hmStar2 : mStar ^ 2 = 3 * qStar := by
+    rw [hconj, Real.sq_sqrt (by linarith : (0 : ℝ) ≤ 3 * qStar)]
+  -- Step 3: the `ε`–`δ` limit via the factor-3 bridge `R_1 = 3 · ⟨(ô^{(3)})²⟩`.
+  obtain ⟨L₁, hsing⟩ := hsinglet
+  intro ε hε
+  obtain ⟨L₀, hL₀⟩ := hlim3 (ε / 3) (by linarith)
+  refine ⟨max L₀ L₁, fun L _ hLge h2 hev => ?_⟩
+  have hL₀le : L₀ ≤ L := le_trans (le_max_left _ _) hLge
+  have hL₁le : L₁ ≤ L := le_trans (le_max_right _ _) hLge
+  obtain ⟨h3, h1⟩ := hsing L hL₁le h2 hev
+  have hR1 : orderSqMoment d L N (Φ L) 1
+      = 3 * (star (Φ L) ⬝ᵥ ((staggeredOrderOpS (torusParitySublattice d L) N *
+          staggeredOrderOpS (torusParitySublattice d L) N).mulVec (Φ L))).re := by
+    simp only [orderSqMoment, pow_one]
+    rw [orderSqOp_expectation_eq_three_mul_axis3 (torusParitySublattice d L) (Φ L) h3 h1,
+      Complex.mul_re, Complex.re_ofNat, Complex.im_ofNat, zero_mul, sub_zero]
+  have hR0 : orderSqMoment d L N (Φ L) 0 = (star (Φ L) ⬝ᵥ Φ L).re := by
+    simp only [orderSqMoment, pow_zero, Matrix.one_mulVec]
+  have hbridge : orderSqMoment d L N (Φ L) 1 /
+      (orderSqMoment d L N (Φ L) 0 * ((L : ℝ) ^ d) ^ 2)
+      = 3 * ((star (Φ L) ⬝ᵥ ((staggeredOrderOpS (torusParitySublattice d L) N *
+          staggeredOrderOpS (torusParitySublattice d L) N).mulVec (Φ L))).re /
+          ((star (Φ L) ⬝ᵥ Φ L).re * ((L : ℝ) ^ d) ^ 2)) := by
+    rw [hR1, hR0, mul_div_assoc]
+  have haxis3 := hL₀ L hL₀le h2 hev
+  have key : ∀ a : ℝ, |a - qStar| < ε / 3 → |3 * a - 3 * qStar| < ε := by
+    intro a ha
+    rw [show 3 * a - 3 * qStar = 3 * (a - qStar) from by ring, abs_mul,
+      show |(3 : ℝ)| = 3 from by norm_num]
+    linarith
+  rw [hbridge, hmStar2]
+  exact key _ haxis3
+
+end LatticeSystem.Quantum

--- a/scripts/audit/capstones.txt
+++ b/scripts/audit/capstones.txt
@@ -348,3 +348,13 @@ orderSq_collapse_vecNormSqRe
 # eqs. (4.2.57)–(4.2.61), p. 108–109).  Zero-referenced until the sphere-average assembly (PR-6)
 # consumes it as the per-direction normalisation constant `c_M`. RE-EVALUATE/DELIST when consumed.
 directionTanakaTowerTerm_vecNormSqRe_indep
+
+# TEMPORARY arc-tip (temp-then-delist lifecycle) — §4.2 Prop 4.10 (#4974) L5-b-i,
+# `Quantum/SpinS/AndersonTowerOrderSqBaseRatio.lean`. The base `ô²`-moment ratio limit
+# `lim_L R_1/(R_0·V²) = (m∗)²` for a total-spin-singlet ground-state family, from factor-3 diagonal
+# isotropy `R_1 = 3·⟨(ô^{(3)})²⟩`, the axis-3 long-range-order limit `⟨(ô^{(3)})²⟩/(‖Φ‖²V²) → q∗`, and
+# Conjecture 4.12 `(m∗)² = 3 q∗` (explicit hypothesis, never asserted).  Concentration-independent
+# and independent of Theorem 4.9 `m∗ = √q₀` (Tasaki §4.2.2, eqs. (4.2.25)–(4.2.26), (4.2.57)–(4.2.59),
+# p. 108–109).  Zero-referenced until the geometric moment squeeze (L5-b-iii) consumes it as the
+# base of the geometric lower bound.  RE-EVALUATE/DELIST when consumed.
+orderSqMoment_baseRatio_tendsto


### PR DESCRIPTION
## Summary

Discharges the **base ratio** (L5-b-i) for Prop 4.10 collapse phase: proves the exact limit `lim_{L→∞} R_1/(R_0·V²) = (mStar)²` (where R_k = orderSqMoment d L N Φ k, V = L^d).

Consumes:
- L4a factor-3 isotropy: `orderSqOp_expectation_eq_three_mul_axis3` (ô² = 3·⟨(ô³)²⟩ in singlet h₃⊕h₁)
- Axis-3 LRO limit hypothesis: qStar (IsTanakaSphereAverageConstants:140-144)
- Conjecture 4.12: mStar² = 3·qStar (held as explicit hypothesis, never asserted)

**Key fact**: This base proof does NOT require Thm 4.9's mStar=√q₀ or any concentration—it closes solely via 3qStar. Concentration (L5-b-ii) is independent, applied later to construct upper bounds.

Scope boundary: base ratio only. **Concentration bounds (b-ii) and geometric collapse (b-iii) deferred to subsequent PRs.**

Route β (ô² direct, p̂-axiom dormant): all lemmas use `staggeredOrderOpS` (axis-3) and `orderSqMoment`; no reference to p̂-side declarations.

New file: `LatticeSystem/Quantum/AndersonTowerOrderSqBaseRatio.lean` (est. 80–130 lines, doc-commented, warning-free).

Refs #4974 (Prop 4.10 collapse crux), #4777 (Thm 4.2 RP infra), #4769 (frontier issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
