### PR TITLE
refactor: remove unused many-body norm helpers — #5084

### DIFF
--- a/LatticeSystem/Quantum/SpinS/ManyBodyOperatorNorm.lean
+++ b/LatticeSystem/Quantum/SpinS/ManyBodyOperatorNorm.lean
@@ -79,23 +79,6 @@ theorem manyBodyOperatorNormS_mul_le (M₁ M₂ : ManyBodyOpS Λ N) :
     manyBodyOperatorNormS_eq_toEuclideanCLM, map_mul]
   exact norm_mul_le _ _
 
-/-- **Power submultiplicativity** of the many-body `L²` operator norm (for `n > 0`). -/
-theorem manyBodyOperatorNormS_pow_le (M : ManyBodyOpS Λ N) {n : ℕ} (hn : 0 < n) :
-    manyBodyOperatorNormS (M ^ n) ≤ manyBodyOperatorNormS M ^ n := by
-  rw [manyBodyOperatorNormS_eq_toEuclideanCLM, map_pow, manyBodyOperatorNormS_eq_toEuclideanCLM]
-  exact norm_pow_le' _ hn
-
-/-- **List-product submultiplicativity**: the norm of an ordered product is at most the product of
-the norms.  Used to bound `balancedOrderProductS`. -/
-theorem manyBodyOperatorNormS_list_prod_le (l : List (ManyBodyOpS Λ N)) :
-    manyBodyOperatorNormS l.prod ≤ (l.map manyBodyOperatorNormS).prod := by
-  induction l with
-  | nil => simp [manyBodyOperatorNormS_eq_toEuclideanCLM]
-  | cons a t ih =>
-    rw [List.prod_cons, List.map_cons, List.prod_cons]
-    refine le_trans (manyBodyOperatorNormS_mul_le a t.prod) ?_
-    exact mul_le_mul_of_nonneg_left ih (manyBodyOperatorNormS_nonneg a)
-
 /-- **Finite-sum triangle inequality** for the many-body `L²` operator norm. -/
 theorem manyBodyOperatorNormS_sum_le {ι : Type*} (s : Finset ι) (f : ι → ManyBodyOpS Λ N) :
     manyBodyOperatorNormS (∑ x ∈ s, f x) ≤ ∑ x ∈ s, manyBodyOperatorNormS (f x) := by

--- a/scripts/audit/capstones.txt
+++ b/scripts/audit/capstones.txt
@@ -6,15 +6,6 @@
 #         that the textual gate cannot see).
 # Add a name only after confirming the finding is a genuine false positive.
 
-# TEMPORARY move-only V1 false positives — tracker #5084, PR-1 #5085.
-# These public API endpoints already existed in OrderOperatorAlgebra.lean on main and
-# are moved byte-for-byte to ManyBodyOperatorNorm.lean. The diff-scoped gate sees the
-# new host as new declarations even though the reviewed API is unchanged. PR-2 MUST
-# disposition each declaration by consumer connection, deletion, or the minimal valid
-# relocation-aware gate fix, and MUST DELIST both entries before #5084 closes.
-manyBodyOperatorNormS_pow_le
-manyBodyOperatorNormS_list_prod_le
-
 # V2 false positive: 60-line truncation artifact. The two theorems below share a
 # long common hypothesis prefix (AnisotropicHeisenbergSpinSCaseIIBlockPFMin.lean
 # :361 and :446); the gate truncates the compared statement at 60 lines before


### PR DESCRIPTION
## Summary

PR-2 for #5084 removes two zero-reference many-body norm helpers:

- `manyBodyOperatorNormS_pow_le`;
- `manyBodyOperatorNormS_list_prod_le`.

It also DELISTs both names and removes their temporary move-only comment from
`scripts/audit/capstones.txt`.

The tracked diff is exactly two files and 26 deletions. No compatibility aliases,
consumer rewrites, audit-gate logic, public-document edits, or unrelated cleanup are
included.

## Disposition evidence

- Both declarations had zero source consumers.
- Neither declaration appeared in `README.md`, `docs/index.md`, or
  `tex/proof-guide.tex`.
- The stale `balancedOrderProductS` usage claim did not correspond to an actual
  consumer.
- Chapter 7 has zero diff.

Deletion and temporary-capstone DELIST are therefore the smallest valid disposition;
an artificial consumer or permanent audit exception is not introduced.

## Verification

- Targeted Lean elaboration passed.
- Full `lake build` passed across 4506 jobs with zero warnings.
- The surviving reviewed theorem endpoints remain std3 (`propext`,
  `Classical.choice`, `Quot.sound`).
- Chapter 7 diff check is empty.
- Independent pre-commit verification and review passed.
- The pre-push audit gate passed on commit `b205a242` with no new decorative or
  duplicate declarations.

Closes #5084
