### PR TITLE
refactor: remove 47 dead longLine suppressions — #5104 PR-E1

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfBalancedGSFromMLM.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfBalancedGSFromMLM.lean
@@ -22,7 +22,6 @@ open Matrix
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 
-set_option linter.style.longLine false in
 /-- **Spin-1/2 strict gap for all non-balanced sectors from Theorem 2.3 PF**:
 the PR #4028 strict-gap theorem, repackaged with an arbitrary non-empty sector
 `M` instead of a fixed `M_orig`. -/
@@ -72,7 +71,6 @@ theorem spinHalf_anisotropicHeisenbergS_strict_gap_all_M_of_MLM_casimir_ladder_t
     M_balanced M h_balanced hM_ne h_centered_nonzero
     hlam'_lb hlam'_ub hD'
 
-set_option linter.style.longLine false in
 /-- **Spin-1/2 balanced sector is the target ground sector from Theorem 2.3 PF**:
 the balanced sector minimum at `(lambda', D')` equals the full anisotropic
 Hamiltonian ground energy. -/

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfCaseII.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfCaseII.lean
@@ -25,7 +25,6 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-! ## Spin-1/2 target wrappers -/
 
-set_option linter.style.longLine false in
 /-- Spin-`1/2` strict case-(ii) target ground eigenspace `finrank <= 1` from
 the MLM/Casimir/Theorem 2.3 endpoint. -/
 theorem spinHalf_anisotropicHeisenbergS_case_ii_target_finrank_le_one_of_MLM_casimir_ladder_t23_pf

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfCaseIICore.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfCaseIICore.lean
@@ -45,7 +45,6 @@ theorem anisotropicHeisenbergParametricPath_eq_zero_of_fst_eq_one_of_one_lt
 
 /-! ## `N = 1` non-corner path-global input -/
 
-set_option linter.style.longLine false in
 /-- Strict case-(ii) non-corner parity-block PF/min callback with only
 `1 <= N`.  The `lambda = 1`, `D < 0` branch is impossible because the target
 satisfies `1 < lambda`, so the proof never needs the ion-only totality
@@ -128,7 +127,6 @@ theorem axisSwappedParityBlockPFMinAt_of_total_reachability_noncorner_lambda_gt_
       linarith
     · exact False.elim (hnot_corner ⟨hlam_path_eq.symm, hD_path_eq⟩)
 
-set_option linter.style.longLine false in
 /-- Non-corner strict case-(ii) parity-block full-min bound with only
 `1 <= N`, using the strict-target path geometry to avoid the ion-only branch. -/
 theorem axisSwappedSubmatrix_full_min_finrank_le_one_of_total_reachability_noncorner_lambda_gt_one
@@ -170,7 +168,6 @@ theorem axisSwappedSubmatrix_full_min_finrank_le_one_of_total_reachability_nonco
     (D := (anisotropicHeisenbergParametricPath lam D t).2)
     p hp ν hν_bound hν_eq_min
 
-set_option linter.style.longLine false in
 /-- Path-global full `finrank <= 2` for strict spin-`S` case-(ii) targets
 from reachability available under `1 <= N`, plus the SU(2) corner callback. -/
 theorem caseII_path_global_finrank_bound_of_total_reachability_and_corner_lambda_gt_one
@@ -232,7 +229,6 @@ theorem caseII_path_global_finrank_bound_of_total_reachability_and_corner_lambda
           (anisotropicHeisenbergParametricPath lam D t).2) : ℝ) : ℂ)
       h_even h_odd
 
