### PR TITLE
refactor: close final longLine loopholes — #5104 PR-E2 (9→0 suppressions)

### DIFF
--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfCaseII.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfCaseII.lean
@@ -152,7 +152,6 @@ theorem spinHalf_aHeisS_case_ii_target_zeroMag_of_MLM_casLadder_t23_pf
 
 /-! ## Exact spin-1/2 parameter-region wrapper -/
 
-set_option linter.style.longLine false in
 /-- Spin-`1/2` Tasaki Theorem 2.4 target uniqueness wrapper over the exact
 case-(i) and case-(ii) parameter region currently proved for `N = 1`. -/
 theorem spinHalf_anisotropicHeisenbergS_tasaki24_target_finrank_le_one_of_MLM_casimir_ladder_t23_pf
@@ -194,7 +193,8 @@ theorem spinHalf_anisotropicHeisenbergS_tasaki24_target_finrank_le_one_of_MLM_ca
   classical
   rcases h_region with h_case_i | h_boundary_or_case_ii
   · rcases h_case_i with ⟨hlam_lb, hlam_ub, hD_nonneg⟩
-    exact spinHalf_anisotropicHeisenbergS_target_finrank_le_one_of_MLM_casimir_ladder_t23_pf_D_nonneg
+    exact
+      spinHalf_anisotropicHeisenbergS_target_finrank_le_one_of_MLM_casimir_ladder_t23_pf_D_nonneg
       (Λ := Λ) A hJim hJnn hJpos hJself hJbip hJ_star hJ_sym hc_axis_strict
       hA_ne hB_ne c_mlm c_toy hT23 hc_heis_strict hc_toy_strict h_card_eq
       M_balanced h_balanced h_centered_nonzero hlam_lb hlam_ub hD_nonneg
@@ -206,7 +206,8 @@ theorem spinHalf_anisotropicHeisenbergS_tasaki24_target_finrank_le_one_of_MLM_ca
       c_mlm c_toy hT23 hc_heis_strict hc_toy_strict h_card_eq D
   · rcases h_case_ii with ⟨hlam_case_ii, hD_case_ii⟩
     rcases lt_or_eq_of_le hlam_case_ii with hlam_gt | hlam_eq
-    · exact spinHalf_anisotropicHeisenbergS_case_ii_target_finrank_le_one_of_MLM_casimir_ladder_t23_pf
+    · exact
+        spinHalf_anisotropicHeisenbergS_case_ii_target_finrank_le_one_of_MLM_casimir_ladder_t23_pf
         (Λ := Λ) A hJim hJnn hJpos hJself hJbip hJ_star hJ_sym hA_ne hB_ne
         M_balanced h_balanced h_centered_nonzero c_mlm c_toy hT23 hc_heis_strict
         hc_toy_strict h_card_eq hlam_gt hD_case_ii

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfDNonnegBoundary.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfDNonnegBoundary.lean
@@ -3,7 +3,6 @@ import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSpinHalfDNonnegBoundaryC
 set_option linter.unusedSectionVars false
 set_option linter.unusedSimpArgs false
 set_option linter.unusedVariables false
-set_option linter.style.longLine false
 
 /-!
 # Spin-1/2 `D >= 0` boundary for Theorem 2.4 parity-block finrank
@@ -233,16 +232,18 @@ theorem spinHalf_anisotropicHeisenbergS_obligation_2_of_SU2_global_unique_only_D
 
 /-- Transport Heisenberg ground-line uniqueness at the SU(2) point to the
 anisotropic Hamiltonian written with `(lambda, D) = (1, 0)`. -/
-private theorem anisotropicHeisenbergS_SU2_ground_eigenspace_finrank_le_one_of_heisenberg_D_nonneg_aux
+private theorem aHeisS_SU2_ground_eigenspace_finrank_le_one_of_heisenberg_D_nonneg_aux
     {J : Λ → Λ → ℂ} (hJ_star : ∀ x y, star (J x y) = J x y)
     [Nonempty (Λ → Fin (1 + 1))]
     {μ : ℝ}
