### PR TITLE
Remove unnecessary imports found by `lake exe shake` (50 modules, 60 imports)

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/FermionTotalSpinCasimirCharges.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/FermionTotalSpinCasimirCharges.lean
@@ -1,7 +1,6 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.WeakNagaokaTheoremCore
 import LatticeSystem.Fermion.JordanWigner.Hubbard.SpinTotHermitian
 import LatticeSystem.Fermion.JordanWigner.Hubbard.SpinChargeCommutation
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TJFillingSpinCompress
 import LatticeSystem.Fermion.JordanWigner.Hubbard.ChargesCore
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandMultiplet
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/GeneralBasisHN.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/GeneralBasisHN.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandFilling
 import LatticeSystem.Fermion.JordanWigner.Hubbard.GeneralFlatBandOccBasis
-import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
 
 /-!
 # General basis of the `N`-electron space `H_N` (Tasaki Lemma 9.4)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreSpan.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/HardcoreSpan.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.HardcoreBasis
-import LatticeSystem.Fermion.JordanWigner.Hubbard.HopConfig
 
 /-!
 # Span of the one-hole hard-core sector by the basis states

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractiveKineticHopEntry.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractiveKineticHopEntry.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractiveBlockKineticMatrix
 import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractiveHopAction
 import LatticeSystem.Fermion.JordanWigner.HopBasisVec
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractivePosSemidefGround.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/LiebAttractivePosSemidefGround.lean
@@ -5,7 +5,6 @@ import LatticeSystem.Fermion.JordanWigner.Hubbard.LiebAttractiveEnergyReconcile
 import LatticeSystem.Quantum.SpinS.HermitianVariationalLowerBound
 import LatticeSystem.Quantum.SpinS.HermitianVariationalEquality
 import LatticeSystem.Quantum.SpinS.HermitianMinEigenvalueEigenvector
-import LatticeSystem.Fermion.JordanWigner.Hubbard.HubbardImpossibilityLowUVariational
 
 /-!
 # A positive-semidefinite-`W` ground state (Tasaki §10.2.4)

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/MetallicFerroModel.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/MetallicFerroModel.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiFlatBandModel
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJModel
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TJMaximalSpinUnified
 

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/NagaokaConnectivityClassification.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/NagaokaConnectivityClassification.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Fermion.JordanWigner.Hubbard.NagaokaConnectivity
 import LatticeSystem.Fermion.JordanWigner.Hubbard.NagaokaStateQuiver
 
 /-!

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiFlatBandEnergyTower.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiFlatBandEnergyTower.lean
@@ -1,7 +1,5 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiFlatBandZeroEnergy
-import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiFlatBandMultiplet
 import LatticeSystem.Fermion.JordanWigner.Hubbard.EffectiveHamiltonianSpinSymmetry
-import LatticeSystem.Fermion.JordanWigner.Hubbard.SpinTotHermitian
 
 /-!
 # Tasaki §11.3.1: flat-band SU(2) lowering symmetry and the energy tower

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiNonsingularFerro.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/TasakiNonsingularFerro.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Fermion.JordanWigner.Hubbard.TasakiFlatBandModel
-import LatticeSystem.Fermion.JordanWigner.Hubbard.SectorMinEnergy
 
 /-!
 # Tasaki §11.4.3: ferromagnetism in the non-singular Hubbard model (Theorem 11.20)

--- a/LatticeSystem/Fermion/JordanWigner/String.lean
+++ b/LatticeSystem/Fermion/JordanWigner/String.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.ManyBody
 import LatticeSystem.Quantum.Pauli
-import LatticeSystem.Fermion.Mode
 
 /-!
 # Jordan–Wigner string (Tasaki §2 / standard JW mapping)

--- a/LatticeSystem/Math/CStarAlgebra/GNS.lean
+++ b/LatticeSystem/Math/CStarAlgebra/GNS.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Math.CStarAlgebra.State
 import Mathlib.Analysis.InnerProductSpace.Adjoint
