### PR TITLE
refactor: rename 2 dressed ion-parity theorems, drop longLine escapes — #5104 PR-D

### DIFF
--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapIonParityBlockIrreducibleLambdaOne.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapIonParityBlockIrreducibleLambdaOne.lean
@@ -22,12 +22,11 @@ open Matrix
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-set_option linter.style.longLine false in
 /-- **Ion-only shifted parity-block irreducibility under reachability totality**.
 If every two distinct configurations in a parity block are connected by
 ion-only parity moves, then the shifted parity-block matrix is irreducible at
 `lambda = 1`, `D > 0`. -/
-theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_ionParityReachable_total_lambda_one
+theorem shiftedDressedReMatParity_irred_of_ionParityReach_total_lam1
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)
@@ -57,7 +56,7 @@ theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_ionParit
     exact shiftedDressedAxisSwappedReMatrixOnParityBlock_diag_pos A J 1 D N p (hc_strict σ'.1)
   · have hreach := hreach_total σ' σ hsig
     obtain ⟨k, hk⟩ :=
-      shiftedDressedAxisSwappedReMatrixOnParityBlock_pow_apply_pos_of_ionParityReachable_lambda_one
+      shiftedDressedReMatParity_pow_apply_pos_of_ionParityReach_lam1
         A hJim hJnn hJpos hJself hJbip hDim hDpos hc_le p hreach
     have hk_pos : 0 < k := by
       rcases Nat.eq_zero_or_pos k with hk0 | hkp
@@ -67,7 +66,6 @@ theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_ionParit
       · exact hkp
     exact ⟨k, hk_pos, hk⟩
 
-set_option linter.style.longLine false in
 /-- **Ion-only shifted parity-block irreducibility at `lambda = 1`, `D > 0`**.
 The ion-only reachability totality theorem discharges the conditional totality
 hypothesis on the bipartite complete graph. -/
@@ -85,7 +83,7 @@ theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_lambda_one_
     (p : ℕ)
     [Nonempty (parityConfigS Λ N p)] :
     (shiftedDressedAxisSwappedReMatrixOnParityBlock A J 1 D N c p).IsIrreducible := by
-  refine shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_ionParityReachable_total_lambda_one
+  refine shiftedDressedReMatParity_irred_of_ionParityReach_total_lam1
     A hJim hJnn hJpos hJself hJbip hDim hDpos hc_strict p ?_
   intro σ' σ _hne
   refine ionParityReachableS_total A hA_ne hB_ne hN ?_

--- a/LatticeSystem/Quantum/SpinS/DressedAxisSwapIonParityLambdaOne.lean
+++ b/LatticeSystem/Quantum/SpinS/DressedAxisSwapIonParityLambdaOne.lean
@@ -42,12 +42,11 @@ theorem shiftedDressedAxisSwappedReMatrix_apply_pos_of_ionParityStepS_lambda_one
   · exact shiftedDressedAxisSwappedReMatrix_apply_pos_of_singleIonStepS
       A hJself hDim hDpos c hSI
 
-set_option linter.style.longLine false in
 /-- **Block matrix power positivity from ion-only parity reachability at
 `lambda = 1`, `D > 0`**.  For any ion-only reachable pair of parity-block
 configurations, some power of the shifted parity-block submatrix is strictly
 positive at that pair. -/
-theorem shiftedDressedAxisSwappedReMatrixOnParityBlock_pow_apply_pos_of_ionParityReachable_lambda_one
+theorem shiftedDressedReMatParity_pow_apply_pos_of_ionParityReach_lam1
     (A : Λ → Bool) {J : Λ → Λ → ℂ}
     (hJim : ∀ x y, (J x y).im = 0) (hJnn : ∀ x y, 0 ≤ (J x y).re)
     (hJpos : ∀ x y, (bipartiteCompleteGraphOf A).Adj x y → 0 < (J x y).re)


### PR DESCRIPTION
## Summary
Refs #5104

**PR-D (final)**: Rename 2 dressed ion-parity theorems in λ=1 blocks, drop 3 longLine escapes.

- **Rename 2 theorems** (shortening 99 → 60 chars, 93 → 62 chars):
  1. `shiftedDressedAxisSwappedReMatrixOnParityBlock_isIrreducible_of_ionParityReachable_total_lambda_one` → `shiftedDressedReMatParity_irred_of_ionParityReach_total_lam1`
  2. `shiftedDressedAxisSwappedReMatrixOnParityBlock_pow_apply_pos_of_ionParityReachable_lambda_one` → `shiftedDressedReMatParity_pow_apply_pos_of_ionParityReach_lam1`
- **Suppress 3 longLine escapes** (removed `set_option linter.style.longLine false in`).
- Base function `shiftedDressedAxisSwappedReMatrixOnParityBlock` unchanged (identifier-boundary replacement used).
- **Root build**: 4517 jobs, 0 warnings/PANIC, standard axiom triple only.
- **Renaming arc complete**: 38/38 names (PR-A 7 + PR-B 13 + PR-C 16 + PR-D 2).

**Changes**: +4, −7 (2 files).