-    (hμ : hermitianMinEigenvalue (heisenbergHamiltonianS_isHermitian_of_real (Λ := Λ) hJ_star 1) = μ)
+    (hμ : hermitianMinEigenvalue
+      (heisenbergHamiltonianS_isHermitian_of_real (Λ := Λ) hJ_star 1) = μ)
     (huniq :
       finrank ℂ ↥(End.eigenspace (Matrix.toLin' (heisenbergHamiltonianS (Λ := Λ) J 1))
         (μ : ℂ)) ≤ 1) :
     finrank ℂ ↥(End.eigenspace (Matrix.toLin' (anisotropicHeisenbergS (Λ := Λ) J 1 0 1))
-      ((hermitianMinEigenvalue (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ_star 1 1 0) :
+      ((hermitianMinEigenvalue
+        (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ_star 1 1 0) :
         ℝ) : ℂ)) ≤ 1 := by
   have hmin :
       hermitianMinEigenvalue (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ_star 1 1 0) =
@@ -324,7 +325,7 @@ theorem spinHalf_anisotropicHeisenbergS_obligation_2_of_MLM_casimir_ladder_t23_p
         ((hermitianMinEigenvalue
           (anisotropicHeisenbergS_full_isHermitian_real (Λ := Λ) hJ_star 1 1 0) :
             ℝ) : ℂ)) ≤ 1 :=
-    anisotropicHeisenbergS_SU2_ground_eigenspace_finrank_le_one_of_heisenberg_D_nonneg_aux
+    aHeisS_SU2_ground_eigenspace_finrank_le_one_of_heisenberg_D_nonneg_aux
       (Λ := Λ) hJ_star hμ_min huniq_heis
   exact spinHalf_anisotropicHeisenbergS_obligation_2_of_SU2_global_unique_only_D_nonneg
     A hJim hJnn hJpos hJself hJbip hc_axis_strict hA_ne hB_ne hJ_star

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfDNonnegBoundaryCore.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinHalfDNonnegBoundaryCore.lean
@@ -3,14 +3,14 @@ import LatticeSystem.Quantum.SpinS.AnisotropicHeisenbergSpinHalfTargetUniqueness
 set_option linter.unusedSectionVars false
 set_option linter.unusedSimpArgs false
 set_option linter.unusedVariables false
-set_option linter.style.longLine false
 
 /-!
 # Spin-1/2 `D >= 0` boundary for Theorem 2.4 — parity-block core
 
 Foundational layer of the spin-1/2 `D >= 0` parity-block Perron--Frobenius route (Tasaki §2.5
 Theorem 2.4, Issue #412): single-ion `±2` impossibility at spin 1/2, shifted-dressed parity-block
-positivity / irreducibility, the PF positive eigenvector, the Hermitian-min-eigenvalue = PF identity,
+positivity / irreducibility, the PF positive eigenvector, the
+Hermitian-min-eigenvalue = PF identity,
 the parity-block `finrank <= 1` and the global `finrank <= 2` (truly unconditional / at-global-min /
 path) theorems.
 
@@ -434,7 +434,6 @@ theorem spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_truly_uncondit
   exact spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_min_block_mins
     hJim hlam hDim hJself h0 h1
 
-set_option linter.style.longLine false in
 /-- Spin-`1/2` anisotropic `H` eigenspace `finrank <= 2` at its global
 Hermitian minimum with nonnegative `D`. -/
 theorem spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_D_nonneg
@@ -456,7 +455,8 @@ theorem spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_
       ((hermitianMinEigenvalue
         (anisotropicHeisenbergS_isHermitian_of_real (Λ := Λ) (N := 1)
           hJ_star hlam_star hD_star) : ℝ) : ℂ)) ≤ 2 := by
-  have hbound := spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_truly_unconditional_D_nonneg
+  have hbound :=
+    spinHalf_anisotropicHeisenbergS_eigenspace_finrank_le_two_truly_unconditional_D_nonneg
     A hJim hJnn hJpos hJself hJbip hlam hlb hub hDim hDnn hc_strict hA_ne hB_ne
   have hblock_eq := hermitianMinEigenvalue_axisSwapped_eq_min_block_mins
     (Λ := Λ) (N := 1) hJim hlam hDim hJself

--- a/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSLambdaOneBoundaryCore.lean
+++ b/LatticeSystem/Quantum/SpinS/AnisotropicHeisenbergSpinSLambdaOneBoundaryCore.lean
@@ -270,7 +270,6 @@ theorem axisSwapAHeisS_submat_finrank_le_one_at_hMinEig_lam1_D_pos
   exact axisSwappedAnisotropicHeisenbergS_submatrix_finrank_le_one_at_min_conditional
     hJim hOneIm hDim p ν h_finrank_bare hν_eq
 
-set_option linter.style.longLine false in
 /-- General spin-`S` anisotropic `H` eigenspace `finrank <= 2` at
 `min(per-block mins)` at `lambda = 1`, `D.re > 0`. -/
 theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_unconditional_lambda_one_D_pos_general
@@ -293,7 +292,8 @@ theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_unconditional_lambda_on
               (Λ := Λ) (N := N) hJim (show ((1 : ℂ).im = 0) from by norm_num) hDim 0))
           (hermitianMinEigenvalue
             (axisSwappedAnisotropicHeisenbergS_submatrix_isHermitian_of_real
-              (Λ := Λ) (N := N) hJim (show ((1 : ℂ).im = 0) from by norm_num) hDim 1)) : ℝ) : ℂ)) ≤ 2 := by
+              (Λ := Λ) (N := N) hJim (show ((1 : ℂ).im = 0) from by norm_num) hDim 1))
+                : ℝ) : ℂ)) ≤ 2 := by
   have hOneIm : ((1 : ℂ).im = 0) := by norm_num
   have h0 :=
     axisSwapAHeisS_submat_finrank_le_one_at_hMinEig_lam1_D_pos