-import Mathlib.Analysis.CStarAlgebra.GelfandNaimarkSegal
 
 /-!
 # Tasaki Appendix A.7: the GNS construction (Theorem A.28)

--- a/LatticeSystem/Math/PosSemidef/Kernel.lean
+++ b/LatticeSystem/Math/PosSemidef/Kernel.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Math.RayleighPosSemidefKernel
-import LatticeSystem.Math.PosSemidef.Basics
 
 /-!
 # Tasaki Appendix A.2.3: zeros of the energy form are kernel vectors (Lemma A.11)

--- a/LatticeSystem/Math/RealForm/AntilinearFixedFinrank.lean
+++ b/LatticeSystem/Math/RealForm/AntilinearFixedFinrank.lean
@@ -1,7 +1,5 @@
 import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.LinearAlgebra.Dimension.Finite
-import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
-import Mathlib.LinearAlgebra.BilinearForm.Basic
 import Mathlib.LinearAlgebra.Complex.Module
 import Mathlib.LinearAlgebra.Complex.FiniteDimensional
 

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpinCore.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpinCore.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.TotalSpin
 import LatticeSystem.Quantum.TotalSpin.Casimir
-import LatticeSystem.Quantum.MagnetizationSubspaceCore
 
 set_option linter.unusedSectionVars false
 set_option linter.unusedSimpArgs false

--- a/LatticeSystem/Quantum/SpinS/AKLTMatrixProduct.lean
+++ b/LatticeSystem/Quantum/SpinS/AKLTMatrixProduct.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.MPSTheorem75
 import LatticeSystem.Quantum.SpinS.MPSTheorem76Unitary
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/AllAlignedStateCore.lean
+++ b/LatticeSystem/Quantum/SpinS/AllAlignedStateCore.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Quantum.SpinS.Heisenberg
-import LatticeSystem.Quantum.SpinS.MultiSiteCasimir
 import LatticeSystem.Quantum.SpinS.Magnetization
 import LatticeSystem.Quantum.SpinS.MultiSiteDot
 import LatticeSystem.Quantum.SpinS.LadderBoundary

--- a/LatticeSystem/Quantum/SpinS/AnisotropicEigenspaceSectorFinrankEq.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicEigenspaceSectorFinrankEq.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorEmbeddingLift
 import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergMagSectorInverseLift
-import LatticeSystem.Quantum.SpinS.MagSectorLinearEquiv
 
 /-!
 # Anisotropic sector matrix eigenspace and full Hilbert eigenspace finrank transfer

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedGSSetZeroMem.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergBalancedGSSetZeroMem.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergBalancedGSSetClosed
-import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergFullMinLeSectorMin
 
 /-!
 # `0 ∈ balancedGSSet` from the strict-GS axiom at `(1, 0)`

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfLambdaOneBoundary.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfLambdaOneBoundary.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergReduction
 import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergFullMinEigenvalueContinuous
 import LatticeSystem.Quantum.SpinS.Theorem24SU2GlobalUniquenessFromMLM
 import LatticeSystem.Quantum.SpinS.Theorem24ZeroMagnetizationFromUniqueness

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIStrictGapBridge.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIStrictGapBridge.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSpinSCaseIIConditionalBridge
 import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSpinSTargetFromStrictGap
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSDNonnegBoundaryCore.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSDNonnegBoundaryCore.lean
@@ -2,7 +2,6 @@ import LatticeSystem.Quantum.SpinS.AxisSwapUnitarySSpinS
 import LatticeSystem.Quantum.SpinS.BareSubmatrixBoundAtMin
 import LatticeSystem.Quantum.SpinS.DressedAxisSwapBondParityBlockIrreducibleDNonneg
 import LatticeSystem.Quantum.SpinS.DressedBareSubmatrixMinEqPFStructural
-import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSpinSMLMEndpoint
 /-!
 # General spin-S `D >= 0` boundary for the parity-block capstone — core lemmas
 