-set_option linter.style.longLine false in
 /-- Path-global full `finrank <= 2` for strict case-(ii) targets, using a
 single full SU(2)-corner uniqueness callback. -/
 theorem caseII_path_global_finrank_bound_of_total_reachability_and_su2_unique_lambda_gt_one

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfDNonnegBoundary.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfDNonnegBoundary.lean
@@ -25,7 +25,6 @@ namespace LatticeSystem.Quantum
 open Matrix Module Set LatticeSystem.Math.PerronFrobenius
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
-set_option linter.style.longLine false in
 /-- Spin-`1/2` obligation (2) under a single SU(2)-point strict-gap axiom,
 with target `D' >= 0`. -/
 theorem spinHalf_anisotropicHeisenbergS_obligation_2_single_axiom_D_nonneg
@@ -124,7 +123,6 @@ theorem spinHalf_anisotropicHeisenbergS_obligation_2_single_axiom_D_nonneg
     M_balanced M_chosen h_balanced hM_chosen_centered_ne hlam'_lb hlam'_ub hD'
     hM_chosen_cross h_strict_chosen axiom_GS_at_SU2 h_below
 
-set_option linter.style.longLine false in
 /-- Spin-`1/2` obligation (2) from SU(2) global uniqueness with target
 `D' >= 0`. -/
 theorem spinHalf_anisotropicHeisenbergS_obligation_2_of_SU2_global_unique_D_nonneg
@@ -189,7 +187,6 @@ theorem spinHalf_anisotropicHeisenbergS_obligation_2_of_SU2_global_unique_D_nonn
     M_balanced M_orig h_balanced hM_orig_ne h_centered_nonzero
     hlam'_lb hlam'_ub hD' h_violation_orig h_strict_gap_at_SU2
 
-set_option linter.style.longLine false in
 /-- Spin-`1/2` obligation (2) from only SU(2) global uniqueness with target
 `D' >= 0`. -/
 theorem spinHalf_anisotropicHeisenbergS_obligation_2_of_SU2_global_unique_only_D_nonneg
@@ -259,7 +256,6 @@ private theorem anisotropicHeisenbergS_SU2_ground_eigenspace_finrank_le_one_of_h
   rw [hmin]
   exact huniq
 
-set_option linter.style.longLine false in
 /-- Spin-`1/2` obligation (2) from the MLM/Casimir endpoint with target
 `D' >= 0`. -/
 theorem spinHalf_anisotropicHeisenbergS_obligation_2_of_MLM_casimir_ladder_t23_pf_D_nonneg
@@ -427,7 +423,6 @@ theorem spinHalf_anisotropicHeisenbergS_strict_gap_all_M_of_MLM_casimir_ladder_t
     M_balanced M h_balanced hM_ne h_centered_nonzero
     hlam'_lb hlam'_ub hD'
 
-set_option linter.style.longLine false in
 /-- Spin-`1/2` balanced sector is the full target ground sector, with target
 `D' >= 0`. -/
 theorem spinHalf_anisotropicHeisenbergS_balanced_eq_full_of_MLM_casimir_ladder_t23_pf_D_nonneg
@@ -485,7 +480,6 @@ theorem spinHalf_anisotropicHeisenbergS_balanced_eq_full_of_MLM_casimir_ladder_t
   exact hermitianMinEigenvalue_balanced_eq_full_of_strict_gap
     hJ_star 1 M_balanced lam' D' h_strict_gap
 
-set_option linter.style.longLine false in
 /-- Spin-`1/2` target ground eigenspace `finrank <= 1` in the case-(i)
 `D' >= 0` boundary strip. -/
 theorem spinHalf_anisotropicHeisenbergS_target_finrank_le_one_of_MLM_casimir_ladder_t23_pf_D_nonneg

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfDNonnegBoundaryCore.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfDNonnegBoundaryCore.lean
@@ -531,7 +531,6 @@ theorem spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_
     hlam_t_im hlb_t hub_t hD_t_im hDnn_t
     (hc_strict lam_t D_t) hA_ne hB_ne hJ_star hlam_t_star hD_t_star
 
