### PR TITLE
refactor: dedup dotProduct_star_self_re_pos (tier2 2026-07-18 High-1) — #4718

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HubbardImpossibilityLowUVariational.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HubbardImpossibilityLowUVariational.lean
@@ -83,16 +83,6 @@ theorem dotProduct_star_self_eq_ofReal {n : Type*} [Fintype n] (v : n → ℂ) :
   refine Finset.sum_congr rfl (fun i _ => ?_)
   rw [← Complex.normSq_eq_conj_mul_self]
 
-/-- For a nonzero vector `v`, the squared norm `(⟨v, v⟩).re = Σ_i |v_i|²` is strictly positive. -/
-theorem dotProduct_star_self_re_pos {n : Type*} [Fintype n] {v : n → ℂ} (hv : v ≠ 0) :
-    0 < (dotProduct (star v) v).re := by
-  classical
-  obtain ⟨i₀, hi₀⟩ := Function.ne_iff.mp hv
-  rw [Pi.zero_apply] at hi₀
-  rw [dotProduct_star_self_eq_ofReal, Complex.ofReal_re]
-  refine Finset.sum_pos' (fun i _ => Complex.normSq_nonneg _) ⟨i₀, Finset.mem_univ _, ?_⟩
-  exact (Complex.normSq_pos).mpr hi₀
-
 /-! ## The trial-state Rayleigh quotient -/
 
 /-- **The on-site interaction scales linearly in `U`**: `Ĥ_int(U) = U • Ĥ_int(1)`. -/

--- a/LatticeSystem/Math/ComplexVectorKernel.lean
+++ b/LatticeSystem/Math/ComplexVectorKernel.lean
@@ -46,6 +46,17 @@ theorem star_dotProduct_self_eq {n : Type*} [Fintype n] (v : n → ℂ) :
   refine Finset.sum_congr rfl (fun i _ => ?_)
   rw [Pi.star_apply, Complex.star_def, mul_comm, Complex.mul_conj]
 
+/-- For a nonzero vector `v`, the squared norm `(star v ⬝ᵥ v).re = ∑ ‖v_i‖²` is strictly
+positive. -/
+theorem dotProduct_star_self_re_pos {n : Type*} [Fintype n] {v : n → ℂ} (hv : v ≠ 0) :
+    0 < (star v ⬝ᵥ v).re := by
+  classical
+  obtain ⟨i₀, hi₀⟩ := Function.ne_iff.mp hv
+  rw [Pi.zero_apply] at hi₀
+  rw [star_dotProduct_self_eq, Complex.ofReal_re]
+  exact Finset.sum_pos' (fun i _ => Complex.normSq_nonneg _)
+    ⟨i₀, Finset.mem_univ _, Complex.normSq_pos.mpr hi₀⟩
+
 /-- The conjugated quadratic form `⟨v, Mᴴ M v⟩ = ‖M v‖²` is a non-negative real. -/
 theorem star_dotProduct_conjTranspose_mul_mulVec_eq {n : Type*} [Fintype n]
     (M : Matrix n n ℂ) (v : n → ℂ) :

--- a/LatticeSystem/Quantum/SpinS/LiebSchultzMattisProofCore.lean
+++ b/LatticeSystem/Quantum/SpinS/LiebSchultzMattisProofCore.lean
@@ -30,20 +30,6 @@ namespace LatticeSystem.Quantum
 open Matrix NormedSpace
 open scoped ComplexOrder
 
-/-- For a nonzero vector, the squared norm `⟨v, v⟩.re = Σ_i |v_i|²` is strictly positive. -/
-theorem dotProduct_star_self_re_pos {ι : Type*} [Fintype ι] {v : ι → ℂ} (hv : v ≠ 0) :
-    0 < (star v ⬝ᵥ v).re := by
-  classical
-  obtain ⟨i₀, hi₀⟩ := Function.ne_iff.mp hv
-  rw [Pi.zero_apply] at hi₀
-  have hsum : (star v ⬝ᵥ v) = ((∑ i, Complex.normSq (v i) : ℝ) : ℂ) := by
-    simp only [dotProduct, Pi.star_apply, RCLike.star_def]
-    push_cast
-    exact Finset.sum_congr rfl (fun i _ => (Complex.normSq_eq_conj_mul_self ..).symm)
-  rw [hsum, Complex.ofReal_re]
-  exact Finset.sum_pos' (fun i _ => Complex.normSq_nonneg _)
-    ⟨i₀, Finset.mem_univ _, Complex.normSq_pos.mpr hi₀⟩
-
 /-- Complex exponentials multiply by adding exponents (forward rewrite helper, `a b` explicit so the
 `Commute` witness is resolved inside the proof — avoids metavariable issues in `←` rewrites). -/
 theorem cexp_mul_cexp (a b : ℂ) :