--- a/LatticeSystem/Quantum/SpinS/AnisotropicSectorPFAtMin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicSectorPFAtMin.lean
@@ -2,7 +2,6 @@ import LatticeSystem.Quantum.SpinS.DressedAnisotropicMatrixOnMagSector
 import LatticeSystem.Math.HermitianMinEqOfShiftPF
 import LatticeSystem.Quantum.SpinS.MatrixSimilaritySpectrum
 import LatticeSystem.Quantum.SpinS.HermitianMinSimilarInvariance
-import LatticeSystem.Quantum.SpinS.ParityBlockDressedFinrank
 
 /-!
 # Anisotropic sector Perron--Frobenius bound at the Hermitian minimum

--- a/LatticeSystem/Quantum/SpinS/BareSubmatrixBoundAtMin.lean
+++ b/LatticeSystem/Quantum/SpinS/BareSubmatrixBoundAtMin.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.BareSubmatrixPFFinrank
 import LatticeSystem.Quantum.SpinS.ParityBlockSubmatrixHermitian
 import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
 

--- a/LatticeSystem/Quantum/SpinS/BipartiteToyMinEnergy.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteToyMinEnergy.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Quantum.SpinS.ToyHamiltonianJointEigenspace
-import LatticeSystem.Quantum.SpinS.SublatticeCasimirNeel
 
 /-!
 # Predicted toy-Hamiltonian ground-state subspace and minimum energy

--- a/LatticeSystem/Quantum/SpinS/BipartiteToyMinEnergySymmReViaImbalanceNormSq.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteToyMinEnergySymmReViaImbalanceNormSq.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Quantum.SpinS.BipartiteToyMinEnergySymmViaImbalance
-import LatticeSystem.Quantum.SpinS.BipartiteImbalanceWeightAbs
 
 /-!
 # Symm-energy real part via `‖bipartiteImbalanceWeight‖²`

--- a/LatticeSystem/Quantum/SpinS/BoseEinsteinCondensateCoherentSecondMomentConcentration.lean
+++ b/LatticeSystem/Quantum/SpinS/BoseEinsteinCondensateCoherentSecondMomentConcentration.lean
@@ -1,7 +1,6 @@
 import LatticeSystem.Quantum.SpinS.BoseEinsteinCondensateCoherentSecondMoment
 import LatticeSystem.Quantum.SpinS.BoseEinsteinCondensateCoherentMoment
 import LatticeSystem.Quantum.SpinS.BoseEinsteinCondensateCoherentConcentration
-import LatticeSystem.Quantum.SpinS.AndersonTowerCartWordReBand
 import LatticeSystem.Quantum.SpinS.AndersonTowerEnergyBoundSU2
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/ComplexDressedSubmatrixPFEigenvector.lean
+++ b/LatticeSystem/Quantum/SpinS/ComplexDressedSubmatrixPFEigenvector.lean
@@ -1,7 +1,6 @@
 import LatticeSystem.Quantum.SpinS.DressedSubmatrixPFEigenvectorStructural
 import LatticeSystem.Quantum.SpinS.MagConfig
 import LatticeSystem.Quantum.SpinS.ComplexDressedParityBlockFinrank
-import LatticeSystem.Quantum.SpinS.SubmatrixMinEigenvalue
 
 /-!
 # Existence of complex PF eigenvector for the (complex) dressed-Ĥ' submatrix

--- a/LatticeSystem/Quantum/SpinS/EigenspaceSectorFinrankEq.lean
+++ b/LatticeSystem/Quantum/SpinS/EigenspaceSectorFinrankEq.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.SpinS.SectorEmbeddingComplexEigval
 import LatticeSystem.Quantum.SpinS.SectorRestrictionComplexEigval
-import LatticeSystem.Quantum.SpinS.MagSectorLinearEquiv
 
 /-!
 # Sector matrix eigenspace and full Hilbert eigenspace ⊓ sector subspace: finrank equality