-set_option linter.style.longLine false in
 /-- The deformation contradiction capstone with target `D' >= 0`. -/
 theorem spinHalf_anisotropicHeisenbergS_obligation_2_axiomatic_sup_crossing_hne_D_nonneg
     (A : Λ → Bool) {J : Λ → Λ → ℂ}

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfLambdaOneBoundary.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfLambdaOneBoundary.lean
@@ -222,7 +222,6 @@ theorem spinHalf_anisotropicHeisenbergS_lambda_one_finrank_le_one_of_heisenberg
   rw [hfin_shift]
   simpa [hH0_def] using h_heis_unique
 
-set_option linter.style.longLine false in
 /-- Spin-1/2 `lambda = 1` target uniqueness from the Theorem 2.3 MLM/Casimir
 endpoint.  The single-ion term is a scalar shift, so no strict-region
 Perron--Frobenius parity-block irreducibility is used. -/

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2FromMLM.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfObligation2FromMLM.lean
@@ -52,7 +52,6 @@ private theorem anisotropicHeisenbergS_SU2_ground_eigenspace_finrank_le_one_of_h
   rw [hmin]
   exact huniq
 
-set_option linter.style.longLine false in
 /-- **Spin-1/2 obligation (2) from the MLM/Casimir SU(2) endpoint**: the
 deformation contradiction follows from the Theorem 2.3 common-energy endpoint
 and the balanced zero-Casimir ladder obstruction, without an abstract
@@ -126,7 +125,6 @@ theorem spinHalf_anisotropicHeisenbergS_obligation_2_of_MLM_casimir_ladder
     M_balanced M_orig h_balanced hM_orig_ne h_centered_nonzero
     hlam'_lb hlam'_ub hD' h_violation_orig h_SU2_global_unique
 
-set_option linter.style.longLine false in
 /-- **Spin-1/2 obligation (2) from the MLM/Casimir endpoint with sector PF
 constructed from Theorem 2.3**: this is the same deformation contradiction as
 `spinHalf_anisotropicHeisenbergS_obligation_2_of_MLM_casimir_ladder`, but the
@@ -194,7 +192,6 @@ theorem spinHalf_anisotropicHeisenbergS_obligation_2_of_MLM_casimir_ladder_t23_p
     M_balanced M_orig h_balanced hM_orig_ne h_centered_nonzero
     hlam'_lb hlam'_ub hD' h_violation_orig
 
-set_option linter.style.longLine false in
 /-- **Spin-1/2 obligation (2) strict gap from the MLM/Casimir endpoint with
 Theorem 2.3 sector PF**: at the target point of the deformation path, every
 non-balanced sector has strictly larger minimum energy than the balanced

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfTargetUniquenessFromBalancedPF.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfTargetUniquenessFromBalancedPF.lean
@@ -31,7 +31,6 @@ open Matrix Module
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
 
-set_option linter.style.longLine false in
 /-- **Spin-1/2 balanced-sector Perron--Frobenius simplicity at the target point**:
 the anisotropic target sector matrix has a one-dimensional ground eigenspace in
 the balanced magnetization sector. -/

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIArgminFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIArgminFinrank.lean
@@ -21,7 +21,6 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-! ## Case-(ii) target wrappers from first-crossing `finrank <= 2` bounds -/
 
-set_option linter.style.longLine false in
 /-- **General spin-S case-(ii) target ground eigenspace `finrank <= 1` from
 first-crossing `finrank <= 2` bounds**. -/
 theorem anisotropicHeisenbergS_case_ii_target_finrank_le_one_of_first_crossing_finrank_bound
@@ -87,7 +86,6 @@ theorem anisotropicHeisenbergS_case_ii_target_finrank_le_one_of_first_crossing_f
       hlam_case_ii hD_case_ii h_centered_nonzero h_strict_gap_at_SU2
       h_GS_at_SU2 h_finrank_at_first_crossing)
 