@@ -304,7 +304,6 @@ theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_unconditional_lambda_on
   exact anisotropicHeisenbergS_eigenspace_finrank_le_two_at_min_block_mins_general
     hJim hOneIm hDim hJself h0 h1
 
-set_option linter.style.longLine false in
 /-- General spin-`S` anisotropic `H` eigenspace `finrank <= 2` at its global
 Hermitian minimum at `lambda = 1`, `D.re > 0`. -/
 theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_lambda_one_D_pos_general
@@ -330,7 +329,8 @@ theorem anisotropicHeisenbergS_eigenspace_finrank_le_two_at_global_min_lambda_on
   classical
   have hOneIm : ((1 : ℂ).im = 0) := by norm_num
   have hOneStar : star (1 : ℂ) = (1 : ℂ) := by norm_num
-  have hbound := anisotropicHeisenbergS_eigenspace_finrank_le_two_unconditional_lambda_one_D_pos_general
+  have hbound :=
+    anisotropicHeisenbergS_eigenspace_finrank_le_two_unconditional_lambda_one_D_pos_general
     A hJim hJnn hJpos hJself hJbip hDim hDpos hc_strict hA_ne hB_ne hN
   have hblock_eq := hermitianMinEigenvalue_axisSwapped_eq_min_block_mins
     (Λ := Λ) (N := N) hJim hOneIm hDim hJself

--- a/LatticeSystem/Quantum/SpinS/JointCasimirEigenspaceLadderInvariant.lean
+++ b/LatticeSystem/Quantum/SpinS/JointCasimirEigenspaceLadderInvariant.lean
@@ -22,7 +22,6 @@ namespace LatticeSystem.Quantum
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-set_option linter.style.longLine false in
 /-- **`Ŝ⁺_tot`-invariance of the joint sublattice-Casimir eigenspace**. -/
 theorem jointSublatticeCasimirEigenspace_totalSpinSOpPlus_invariant (A : Λ → Bool) (N : ℕ) :
     Submodule.map (totalSpinSOpPlus Λ N).mulVecLin
@@ -45,10 +44,10 @@ theorem jointSublatticeCasimirEigenspace_totalSpinSOpPlus_invariant (A : Λ → 
     rw [show (sublatticeSpinSquaredS N (fun x => ! A x)).mulVec ((totalSpinSOpPlus Λ N).mulVec v) =
         (totalSpinSOpPlus Λ N).mulVec ((sublatticeSpinSquaredS N (fun x => ! A x)).mulVec v) from by
       rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec,
-          (sublatticeSpinSquaredS_commute_totalSpinSOpPlus (Λ := Λ) (N := N) (fun x => ! A x)).symm.eq]]
+          (sublatticeSpinSquaredS_commute_totalSpinSOpPlus (Λ := Λ) (N := N)
+            (fun x => ! A x)).symm.eq]]
     rw [h_B, Matrix.mulVec_smul]
 
-set_option linter.style.longLine false in
 /-- **`Ŝ⁻_tot`-invariance of the joint sublattice-Casimir eigenspace**. -/
 theorem jointSublatticeCasimirEigenspace_totalSpinSOpMinus_invariant (A : Λ → Bool) (N : ℕ) :
     Submodule.map (totalSpinSOpMinus Λ N).mulVecLin