--- a/LatticeSystem/Quantum/SpinS/HeisenbergCore.lean
+++ b/LatticeSystem/Quantum/SpinS/HeisenbergCore.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Quantum.SpinS.Magnetization
-import LatticeSystem.Quantum.SpinS.MultiSiteDotOffDiag
 import LatticeSystem.Quantum.SpinS.MultiSiteDot
 import LatticeSystem.Quantum.SpinS.MultiSiteDotComm
 import LatticeSystem.Quantum.SpinS.TotalSpin

--- a/LatticeSystem/Quantum/SpinS/HeisenbergSpinSOp3Commutator.lean
+++ b/LatticeSystem/Quantum/SpinS/HeisenbergSpinSOp3Commutator.lean
@@ -8,7 +8,6 @@ Combined with the per-bond commutator case analysis (left/right endpoint, off-bo
 spin-current divergence `[Ĥ, Ŝ_z^{(3)}]` to the two bonds incident to `z`, the quantity entering the
 double commutator of the infrared / f-sum-rule bound.
 -/
-import LatticeSystem.Quantum.SpinS.SingleBondSpinSOp3Commutator
 import LatticeSystem.Quantum.SpinS.HeisenbergCore
 
 namespace LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/LadderBoundaryAnnihilation.lean
+++ b/LatticeSystem/Quantum/SpinS/LadderBoundaryAnnihilation.lean
@@ -1,6 +1,4 @@
-import LatticeSystem.Quantum.SpinS.IterateInductiveNonvanishing
 import LatticeSystem.Quantum.SpinS.AllAlignedStateMagShift
-import LatticeSystem.Quantum.SpinS.MagnetizationDirectSum
 
 /-!
 # Boundary annihilation of the saturated-ferromagnet ladder

--- a/LatticeSystem/Quantum/SpinS/LiebSchultzMattisGeneral.lean
+++ b/LatticeSystem/Quantum/SpinS/LiebSchultzMattisGeneral.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.LiebSchultzMattis
 import LatticeSystem.Quantum.SpinS.ManyBodyOperatorNorm
 import LatticeSystem.Quantum.SpinS.RingDistance
 

--- a/LatticeSystem/Quantum/SpinS/LiebSchultzMattisProofCore.lean
+++ b/LatticeSystem/Quantum/SpinS/LiebSchultzMattisProofCore.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.SpinS.AndersonTower
 import LatticeSystem.Quantum.SpinS.HermitianVariationalLowerBound
-import LatticeSystem.Quantum.SpinS.HermitianMinEigenvalueEigenvector
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds
 import Mathlib.LinearAlgebra.Matrix.PosDef
 import Mathlib.Analysis.Complex.Order

--- a/LatticeSystem/Quantum/SpinS/MagConfig.lean
+++ b/LatticeSystem/Quantum/SpinS/MagConfig.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.SpinS.Magnetization
 import LatticeSystem.Quantum.SpinS.RaiseLower
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 import Mathlib.Combinatorics.SimpleGraph.Basic
 
 set_option linter.unusedSectionVars false

--- a/LatticeSystem/Quantum/SpinS/OrderOperatorAlgebra.lean
+++ b/LatticeSystem/Quantum/SpinS/OrderOperatorAlgebra.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Math.MatrixAnalysis.HermitianExpUnitary
 import LatticeSystem.Quantum.SpinS.ManyBodyOperatorNorm
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/ParityReachCanonicalTransfer.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachCanonicalTransfer.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.ParityReachConcentrateAB
 import LatticeSystem.Quantum.SpinS.ParityReachTransferIter
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/ParityReachableNoParityBond.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableNoParityBond.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.ParityReachableMatrixPow
 import LatticeSystem.Quantum.SpinS.ParityReachableSymm
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/ParityReachableNoSingleIon.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableNoSingleIon.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.ParityReachableMatrixPow
 import LatticeSystem.Quantum.SpinS.ParityReachableSymm
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
+++ b/LatticeSystem/Quantum/SpinS/ParityReachableWithinSector.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Quantum.SpinS.ParityReachable
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
 
 set_option linter.unusedSectionVars false
 set_option linter.unusedSimpArgs false

--- a/LatticeSystem/Quantum/SpinS/RaiseLowerMatrixPow.lean
+++ b/LatticeSystem/Quantum/SpinS/RaiseLowerMatrixPow.lean
@@ -1,5 +1,4 @@
 import LatticeSystem.Quantum.SpinS.RaiseLower
-import LatticeSystem.Quantum.MarshallLiebMattis.MatrixPowPath
 
 /-!
 # Matrix-power positivity from raise/lower reachability

--- a/LatticeSystem/Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean
+++ b/LatticeSystem/Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean
@@ -1,6 +1,3 @@
-import LatticeSystem.Quantum.SpinS.RayleighOnDiagonal
-import LatticeSystem.Quantum.SpinS.RayleighUnitarySimilarity
-import LatticeSystem.Quantum.SpinS.RayleighOnVecBddBelow
 import Mathlib.Analysis.Matrix.Spectrum
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/RingReflectionCauchySchwarzSqrt.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflectionCauchySchwarzSqrt.lean
@@ -10,7 +10,6 @@ valid for a reflection-invariant reflection-positive trace weight `M` and left-s
 the Dyson–Lieb–Simon spreading argument toward Gaussian domination.
 -/
 import LatticeSystem.Quantum.SpinS.RingReflectionChessboard
-import Mathlib.Analysis.SpecialFunctions.Sqrt
 
 namespace LatticeSystem.Quantum
 

--- a/LatticeSystem/Quantum/SpinS/RingReflectionChessboardTransport.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflectionChessboardTransport.lean
@@ -9,7 +9,6 @@ is the Marshall gauge relative to the *shifted* reflection plane.  Combined with
 covariance of `θ`, this carries the single-axis chessboard to every bond of the ring, the step
 needed to assemble the Dyson–Lieb–Simon Gaussian domination from the fixed-plane estimate.
 -/
-import LatticeSystem.Quantum.SpinS.RingReflectionGibbsChessboard
 import LatticeSystem.Quantum.SpinS.RingTranslationGibbs
 
 namespace LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/RingReflectionKineticConeRep.lean
+++ b/LatticeSystem/Quantum/SpinS/RingReflectionKineticConeRep.lean
@@ -9,7 +9,6 @@ a single cone generator (`θ(L)·L`, `L = exp X` left-supported), so the kinetic
 **cone-representable** (`coneRep_exp_add`).  Combined with the RP-weight cone, this is the kinetic
 building block that the Trotter expansion of `e^{-βH}` consumes.
 -/
-import LatticeSystem.Quantum.SpinS.RingReflectionRPWeightCone
 import LatticeSystem.Quantum.SpinS.RingReflectionExpSupport
 import Mathlib.Analysis.Matrix.Normed
 

--- a/LatticeSystem/Quantum/SpinS/SingleClusterHamiltonianMinCore.lean
+++ b/LatticeSystem/Quantum/SpinS/SingleClusterHamiltonianMinCore.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.SpinS.HermitianMinLeOfEigenvector
 import LatticeSystem.Quantum.SpinS.SingleClusterHamiltonianEnergy
-import LatticeSystem.Quantum.SpinS.SingleClusterCoupledSectorEnergy
 import LatticeSystem.Quantum.SpinS.SingleClusterLeafCasimirBound
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelCore.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeCasimirNeelCore.lean
@@ -2,13 +2,7 @@ import LatticeSystem.Quantum.SpinS.SublatticeSpinDot
 import LatticeSystem.Quantum.SpinS.SublatticeSpinLadderDef
 import LatticeSystem.Quantum.SpinS.MultiSiteMatrixElement
 import LatticeSystem.Quantum.SpinS.Magnetization
-import LatticeSystem.Quantum.SpinS.ToyHamiltonianCasimir
 import LatticeSystem.Quantum.SpinS.BasisVecSOrthonormal
-import LatticeSystem.Quantum.SpinS.MagConfig
-import LatticeSystem.Quantum.SpinS.SingleSiteCasimirExpectation
-import LatticeSystem.Quantum.SpinS.BipartiteCompleteGraphCore
-import LatticeSystem.Quantum.SpinS.AllAlignedStateOrthogonal
-import LatticeSystem.Quantum.SpinS.SingleSiteTransverseMeanZero
 
 set_option linter.unusedSectionVars false
 set_option linter.unusedSimpArgs false

--- a/LatticeSystem/Quantum/SpinS/Theorem23GlobalMinimality.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23GlobalMinimality.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.SpinS.MagSectorEmbedding
 import LatticeSystem.Quantum.SpinS.Theorem23Sectors
-import LatticeSystem.Quantum.SpinS.Theorem23PFConstancyCasimir
 import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSectorMarshall
 import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSectorEigenvalueUnique
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23Predicted.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23Predicted.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.Theorem23PredictedEndpoint
 import LatticeSystem.Quantum.SpinS.Theorem23LocalRaisedSiteSum
 
 

--- a/LatticeSystem/Quantum/SpinS/Theorem23StructuralComplexSectorEigenvec.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23StructuralComplexSectorEigenvec.lean
@@ -1,4 +1,3 @@
-import LatticeSystem.Quantum.SpinS.DressedMatrixOnMagSectorEigenvalueUnique
 import LatticeSystem.Quantum.SpinS.Theorem23StructuralMagSectorPF
 
 /-!

--- a/LatticeSystem/Quantum/SpinS/Theorem23TotalLoweringNonvanishing.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23TotalLoweringNonvanishing.lean
@@ -1,6 +1,5 @@
 import LatticeSystem.Quantum.SpinS.CasimirRearrangement
 import LatticeSystem.Quantum.SpinS.TotalSpin
-import LatticeSystem.Quantum.SpinS.Magnetization
 import LatticeSystem.Math.ComplexVectorKernel
 
 /-!


### PR DESCRIPTION
## Summary

Remove unused imports from **50 modules (60 import lines)**, as reported by `lake exe shake`
(tier2 audit 2026-07-21, `.self-local/shake-out.txt`). Deletion-only: **0 insertions**, every
changed line matches `^-(public )?import [A-Za-z0-9_.]+$`. No declaration, proof, doc comment
or `set_option` is touched.

Refs #5098 (build-speed refactoring coordination)
Refs #4980 (tier2 audit report)

## Why this subset is safe

Removing an import from an upstream module **can** break a downstream module that was relying on
it transitively — that is precisely what shake's `instead` clause reports
(`Shake/Main.lean:374-377`: `import X in Y` means module `Y` must gain `import X`). So "no imports
were added" is *not* by itself a safety argument. Safety here rests on two checks:

1. **Scope restriction.** Only shake blocks carrying neither an `add` nor an `instead` clause are
   applied — i.e. the ones shake itself determined need no companion edit anywhere else.
2. **Full root build.** `lake build LatticeSystem` completes with **0 errors and 0 warnings**.

## Isolation (orphan) check

A deletion can also *silently orphan* a module: if the removed import was that module's only
in-repo reference, the module drops out of `defaultTargets = ["LatticeSystem", "LatticeSystem.Tests"]`
(declared without globs), so it is no longer compiled — leaving zero-warning, `#print axioms` and
sorry-absence monitoring — **while the build still succeeds**. `audit_gate --diff main` does not
detect this.

Reachability from both build roots was therefore computed explicitly, before and after:

| | unreachable modules (from `LatticeSystem` + `LatticeSystem.Tests`) |
|---|---|
| `main` | 0 |
| this branch | **0** |

One candidate removal was found to violate this and **was excluded**:
`AnisotropicHeisenbergSpinHalfObligation2AxiomaticV3Hne.lean` keeps its import of
`AnisotropicHeisenbergCrossingDualSectorGroundExplicit`, which is the only in-repo reference to
that module and, transitively, to `AnisotropicHeisenbergParametricGapCrossingGeneric`. Both carry
Tasaki §2.5 Theorem 2.4 obligation (2) results listed in `docs/index.md:2354/2357`. The job count
confirms it: 4400 jobs with the removal vs **4402** without it.

Wiring root-unreachable modules into a build root is the right long-term fix, but it is the same
issue as the **21 pre-existing root-unreachable production modules (3,251 lines)** found by the
tier2 survey, so it is handled in a dedicated PR under #5098. This PR stays purely mechanical.

## Scope: correction to the tier2 survey's "79 pure-removal modules"

Re-parsing the raw shake output shows that figure counted every block **without an `add` line**
(**83 modules / 107 imports**), which includes **32 blocks carrying an `instead` clause**. Those
are companion-edit cases, not deletion-only. `Quantum/ManyBody.lean` → `HermitianSum`, named as the
survey's most important item, is exactly such a case (`instead: ... in MultiSiteDot` and
`... in GibbsState`) and is **not** part of this PR.