-set_option linter.style.longLine false in
 /-- **General spin-S case-(ii) target ground states have zero total
 magnetization from first-crossing `finrank <= 2` bounds**. -/
 theorem anisotropicHeisenbergS_case_ii_target_zero_magnetization_of_first_crossing_finrank_bound

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIArgminFinrankCore.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIArgminFinrankCore.lean
@@ -23,7 +23,6 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-! ## Argmin first-crossing contradiction from a first-crossing `finrank <= 2` bound -/
 
-set_option linter.style.longLine false in
 /-- **General spin-S case-(ii) argmin first-crossing contradiction from a
 first-crossing `finrank <= 2` bound**.
 

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIBlockPathFinrankCore.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIBlockPathFinrankCore.lean
@@ -19,7 +19,6 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-! ## Path-global finrank from parity-block path bounds -/
 
-set_option linter.style.longLine false in
 /-- **General spin-S case-(ii) path-global `finrank <= 2` input from
 axis-swapped parity-block submatrix simplicity**.
 

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIPathGlobalFinrank.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSCaseIIPathGlobalFinrank.lean
@@ -22,7 +22,6 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
 /-! ## First-crossing finrank from path-global finrank -/
 
-set_option linter.style.longLine false in
 /-- **General spin-S case-(ii) first-crossing finrank input from a path-global
 finrank bound**.
 
@@ -70,7 +69,6 @@ theorem caseII_first_crossing_finrank_bound_of_path_global_finrank_bound
 
 /-! ## Case-(ii) target wrappers from path-global finrank -/
 
-set_option linter.style.longLine false in
 /-- **General spin-S case-(ii) target ground eigenspace `finrank <= 1` from a
 path-global `finrank <= 2` bound**. -/
 theorem anisotropicHeisenbergS_case_ii_target_finrank_le_one_of_path_global_finrank_bound
@@ -125,7 +123,6 @@ theorem anisotropicHeisenbergS_case_ii_target_finrank_le_one_of_path_global_finr
     (caseII_first_crossing_finrank_bound_of_path_global_finrank_bound
       (Λ := Λ) (N := N) (J := J) hJ_star M_balanced h_path_global_finrank)
 
-set_option linter.style.longLine false in
 /-- **General spin-S case-(ii) target ground states have zero total
 magnetization from a path-global `finrank <= 2` bound**. -/
 theorem anisotropicHeisenbergS_case_ii_target_zero_magnetization_of_path_global_finrank_bound

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSDNonnegBoundaryGlobalMin.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSDNonnegBoundaryGlobalMin.lean
@@ -25,7 +25,6 @@ open Matrix Module Set
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 /-! ## Deformation-path and target wrappers with `D >= 0` -/
 
-set_option linter.style.longLine false in
 /-- General spin-`S` anisotropic `H` eigenspace `finrank <= 2` at its global
 Hermitian minimum under `D.re >= 0`. -/
 theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_D_nonneg_general
@@ -69,7 +68,6 @@ theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_D_nonneg_
   rw [henergy_eq] at hbound
   exact hbound
 
-set_option linter.style.longLine false in
 /-- General spin-`S` `finrank <= 2` at the global minimum along the
 parametric path, with target `D' >= 0`. -/
 theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_path_D_nonneg_general
@@ -126,7 +124,6 @@ theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_path_D_no
     hlam_t_im hlb_t hub_t hD_t_im hDnn_t
     (hc_strict lam_t D_t) hA_ne hB_ne hN hJ_star hlam_t_star hD_t_star
 
-set_option linter.style.longLine false in
 /-- General spin-`S` deformation contradiction capstone with target
 `D' >= 0`. -/
 theorem anisotropicHeisenbergS_obligation_2_axiomatic_sup_crossing_hne_D_nonneg_general
@@ -225,7 +222,6 @@ theorem anisotropicHeisenbergS_obligation_2_axiomatic_sup_crossing_hne_D_nonneg_
     h_finrank hΦ_bal_ne h_balanced hΦ_bal_eig
     hΦ_M_ne hM_ne_balanced hΦ_M_eig
 
