### PR TITLE
De-privatise orderedProd_append and state_norm_pos — #5094

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AKLTStringOrderTransfer.lean
+++ b/LatticeSystem/Quantum/SpinS/AKLTStringOrderTransfer.lean
@@ -715,7 +715,7 @@ private theorem state_norm_exact (L : ℕ) :
 
 /-- The frozen periodic akltVBSState has a strictly positive squared norm once the
 ring contains at least two sites. -/
-private theorem state_norm_pos (L : ℕ) (hL : 2 ≤ L) :
+theorem state_norm_pos (L : ℕ) (hL : 2 ≤ L) :
     0 < vecNormSqRe (akltVBSState L) := by
   rw [state_norm_exact]
   have hfactor :

--- a/LatticeSystem/Quantum/SpinS/MPSTheorem76Algebra.lean
+++ b/LatticeSystem/Quantum/SpinS/MPSTheorem76Algebra.lean
@@ -33,7 +33,7 @@ private noncomputable def evalWords (A : MPSMatrices D N) (ℓ : ℕ) :
   Finsupp.linearCombination ℂ (wordEval A)
 
 /-- Ordered MPS products turn list concatenation into matrix multiplication. -/
-private theorem orderedProd_append (A : MPSMatrices D N)
+theorem orderedProd_append (A : MPSMatrices D N)
     (u v : List (Fin (N + 1))) :
     orderedProd A (u ++ v) = orderedProd A u * orderedProd A v := by
   induction u with


### PR DESCRIPTION
## Summary

De-privatise two AKLT MPS/VBS helper functions to make them publicly available for the Theorem 7.1 spectral-gap proof (Gate D5b–D5c, Stage 1 frustration-freeness). De-privatisation avoids duplication (forbidden by repo convention) and enables downstream reuse in the Knabe-path critical chain.

**Note**: This is a visibility change only. No files are moved, no code is reorganised, and all proofs remain unchanged.

## Changes

**Target helpers** (de-privatise, do not re-implement):
1. `orderedProd_append` in `LatticeSystem/Quantum/SpinS/MPSTheorem76Algebra.lean` (line 36) — needed by Knabe aggregation path
2. `state_norm_pos` in `LatticeSystem/Quantum/SpinS/AKLTStringOrderTransfer.lean` (line 718) — needed by Knabe aggregation path

**Optional, to be determined during Stage 1 implementation**:
- `state_norm_exact` (line 698 of same file) — include only if Stage 1 proof requires it; do not over-generalise

**Implementation**:
- Change `private` to `public` (or equivalent visibility) for targets 1 and 2.
- Statement and proof unchanged (visibility update only).

**docs/index.md and TeX: no update required**. Both helpers are already in the per-decl file refs columns; they are not book-facing capstone declarations and do not appear in the docs/index.md row lists. Adding them to index rows would require updating capstone classification criteria (currently: book-facing theorem/lemma + published numerics or proof strategy). Helpers satisfy neither criterion, so docs/index.md and TeX are left unchanged per backward-chaining discipline.

## Test Plan

- [x] Build passes (no new errors, warnings, sorry/admit).
- [x] De-privatised helpers remain callable from downstream modules.
- [x] Codex review (mandatory for production changes).

## Review Notes

This refactor is authorised per CLAUDE.local.md (Theorem 7.1 frustration-freeness is on critical path; de-privatisation avoids duplication, forbidden by convention). No merge without codex verdict.

Refs #5094

🤖 Generated with [Claude Code](https://claude.com/claude-code)