@@ -69,9 +68,11 @@ theorem jointSublatticeCasimirEigenspace_totalSpinSOpMinus_invariant (A : Λ →
   · rw [SetLike.mem_coe, Module.End.mem_eigenspace_iff,
         Matrix.mulVecLin_apply, Matrix.mulVecLin_apply]
     rw [show (sublatticeSpinSquaredS N (fun x => ! A x)).mulVec ((totalSpinSOpMinus Λ N).mulVec v) =
-        (totalSpinSOpMinus Λ N).mulVec ((sublatticeSpinSquaredS N (fun x => ! A x)).mulVec v) from by
+        (totalSpinSOpMinus Λ N).mulVec
+          ((sublatticeSpinSquaredS N (fun x => ! A x)).mulVec v) from by
       rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec,
-          (sublatticeSpinSquaredS_commute_totalSpinSOpMinus (Λ := Λ) (N := N) (fun x => ! A x)).symm.eq]]
+          (sublatticeSpinSquaredS_commute_totalSpinSOpMinus (Λ := Λ) (N := N)
+            (fun x => ! A x)).symm.eq]]
     rw [h_B, Matrix.mulVec_smul]
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/JointCasimirEigenspaceMagInvariant.lean
+++ b/LatticeSystem/Quantum/SpinS/JointCasimirEigenspaceMagInvariant.lean
@@ -21,7 +21,6 @@ namespace LatticeSystem.Quantum
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N : ℕ}
 
-set_option linter.style.longLine false in
 /-- **`Ŝ³_tot`-invariance of the joint sublattice-Casimir eigenspace**. -/
 theorem jointSublatticeCasimirEigenspace_totalSpinSOp3_invariant (A : Λ → Bool) (N : ℕ) :
     Submodule.map (totalSpinSOp3 Λ N).mulVecLin
@@ -44,7 +43,8 @@ theorem jointSublatticeCasimirEigenspace_totalSpinSOp3_invariant (A : Λ → Boo
     rw [show (sublatticeSpinSquaredS N (fun x => ! A x)).mulVec ((totalSpinSOp3 Λ N).mulVec v) =
         (totalSpinSOp3 Λ N).mulVec ((sublatticeSpinSquaredS N (fun x => ! A x)).mulVec v) from by
       rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec,
-          (sublatticeSpinSquaredS_commute_totalSpinSOp3 (Λ := Λ) (N := N) (fun x => ! A x)).symm.eq]]
+          (sublatticeSpinSquaredS_commute_totalSpinSOp3 (Λ := Λ) (N := N)
+            (fun x => ! A x)).symm.eq]]
     rw [h_B, Matrix.mulVec_smul]
 
 end LatticeSystem.Quantum


### PR DESCRIPTION
## PR-E2 — final longLine loophole closure (#5104 PR-E, part 2)

Completes **PR-E**: after PR-E1 (#5111) removed the 47 dead suppressions, this
wraps the 13 genuinely-over-100 lines guarded by the last **9** suppressions and
removes those suppressions. **Repo-wide `set_option linter.style.longLine false`: 9 → 0.**

**Changes** (6 files, files, +26 -23):
- 12 lines wrapped onto continuation lines (deeply-indented `exact`/`have := <name>`
  use-sites, a nested type ascription, `rw` ladder-commute steps, one doc-prose line).
- 1 rename: private aux `anisotropicHeisenbergS_SU2_ground_eigenspace_finrank_le_one_of_heisenberg_D_nonneg_aux`
  → `aHeisS_SU2_ground_eigenspace_finrank_le_one_of_heisenberg_D_nonneg_aux` (2 in-file refs;
  its 102-char `private theorem` header could not be wrapped). No docs/tex refs.
- Removed all 9 remaining suppressions: 2 file-wide (`...DNonnegBoundary.lean:6`,
  `...DNonnegBoundaryCore.lean:6`) + 7 per-decl.

**Verification** (local): `lake build` **4517 jobs green**, 0 warnings, 0 PANIC/error,
**0 lines >100 codepoints** across the 6 files, **repo-wide suppressions = 0** (grep).
Semantics unchanged (whitespace wraps + one identifier rename).

**Note:** the PR-E classifier had estimated all 9 wrappable with 0 renames; wrapping
surfaced 1 declaration-header case needing a rename (caught by per-line inspection).

Refs #5104