| | modules | import lines |
|---|---|---|
| **applied here** (`remove` only) | **50** | **60** |
| deferred: `remove` + `instead` (needs companion imports) | 32 | 46 |
| deferred: `remove` + `add` | 284 | 371 |
| excluded: would orphan a module | 1 | 1 |

Largest single removals: `Quantum/SpinS/SublatticeCasimirNeelCore.lean` (6),
`Quantum/SpinS/RayleighOnVecHermitianLowerBound.lean` (3),
`Math/RealForm/AntilinearFixedFinrank.lean` / `Quantum/SpinS/LadderBoundaryAnnihilation.lean` /
`Hubbard/TasakiFlatBandEnergyTower.lean` (2 each); the rest remove 1 each.

## Measured effect

Repo-internal reverse-dependency (fan-out) sum over `LatticeSystem.*`:

| metric | before | after | delta |
|---|---|---|---|
| fan-out sum, this PR (50 modules) | 177923 | 173619 | **−2.42%** |
| fan-out sum, full no-add set (83 modules, reference only) | 177923 | 152473 | −14.30% |

The −14.30% reproduces the survey's −14.2%, confirming the classification discrepancy above.

**Clean build is essentially unchanged** (root transitive closure 4343 → ~4318, −0.6%). Per tier2,
clean-build cost is elaboration-dominated (65–87%) and the root closure is 61% Mathlib. **This is an
incremental / CI differential-build improvement, not a clean-build speedup** — stated plainly so the
PR is not credited with a wall-clock gain it does not deliver.

## Verification

- `LEAN_NUM_THREADS=2 lake build LatticeSystem` → `Build completed successfully (4402 jobs)`, exit 0.
- `grep -E ': (error|warning):|^error:|^warning:'` over the build log → **0**.
  `PANIC|backtrace|appArg!` → **0**.
- `python3 scripts/audit_gate.py --diff main` → OK (no new decorative/duplicate declarations); also
  re-run and passed by the `.githooks/pre-push` hook.
- Orphan check: 0 unreachable modules, same as `main` (see above).
- `#print axioms` unchanged on capstones: `aklt_string_order_7_2_8`, `mps_theorem_7_5`,
  `mps_theorem_7_6`, `tasaki_lemma_6_4_general_trial_energy_bound`,
  `theorem_10_2_lieb_attractive_unique_singlet`, `tasaki_5_2_bec_tower_half_filling` → standard 3;
  `tanakaSphereAverage_groundState` → standard 3 + the pre-existing documented
  `orderSqMoment_ratio_le_mStarSq`.
- `docs/index.md` / `tex/proof-guide.tex` unchanged: no declaration is added, removed or moved, so
  all per-decl file references stay accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