-set_option linter.style.longLine false in
 /-- General spin-`S` obligation (2) under a single SU(2)-point strict-gap
 axiom, with target `D' >= 0`. -/
 theorem anisotropicHeisenbergS_obligation_2_single_axiom_D_nonneg_general

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSMLMEndpoint.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSMLMEndpoint.lean
@@ -55,7 +55,6 @@ theorem anisotropicHeisenbergS_SU2_ground_eigenspace_finrank_le_one_of_heisenber
   rw [hmin]
   exact huniq
 
-set_option linter.style.longLine false in
 /-- **General spin-S target uniqueness from the MLM/Casimir SU(2) endpoint**:
 Theorem 2.3 supplies the SU(2)-point Heisenberg ground-eigenspace uniqueness,
 which is transported to the anisotropic SU(2) point and then fed to the

--- a/LatticeSystem/Quantum/SpinS/BipartiteToyGSLadderInvariant.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteToyGSLadderInvariant.lean
@@ -40,7 +40,6 @@ theorem sublatticeSpinSquaredS_commute_totalSpinSOpMinus (A : Λ → Bool) :
     ((sublatticeSpinSquaredS_commute_totalSpinSOp2 (Λ := Λ) N A).smul_right
       Complex.I)
 
-set_option linter.style.longLine false in
 /-- **Ŝ^+_tot-invariance of the predicted GS subspace**. -/
 theorem bipartiteToyGroundStateSubspacePredicted_totalSpinSOpPlus_invariant
     (A : Λ → Bool) (N : ℕ) :
@@ -86,7 +85,6 @@ theorem bipartiteToyGroundStateSubspacePredicted_totalSpinSOpPlus_invariant
             (Λ := Λ) (N := N) (fun x => ! A x)).symm.eq]]
     rw [h_B, Matrix.mulVec_smul]
 
-set_option linter.style.longLine false in
 /-- **Ŝ^-_tot-invariance of the predicted GS subspace**. -/
 theorem bipartiteToyGroundStateSubspacePredicted_totalSpinSOpMinus_invariant
     (A : Λ → Bool) (N : ℕ) :

--- a/LatticeSystem/Quantum/SpinS/BipartiteToyGSLeTotalSpinSSquaredEigenspace.lean
+++ b/LatticeSystem/Quantum/SpinS/BipartiteToyGSLeTotalSpinSSquaredEigenspace.lean
@@ -23,7 +23,6 @@ namespace LatticeSystem.Quantum
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-set_option linter.style.longLine false in
 /-- **Predicted GS ⊆ (Ŝ_tot)² eigenspace at target**: definitional
 projection onto the first joint Casimir component. -/
 theorem bipartiteToyGroundStateSubspacePredicted_le_totalSpinSSquaredEigenspace
@@ -42,7 +41,6 @@ theorem bipartiteToyGroundStateSubspacePredicted_le_totalSpinSSquaredEigenspace
   obtain ⟨⟨h_tot, _⟩, _⟩ := hv
   exact h_tot
 
-set_option linter.style.longLine false in
 /-- **Predicted GS ⊆ (Ŝ_A)² eigenspace at target**. -/
 theorem bipartiteToyGroundStateSubspacePredicted_le_sublatticeSpinSquaredSEigenspace
     (A : Λ → Bool) (N : ℕ) :
@@ -56,7 +54,6 @@ theorem bipartiteToyGroundStateSubspacePredicted_le_sublatticeSpinSquaredSEigens
   obtain ⟨⟨_, h_A⟩, _⟩ := hv
   exact h_A
 
-set_option linter.style.longLine false in
 /-- **Predicted GS ⊆ (Ŝ_¬A)² eigenspace at target**. -/
 theorem bipartiteToyGroundStateSubspacePredicted_le_sublatticeSpinSquaredS_complementEigenspace
     (A : Λ → Bool) (N : ℕ) :