--- a/LatticeSystem/Quantum/SpinS/Theorem23SublatticeCasimirSzBound.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23SublatticeCasimirSzBound.lean
@@ -26,14 +26,6 @@ open Matrix
 
 variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
-private theorem star_dotProduct_self_re_pos {n : Type*} [Fintype n]
-    {v : n → ℂ} (hv : v ≠ 0) : 0 < (star v ⬝ᵥ v).re := by
-  rw [star_dotProduct_self_eq, Complex.ofReal_re]
-  obtain ⟨i, hi⟩ := Function.ne_iff.mp hv
-  exact Finset.sum_pos' (fun j _ => Complex.normSq_nonneg _)
-    ⟨i, Finset.mem_univ i, lt_of_le_of_ne (Complex.normSq_nonneg _)
-      (Ne.symm (by simpa [Complex.normSq_eq_zero] using hi))⟩
-
 /-- **Sublattice Casimir dominates `S^3(S^3+1)`**: for a simultaneous eigenvector `v ≠ 0`
 of `(Ŝ_A)²` (eigenvalue `γ`) and `Ŝ_A^(3)` (eigenvalue `q`), `(q(q+1)).re ≤ γ.re`.  From
 `(Ŝ_A)² = Ŝ_A^- Ŝ_A^+ + Ŝ_A^(3)(Ŝ_A^(3)+1)` and `‖Ŝ_A^+ v‖² ≥ 0`. -/
@@ -68,7 +60,7 @@ theorem sublatticeSpinSquaredS_re_ge_sublatticeSpinSOp3_mul_succ (A : V → Bool
   set z : ℝ := ∑ i, Complex.normSq (v i) with hzdef
   set S : ℝ := ∑ i, Complex.normSq ((sublatticeSpinSOpPlus N A).mulVec v i) with hSdef
   have hz_pos : 0 < z := by
-    have := star_dotProduct_self_re_pos hv_ne
+    have := dotProduct_star_self_re_pos hv_ne
     rwa [star_dotProduct_self_eq, Complex.ofReal_re] at this
   have hS_nn : 0 ≤ S := Finset.sum_nonneg (fun i _ => Complex.normSq_nonneg _)
   have hre := congrArg Complex.re hquad
@@ -113,7 +105,7 @@ theorem sublatticeSpinSquaredS_re_ge_sublatticeSpinSOp3_mul_pred (A : V → Bool
   set z : ℝ := ∑ i, Complex.normSq (v i) with hzdef
   set S : ℝ := ∑ i, Complex.normSq ((sublatticeSpinSOpMinus N A).mulVec v i) with hSdef
   have hz_pos : 0 < z := by
-    have := star_dotProduct_self_re_pos hv_ne
+    have := dotProduct_star_self_re_pos hv_ne
     rwa [star_dotProduct_self_eq, Complex.ofReal_re] at this
   have hS_nn : 0 ≤ S := Finset.sum_nonneg (fun i _ => Complex.normSq_nonneg _)
   have hre := congrArg Complex.re hquad


### PR DESCRIPTION
## Summary

Deduplicate `dotProduct_star_self_re_pos` (strictly-positive self-inner-product real part) into the shared model-agnostic module `Math/ComplexVectorKernel.lean`, reusing its existing `star_dotProduct_self_eq`.

**Duplicate declaration violation** (tier2 High-1 refactoring, cf. `audit-tier2-2026-07-18.md`).

## Work

- [x] Common natural location = `Math/ComplexVectorKernel.lean` (already imported by both Fermion and Quantum trees; siblings of this exact lemma live there)
- [x] Define `dotProduct_star_self_re_pos` once there (reuses `star_dotProduct_self_eq`)
- [x] Remove the two flagged copies: `Fermion/.../HubbardImpossibilityLowUVariational.lean`, `Quantum/SpinS/LiebSchultzMattisProofCore.lean`
- [x] Remove a **third** identical private copy `star_dotProduct_self_re_pos` in `Quantum/SpinS/Theorem23SublatticeCasimirSzBound.lean` (surfaced by `audit_gate` V2); repoint its 2 local uses
- [x] All 14 call sites (both trees) resolve via parent-namespace lookup; no per-site import edits needed (import graph already reaches `ComplexVectorKernel`)
- [x] Zero-duplication confirmed via grep (definition in exactly 1 place)

## Verification

- `lake build` root: 4504 jobs, **warning/PANIC-free**
- `audit_gate.py` V1–V3: **pass** (no new decorative/duplicate declarations)
- `#print axioms` unchanged (std3 = propext/Classical.choice/Quot.sound) on representative downstream capstones from both trees: `lieb_schultz_mattis_affleck_lieb`, `hubbard_theorem_11_3`, `theorem_10_2_lieb_attractive_unique_singlet`
- No `sorry`/`admit`/`native_decide`; no docs/tex file-refs to the moved lemma

Refs #4718