--- a/LatticeSystem/Quantum/SpinS/Problem25cBalancedStructuralWrapper.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25cBalancedStructuralWrapper.lean
@@ -18,7 +18,6 @@ open Matrix Module
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
-set_option linter.style.longLine false in
 /-- Problem 2.5.c balanced structural wrapper: in the balanced bipartite
 antiferromagnetic case, the structural Theorem 2.3 proof supplies the MLM/SU(2)
 uniqueness endpoint, so every normalized non-zero Heisenberg ground-state

--- a/LatticeSystem/Quantum/SpinS/Problem25cMLMGroundStateWrapper.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25cMLMGroundStateWrapper.lean
@@ -22,7 +22,6 @@ open Matrix Module
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
-set_option linter.style.longLine false in
 /-- Problem 2.5.c balanced MLM ground-state wrapper: if the balanced Theorem 2.3
 endpoint supplies one-dimensionality of the SU(2)-point Heisenberg ground
 eigenspace, then any normalized non-zero vector at the Hermitian minimum has all

--- a/LatticeSystem/Quantum/SpinS/Problem25dBalancedPFCrossSign.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25dBalancedPFCrossSign.lean
@@ -19,7 +19,6 @@ variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-! ## Balanced PF cross-sublattice sign endpoint -/
 
-set_option linter.style.longLine false in
 /-- Problem 2.5.d balanced Perron--Frobenius cross endpoint: for the concrete
 balanced PF vector from the Theorem 2.3 / Theorem 2.4 endpoint, every
 cross-sublattice pair has negative original two-spin correlation real part. -/

--- a/LatticeSystem/Quantum/SpinS/Problem25dBalancedPFEndpoint.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25dBalancedPFEndpoint.lean
@@ -22,7 +22,6 @@ variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-! ## Balanced PF endpoint -/
 
-set_option linter.style.longLine false in
 /-- Problem 2.5.d balanced Perron--Frobenius endpoint: the balanced Theorem 2.3
 PF vector, rewritten in the sector-supported Marshall form, has strictly
 positive signed two-spin correlation for every cross-sublattice pair. -/

--- a/LatticeSystem/Quantum/SpinS/Problem25dBalancedPFSignCases.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25dBalancedPFSignCases.lean
@@ -19,7 +19,6 @@ variable {V : Type*} [Fintype V] [DecidableEq V] {N : ℕ}
 
 /-! ## Balanced PF sign endpoint -/
 
-set_option linter.style.longLine false in
 /-- Problem 2.5.d balanced Perron--Frobenius sign endpoint: the concrete
 balanced PF vector from the Theorem 2.3 / Theorem 2.4 endpoint satisfies the
 original two-spin correlation sign cases after bipartite-gauge conversion. -/

--- a/LatticeSystem/Quantum/SpinS/Problem25dGroundStatePhaseWrapper.lean
+++ b/LatticeSystem/Quantum/SpinS/Problem25dGroundStatePhaseWrapper.lean
@@ -56,7 +56,6 @@ theorem twoSpinCorrelationS_bipartite_signed_re_pos_of_marshall_cross_eigenphase
 
 /-! ## Balanced MLM ground-state wrapper -/
 
-set_option linter.style.longLine false in
 /-- Problem 2.5.d balanced MLM ground-state wrapper: the balanced
 Marshall--Lieb--Mattis/SU(2) endpoint supplies one-dimensionality of the
 Heisenberg ground eigenspace, so a normalized non-zero Marshall-positive

--- a/LatticeSystem/Quantum/SpinS/SublatticeMaxCasimirEigenspaceLadderInvariant.lean
+++ b/LatticeSystem/Quantum/SpinS/SublatticeMaxCasimirEigenspaceLadderInvariant.lean
@@ -22,7 +22,6 @@ namespace LatticeSystem.Quantum
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-set_option linter.style.longLine false in
 /-- **`Ŝ_A^-`-invariance of the maximal sublattice-Casimir eigenspace**. -/
 theorem sublatticeMaxCasimirEigenspace_sublatticeSpinSOpMinus_invariant (A : Λ → Bool) (M : ℂ) :
     Submodule.map (sublatticeSpinSOpMinus N A).mulVecLin
@@ -37,7 +36,6 @@ theorem sublatticeMaxCasimirEigenspace_sublatticeSpinSOpMinus_invariant (A : Λ 
         (sublatticeSpinSquaredS_commute_sublatticeSpinSOpMinus (Λ := Λ) (N := N) A).symm.eq]]
   rw [hv, Matrix.mulVec_smul]
 
-set_option linter.style.longLine false in
 /-- **`Ŝ_A^+`-invariance of the maximal sublattice-Casimir eigenspace**. -/
 theorem sublatticeMaxCasimirEigenspace_sublatticeSpinSOpPlus_invariant (A : Λ → Bool) (M : ℂ) :
     Submodule.map (sublatticeSpinSOpPlus N A).mulVecLin

--- a/LatticeSystem/Quantum/SpinS/Theorem23Casimir.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23Casimir.lean
@@ -257,7 +257,6 @@ theorem tasaki23_marshallPositive_magSectorEmbedding_ne_zero
     exact (ne_of_gt hpos) hprod_zero
   exact (Complex.ofReal_ne_zero.mpr hreal_ne) happly
 
-set_option linter.style.longLine false in
 /-- **Tasaki §2.5 Theorem 2.3 Marshall-positive sector Casimir
 non-vanishing, lowering direction**: a Marshall-positive sector vector
 with a non-endpoint total-Casimir eigenvalue has non-zero total-lowering
@@ -287,7 +286,6 @@ theorem t23_totSpinSOpMinus_mulVec_marshPos_magSecEmb_ne_zero_of_cas_ne_kernelVa
     tasaki23_totalSpinSOpMinus_mulVec_magSectorEmbedding_ne_zero_of_casimir_ne_kernel_value
       hΦ_cas hγ_ne (tasaki23_marshallPositive_magSectorEmbedding_ne_zero A hv_pos)
 
-set_option linter.style.longLine false in
 /-- **Tasaki §2.5 Theorem 2.3 Marshall-positive sector Casimir
 non-vanishing, raising direction**: a Marshall-positive sector vector
 with a non-endpoint total-Casimir eigenvalue has non-zero total-raising

--- a/LatticeSystem/Quantum/SpinS/Theorem23Predicted.lean
+++ b/LatticeSystem/Quantum/SpinS/Theorem23Predicted.lean
@@ -285,7 +285,6 @@ theorem
     rw [← hcomm]
   rw [hterm]
 
-set_option linter.style.longLine false in
 /-- **Tasaki §2.5 Theorem 2.3 re-embedded source-sector cross-ladder
 site sums**: after the two lowered components are known to lie in the
 successor magnetization eigenspace, re-embed their sector restrictions


### PR DESCRIPTION
## Summary
- Part of #5104 PR-E (post-rename cleanup): Remove 47 dead `set_option linter.style.longLine false` suppressions that no longer serve purpose after refactoring shortened lines below 100-character limit.
- "Dead" suppressions = span content already fits within 100 codepoints but suppression line remained as residue from renaming arc.
- Deletions only: 0 additions, 47 deletions across 25 files; `lake build` root 4517 jobs green with no warning/PANIC/long-line violations after deletion.

## Verification
- Build confirms no suppression was needed (zero re-emergent warnings after removal).
- Meaning preservation: deleted only suppression lines; all declarations, proofs, doc comments unchanged.
- Remaining suppressions: 9 cases still require actual line folding (PR-E2 scope).

Refs #5104
