### PR TITLE
feat: land AKLT BondProjectionAlgebraD6b + TotalSpinCommuteE1b into production (§7.1.4) — #5094 PR-4

### DIFF
--- a/LatticeSystem.lean
+++ b/LatticeSystem.lean
@@ -106,6 +106,7 @@ import LatticeSystem.Quantum.SpinS.ClusterState
 import LatticeSystem.Quantum.SpinS.GeneralAKLT
 import LatticeSystem.Quantum.SpinS.HiddenAntiferromagneticOrder
 import LatticeSystem.Quantum.SpinS.HiddenAntiferromagneticOrderUniqueness
+import LatticeSystem.Quantum.SpinS.AKLTKnabe.BondProjectionAlgebraD6b
 import LatticeSystem.Quantum.SpinS.AKLTKnabe.FrustrationFreeD7c
 import LatticeSystem.Quantum.SpinS.AKLTKnabe.GenericSpectralD7b
 import LatticeSystem.Quantum.SpinS.AKLTKnabe.P2OperatorBridgeD5b
@@ -113,6 +114,7 @@ import LatticeSystem.Quantum.SpinS.AKLTKnabe.Sector2BaseNarrow
 import LatticeSystem.Quantum.SpinS.AKLTKnabe.SiteBlockEmbeddingD5b
 import LatticeSystem.Quantum.SpinS.AKLTKnabe.Sl2LadderSectorsE3
 import LatticeSystem.Quantum.SpinS.AKLTKnabe.Sl2SubmoduleProbeE2
+import LatticeSystem.Quantum.SpinS.AKLTKnabe.TotalSpinCommuteE1b
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattis
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisProof
 import LatticeSystem.Quantum.SpinS.LiebSchultzMattisProofCore

--- a/LatticeSystem/Quantum/SpinS/AKLTKnabe/BondProjectionAlgebraD6b.lean
+++ b/LatticeSystem/Quantum/SpinS/AKLTKnabe/BondProjectionAlgebraD6b.lean
@@ -1,0 +1,281 @@
+import LatticeSystem.Quantum.SpinS.AKLTKnabe.SiteBlockEmbeddingD5b
+import LatticeSystem.Math.MatrixAnalysis.HermitianSum
+
+/-!
+# Gate D6b Stage A: the operator algebra of the AKLT bond projection
+
+This module (Issue #5094; Tasaki §7.1.4, Knabe's argument, pp. 188–190) supplies the purely
+*bond-local* algebra that the window-transport (Stage B) and the Knabe aggregation (Stage C)
+consume:
+
+* **idempotence** `P̂_{x,y} P̂_{x,y} = P̂_{x,y}` for any two distinct sites of a chain — Tasaki uses
+  `P̂² = P̂` to pass from `(Ĥ')²` to eq. (7.1.26);
+* **Hermiticity** of `P̂_{x,y}`;
+* **commutation** of two bond projections supported on four *distinct* sites — Tasaki's remark
+  after eq. (7.1.29) ("if `r ≥ 2`, the two projection operators … commute");
+* **positive semidefiniteness of the product** of two such disjoint bond projections, which is the
+  reason the offset sums `D_d` with `d ∉ {0, 1, −1}` may be discarded in eq. (7.1.36);
+* the **conjugate transpose** of a block embedding and, as its corollary, the transport of positive
+  semidefiniteness along `onEmbS` (design item B5f), which is what turns the four-site window
+  certificate `ε₃ ≥ 2/5` into a certificate for every window of a long chain.
+
+## Periodic ring versus open window (design risk R3 — read before consuming this file)
+
+Tasaki's §7.1.4 argument is stated for a **periodic** chain: `Ĥ'_AKLT = Σ_{x=1}^{L} P̂_{x,x+1}`
+of eq. (7.1.7) **includes the wrap bond** `{L−1, 0}`, whereas the Knabe window
+`ĥ_{x,x+ℓ} = Σ_{j=1}^{ℓ} P̂_{x+j−1,x+j}` of eq. (7.1.30) is the Hamiltonian of the **open** chain
+on `ℓ+1` sites and therefore has **exactly `ℓ` bonds** (three, for `ℓ = 3`) — never a fourth.
+Getting either side wrong is fatal, and the two errors pull in opposite directions.
+
+Everything in *this* file is deliberately on **neither** side: each lemma speaks about one or two
+bonds `{x, y}`, `{a, b}`, `{c, d}` given by *arbitrary* sites of `Fin L`, with only distinctness
+hypotheses. No lemma here mentions `ringSucc`, `y + 1`, a bond sum, or a window, so no lemma here
+can silently add or drop the wrap bond. The periodic/open distinction is made — and must be made —
+by the *callers*: the ring sum `Ĥ'` (Stage C) ranges over all `y : Fin L` including the wrap bond,
+while the window `ĥ_x` (Stage B) is three explicit bond projections.
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems* (1st ed., Springer,
+2020), §7.1.4, eqs. (7.1.7), (7.1.26)–(7.1.30), pp. 188–190.
+-/
+
+namespace LatticeSystem.Quantum.AKLTExactCertificateSector234Sequential
+
+open Matrix
+open scoped ComplexOrder
+
+/-! ## A1: idempotence of the frozen rational two-site table -/
+
+/-- The `(a b), (c d)` entry of the **square** of the frozen rational table `sector2P2Entry`,
+with the nine-term fibre sum over the intermediate two-site configuration written out
+explicitly. Expanding the sum here, in the *statement*, is what keeps each of the `81` entry
+goals of `sector2P2Sq_eq` shallow enough for `norm_num` inside the default recursion depth (the
+same device as `p2Rat_expand` of Gate D5b Stage 2); it also matches the shape produced by
+`sum_fin2_fin3` verbatim, so no `Finset` sum is ever manipulated inside a matrix goal. -/
+private def sector2P2Sq (a b c d : Fin 3) : ℚ :=
+  sector2P2Entry a b 0 0 * sector2P2Entry 0 0 c d
+    + sector2P2Entry a b 0 1 * sector2P2Entry 0 1 c d
+    + sector2P2Entry a b 0 2 * sector2P2Entry 0 2 c d
+    + sector2P2Entry a b 1 0 * sector2P2Entry 1 0 c d
+    + sector2P2Entry a b 1 1 * sector2P2Entry 1 1 c d
+    + sector2P2Entry a b 1 2 * sector2P2Entry 1 2 c d
+    + sector2P2Entry a b 2 0 * sector2P2Entry 2 0 c d
+    + sector2P2Entry a b 2 1 * sector2P2Entry 2 1 c d
+    + sector2P2Entry a b 2 2 * sector2P2Entry 2 2 c d
+
+/-- The `27` entries of `sector2P2Sq = sector2P2Entry` with first row label `0`. -/
+private theorem sector2P2Sq_eq_zero (b c d : Fin 3) :
+    sector2P2Sq 0 b c d = sector2P2Entry 0 b c d := by
+  fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    norm_num [sector2P2Sq, sector2P2Entry, Fin.mk.injEq, Fin.ext_iff]
+
+/-- The `27` entries of `sector2P2Sq = sector2P2Entry` with first row label `1`. -/
+private theorem sector2P2Sq_eq_one (b c d : Fin 3) :
+    sector2P2Sq 1 b c d = sector2P2Entry 1 b c d := by
+  fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    norm_num [sector2P2Sq, sector2P2Entry, Fin.mk.injEq, Fin.ext_iff]
+
+/-- The `27` entries of `sector2P2Sq = sector2P2Entry` with first row label `2`. -/
+private theorem sector2P2Sq_eq_two (b c d : Fin 3) :
+    sector2P2Sq 2 b c d = sector2P2Entry 2 b c d := by
+  fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    norm_num [sector2P2Sq, sector2P2Entry, Fin.mk.injEq, Fin.ext_iff]
+
+/-- **The frozen rational two-site table is idempotent** (design item A1). All `81` entries of the
+square of `sector2P2Entry`, as a `9 × 9` rational matrix indexed by the two-site labels `(a, b)`
+and `(c, d)`, agree with `sector2P2Entry` itself: the table really is the matrix of a projection,
+which is Tasaki's `P̂² = P̂` for the bond projector `P̂₂[Ŝ_x + Ŝ_y]` of eq. (7.1.6). -/
+private theorem sector2P2Sq_eq (a b c d : Fin 3) :
+    sector2P2Sq a b c d = sector2P2Entry a b c d := by
+  fin_cases a
+  · exact sector2P2Sq_eq_zero b c d
+  · exact sector2P2Sq_eq_one b c d
+  · exact sector2P2Sq_eq_two b c d
+
+/-! ## A2–A3: idempotence of the bond projection -/
+
+/-- **The two-site bond projection is idempotent** (design item A2). On the two-site chain
+`Fin 2` the operator `P̂₂[Ŝ₀ + Ŝ₁]` satisfies `P̂ P̂ = P̂`. The `9`-term fibre sum produced by
+`Matrix.mul_apply` is enumerated once by `sum_fin2_fin3` and then matched against the rational
+identity `sector2P2Sq_eq`; the spectator guard is vacuous because the chain has only the two bond
+sites. -/
+theorem bondSpin2ProjectionS_fin2_mul_self :
+    (bondSpin2ProjectionS (0 : Fin 2) 1 * bondSpin2ProjectionS (0 : Fin 2) 1 :
+        ManyBodyOpS (Fin 2) 2) = bondSpin2ProjectionS (0 : Fin 2) 1 := by
+  ext σ' σ
+  rw [Matrix.mul_apply, sum_fin2_fin3]
+  simp only [bondSpin2ProjectionS_fin2_apply_eq_sector2P2Entry, Matrix.cons_val_zero,
+    Matrix.cons_val_one]
+  rw [← sector2P2Sq_eq (σ' 0) (σ' 1) (σ 0) (σ 1)]
+  simp only [sector2P2Sq]
+  push_cast
+  ring
+
+/-- **Every bond projection of a chain is idempotent** (design item A3, Tasaki `P̂² = P̂`, used to
+pass from `(Ĥ')²` to eq. (7.1.26)). For any two *distinct* sites `x ≠ y` of `Fin L` — adjacent or
+not, wrap bond or not — `P̂₂[Ŝ_x + Ŝ_y]` is a projection. The proof transports the two-site
+statement along the block embedding, whose multiplicativity `onEmbS_mul` needs exactly the
+injectivity of the site list `![x, y]`. -/
+theorem bondSpin2ProjectionS_mul_self {L : ℕ} {x y : Fin L} (hxy : x ≠ y) :
+    (bondSpin2ProjectionS x y * bondSpin2ProjectionS x y : ManyBodyOpS (Fin L) 2)
+      = bondSpin2ProjectionS x y := by
+  rw [bondSpin2ProjectionS_eq_onEmbS hxy, onEmbS_mul (injective_bondEmb hxy),
+    bondSpin2ProjectionS_fin2_mul_self]
+
+/-! ## A4: Hermiticity of the bond projection -/
+
+/-- **The bond projection is Hermitian** (design item A4). It is the polynomial
+`½ D + ⅙ D² + ⅓` in the Hermitian bond operator `D = Ŝ_x · Ŝ_y` with real coefficients, and `D`
+commutes with itself, so every summand is Hermitian. -/
+theorem bondSpin2ProjectionS_isHermitian {L : ℕ} (x y : Fin L) :
+    (bondSpin2ProjectionS x y : ManyBodyOpS (Fin L) 2).IsHermitian := by
+  have hD : (spinSDot x y 2 : ManyBodyOpS (Fin L) 2).IsHermitian := spinSDot_isHermitian x y 2
+  have hsq : (spinSDot x y 2 * spinSDot x y 2 : ManyBodyOpS (Fin L) 2).IsHermitian :=
+    hD.mul_of_commute hD rfl
+  have h2 : IsSelfAdjoint ((1 : ℂ) / 2) := by
+    rw [isSelfAdjoint_iff, Complex.star_def]; simp [Complex.conj_ofNat]
+  have h6 : IsSelfAdjoint ((1 : ℂ) / 6) := by
+    rw [isSelfAdjoint_iff, Complex.star_def]; simp [Complex.conj_ofNat]
+  have h3 : IsSelfAdjoint ((1 : ℂ) / 3) := by
+    rw [isSelfAdjoint_iff, Complex.star_def]; simp [Complex.conj_ofNat]
+  exact ((hD.smul h2).add (hsq.smul h6)).add (Matrix.isHermitian_one.smul h3)
+
+/-! ## A5–A6: commutation of bond operators on disjoint site pairs -/
+
+/-- **Two bond Heisenberg operators on disjoint site pairs commute** (design item A5). The four
+cross conditions `a ≠ c`, `a ≠ d`, `b ≠ c`, `b ≠ d` say that the bonds `{a, b}` and `{c, d}` share
+no site; `a = b` or `c = d` is *not* excluded and is not needed. Each of the nine axis pairs is a
+product of four site embeddings at pairwise distinct sites, which commute by
+`onSiteS_mul_onSiteS_of_ne`. -/
+theorem spinSDot_commute_of_disjoint {L : ℕ} {a b c d : Fin L}
+    (hac : a ≠ c) (had : a ≠ d) (hbc : b ≠ c) (hbd : b ≠ d) :
+    Commute (spinSDot a b 2 : ManyBodyOpS (Fin L) 2) (spinSDot c d 2) := by
+  have key : ∀ (A B : Matrix (Fin 3) (Fin 3) ℂ) {i j : Fin L}, i ≠ j →
+      Commute (onSiteS i A : ManyBodyOpS (Fin L) 2) (onSiteS j B) :=
+    fun A B _ _ hij => onSiteS_mul_onSiteS_of_ne hij A B
+  have step : ∀ A B C D : Matrix (Fin 3) (Fin 3) ℂ,
+      Commute ((onSiteS a A : ManyBodyOpS (Fin L) 2) * onSiteS b B)
+        (onSiteS c C * onSiteS d D) :=
+    fun A B C D =>
+      ((key A C hac).mul_right (key A D had)).mul_left
+        ((key B C hbc).mul_right (key B D hbd))
+  simp only [spinSDot]
+  exact Commute.add_left (Commute.add_left
+      (Commute.add_right (Commute.add_right (step _ _ _ _) (step _ _ _ _)) (step _ _ _ _))
+      (Commute.add_right (Commute.add_right (step _ _ _ _) (step _ _ _ _)) (step _ _ _ _)))
+    (Commute.add_right (Commute.add_right (step _ _ _ _) (step _ _ _ _)) (step _ _ _ _))
+
+/-- **Two bond projections on disjoint site pairs commute** (design item A6). This is Tasaki's
+remark after eq. (7.1.29): for offsets `r ≥ 2` the two projections in `Ĉ_r` act on disjoint bonds
+and commute. Each projection is the polynomial `½ D + ⅙ D² + ⅓` in its own bond operator, so
+commutation follows from `spinSDot_commute_of_disjoint` term by term. -/
+theorem bondSpin2ProjectionS_commute_of_disjoint {L : ℕ} {a b c d : Fin L}
+    (hac : a ≠ c) (had : a ≠ d) (hbc : b ≠ c) (hbd : b ≠ d) :
+    Commute (bondSpin2ProjectionS a b : ManyBodyOpS (Fin L) 2) (bondSpin2ProjectionS c d) := by
+  have h : Commute (spinSDot a b 2 : ManyBodyOpS (Fin L) 2) (spinSDot c d 2) :=
+    spinSDot_commute_of_disjoint hac had hbc hbd
+  have h2 : Commute (spinSDot a b 2 : ManyBodyOpS (Fin L) 2) (spinSDot c d 2 * spinSDot c d 2) :=
+    h.mul_right h
+  have h3 : Commute (spinSDot a b 2 * spinSDot a b 2 : ManyBodyOpS (Fin L) 2) (spinSDot c d 2) :=
+    h.mul_left h
+  have h4 : Commute (spinSDot a b 2 * spinSDot a b 2 : ManyBodyOpS (Fin L) 2)
+      (spinSDot c d 2 * spinSDot c d 2) := h2.mul_left h2
+  simp only [bondSpin2ProjectionS]
+  refine Commute.add_left (Commute.add_left ?_ ?_) ?_
+  · refine Commute.add_right (Commute.add_right ?_ ?_) ?_
+    · exact (h.smul_left _).smul_right _
+    · exact (h2.smul_left _).smul_right _
+    · exact ((Commute.one_right _).smul_left _).smul_right _
+  · refine Commute.add_right (Commute.add_right ?_ ?_) ?_
+    · exact (h3.smul_left _).smul_right _
+    · exact (h4.smul_left _).smul_right _
+    · exact ((Commute.one_right _).smul_left _).smul_right _
+  · refine Commute.add_right (Commute.add_right ?_ ?_) ?_
+    · exact ((Commute.one_left _).smul_left _).smul_right _
+    · exact ((Commute.one_left _).smul_left _).smul_right _
+    · exact ((Commute.one_left _).smul_left _).smul_right _
+
+/-! ## A7: the product of two disjoint bond projections is positive semidefinite -/
+
+/-- **The product of two bond projections on four distinct sites is positive semidefinite**
+(design item A7). Under the six distinctness hypotheses the two projections commute, so their
+product `M = P̂_{a,b} P̂_{c,d}` is again a Hermitian idempotent, whence `M = Mᴴ M ≥ 0`. This is the
+fact that lets Stage C discard the offset sums `D_d` with `d ∉ {0, 1, −1}` from Tasaki's
+eq. (7.1.36) — precisely the sums whose two bonds are disjoint. It is *not* available for
+`d = ±1`, where the two bonds overlap in one site and the product is not even Hermitian. -/
+theorem posSemidef_bondSpin2ProjectionS_mul {L : ℕ} {a b c d : Fin L}
+    (hab : a ≠ b) (hcd : c ≠ d) (hac : a ≠ c) (had : a ≠ d) (hbc : b ≠ c) (hbd : b ≠ d) :
+    (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d :
+        ManyBodyOpS (Fin L) 2).PosSemidef := by
+  have hcomm : Commute (bondSpin2ProjectionS a b : ManyBodyOpS (Fin L) 2)
+      (bondSpin2ProjectionS c d) := bondSpin2ProjectionS_commute_of_disjoint hac had hbc hbd
+  have hH : (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d :
+      ManyBodyOpS (Fin L) 2).IsHermitian :=
+    (bondSpin2ProjectionS_isHermitian a b).mul_of_commute
+      (bondSpin2ProjectionS_isHermitian c d) hcomm.eq
+  have hidem : (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d :
+        ManyBodyOpS (Fin L) 2) * (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d)
+      = bondSpin2ProjectionS a b * bondSpin2ProjectionS c d := by
+    calc (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d :
+            ManyBodyOpS (Fin L) 2) * (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d)
+        = bondSpin2ProjectionS a b * (bondSpin2ProjectionS c d * bondSpin2ProjectionS a b)
+            * bondSpin2ProjectionS c d := by simp only [mul_assoc]
+      _ = bondSpin2ProjectionS a b * (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d)
+            * bondSpin2ProjectionS c d := by rw [hcomm.eq]
+      _ = (bondSpin2ProjectionS a b * bondSpin2ProjectionS a b)
+            * (bondSpin2ProjectionS c d * bondSpin2ProjectionS c d) := by simp only [mul_assoc]
+      _ = bondSpin2ProjectionS a b * bondSpin2ProjectionS c d := by
+            rw [bondSpin2ProjectionS_mul_self hab, bondSpin2ProjectionS_mul_self hcd]
+  have key : Matrix.conjTranspose (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d :
+        ManyBodyOpS (Fin L) 2) * (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d)
+      = bondSpin2ProjectionS a b * bondSpin2ProjectionS c d := by
+    rw [hH.eq, hidem]
+  exact key ▸ Matrix.posSemidef_conjTranspose_mul_self
+    (bondSpin2ProjectionS a b * bondSpin2ProjectionS c d : ManyBodyOpS (Fin L) 2)
+
+/-! ## A8–A9 (design item B5f): the block embedding preserves positive semidefiniteness -/
+
+section Embedding
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {N m : ℕ}
+
+/-- **The block embedding commutes with the conjugate transpose** (design item A8). The spectator
+guard `∀ k ∉ range ι, σ' k = σ k` of `onEmbS` is symmetric in its two configurations, so
+transposing the embedded operator is the same as embedding the transposed one. No injectivity is
+needed. (The `ᴴ` postfix does not parse inside this namespace, so `Matrix.conjTranspose` is
+spelled out.) -/
+theorem onEmbS_conjTranspose (ι : Fin m → Λ)
+    (A : Matrix (Fin m → Fin (N + 1)) (Fin m → Fin (N + 1)) ℂ) :
+    (onEmbS ι (Matrix.conjTranspose A) : ManyBodyOpS Λ N)
+      = Matrix.conjTranspose (onEmbS ι A) := by
+  ext σ' σ
+  simp only [Matrix.conjTranspose_apply, onEmbS_apply]
+  split_ifs with h1 h2 h2
+  · rfl
+  · exact absurd (fun k hk => (h1 k hk).symm) h2
+  · exact absurd (fun k hk => (h2 k hk).symm) h1
+  · exact (star_zero ℂ).symm
+
+/-- **The block embedding preserves positive semidefiniteness** (design item B5f/A9). If the
+`m`-site operator `A` is positive semidefinite, so is the many-body operator `onEmbS ι A` obtained
+by letting `A` act on the sites listed by an injective `ι` and the identity elsewhere. The proof
+does *not* decompose the embedding into blocks: it writes `A = Cᴴ C` with `C = √A` (Tasaki
+Lemma A.6) and transports the product through the ring homomorphism property `onEmbS_mul`, so
+that `onEmbS ι A = (onEmbS ι C)ᴴ (onEmbS ι C)`. Injectivity of `ι` enters exactly once, inside
+`onEmbS_mul`.
+
+This is what carries the four-site Knabe certificate `ĥ² − (2/5) ĥ ≥ 0` (Tasaki eq. (7.1.30),
+`ℓ = 3`) to every window of a chain of any length. -/
+theorem onEmbS_posSemidef {ι : Fin m → Λ} (hι : Function.Injective ι)
+    {A : Matrix (Fin m → Fin (N + 1)) (Fin m → Fin (N + 1)) ℂ} (hA : A.PosSemidef) :
+    (onEmbS ι A : ManyBodyOpS Λ N).PosSemidef := by
+  obtain ⟨C, hC, rfl⟩ := LatticeSystem.Math.exists_posSemidef_sq_eq_of_posSemidef hA
+  have hCH : Matrix.conjTranspose C = C := hC.isHermitian
+  have key : (onEmbS ι (C * C) : ManyBodyOpS Λ N)
+      = Matrix.conjTranspose (onEmbS ι C) * onEmbS ι C := by
+    rw [← onEmbS_conjTranspose, onEmbS_mul hι, hCH]
+  rw [key]
+  exact Matrix.posSemidef_conjTranspose_mul_self _
+
+end Embedding
+
+end LatticeSystem.Quantum.AKLTExactCertificateSector234Sequential

--- a/LatticeSystem/Quantum/SpinS/AKLTKnabe/TotalSpinCommuteE1b.lean
+++ b/LatticeSystem/Quantum/SpinS/AKLTKnabe/TotalSpinCommuteE1b.lean
@@ -1,0 +1,93 @@
+import LatticeSystem.Quantum.SpinS.AKLTKnabe.SiteBlockEmbeddingD5b
+import LatticeSystem.Quantum.SpinS.MultiSiteDotComm
+import LatticeSystem.Quantum.SpinS.TotalSpin
+
+/-!
+# Gate E1b: the AKLT window commutes with the total raising operator
+
+This module (Issue #5094; Tasaki §7.1.4, Knabe's argument, pp. 188–190) is the **minimal
+experiment** of the `sl₂`-ladder route to the Knabe window inequality
+`ĥ² ≥ (2/5) ĥ` (design note `aklt-theorem-7-1-e1a-general-window-bound-design.md`, §(h)):
+the open three-bond window
+
+  `ĥ = P̂₀₁ + P̂₁₂ + P̂₂₃`  on `(ℂ³)^{⊗4}`  (Tasaki eq. (7.1.30) with `ℓ = 3`, p. 189)
+
+is `SU(2)`-invariant, i.e. it commutes with the total raising operator `Ŝ⁺_tot`.  This is what
+makes the whole dimensional reduction `81 → 1 + 3 + 6 + 6 + 3` possible, because it lets the
+highest-weight spaces `ker Ŝ⁺_tot ∩ V_m` be `ĥ`-invariant.
+
+The proof is entirely structural — **no `81 × 81` entry computation occurs anywhere**:
+
+* the bond operator `Ŝ_x · Ŝ_y` commutes with each Cartesian total-spin axis operator
+  `Ŝ^{(1)}_tot`, `Ŝ^{(2)}_tot`, by the production lemmas `spinSDot_commutator_totalSpinSOp1` and
+  `spinSDot_commutator_totalSpinSOp2` (Tasaki §2.2 eq. (2.2.17) generalised to spin `S`);
+* hence it commutes with `Ŝ⁺_tot = Ŝ^{(1)}_tot + i Ŝ^{(2)}_tot` (`totalSpinSOpPlus_eq_add`);
+* hence so does the bond projection `P̂_{x,y} = ½ (Ŝ_x · Ŝ_y) + ⅙ (Ŝ_x · Ŝ_y)² + ⅓`
+  (`bondSpin2ProjectionS`, Tasaki eq. (7.1.6), p. 182), being a polynomial in it;
+* hence so does the three-term sum `ĥ`.
+
+Reference: Hal Tasaki, *Physics and Mathematics of Quantum Many-Body Systems* (1st ed., Springer,
+2020), §2.2 eq. (2.2.17) p. 24, §7.1.3 eq. (7.1.6) p. 182, §7.1.4 eq. (7.1.30) p. 189;
+S. Knabe, *J. Stat. Phys.* **52**, 627–638 (1988).
+-/
+
+namespace LatticeSystem.Quantum.AKLTExactCertificateSector234Sequential
+
+open LatticeSystem.Quantum
+
+section Bond
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+
+/-- **`SU(2)` invariance of a single bond operator against the total raising operator**:
+`[Ŝ_x · Ŝ_y, Ŝ⁺_tot] = 0`.  Obtained from the two Cartesian-axis commutator identities
+`spinSDot_commutator_totalSpinSOp1` / `spinSDot_commutator_totalSpinSOp2` (Tasaki §2.2
+eq. (2.2.17), p. 24, in its spin-`S` form) through the decomposition
+`Ŝ⁺_tot = Ŝ^{(1)}_tot + i Ŝ^{(2)}_tot`. -/
+theorem spinSDot_commute_totalSpinSOpPlus (x y : Λ) (N : ℕ) :
+    Commute (spinSDot x y N) (totalSpinSOpPlus Λ N) := by
+  have h1 : Commute (spinSDot x y N) (totalSpinSOp1 Λ N) := by
+    unfold Commute SemiconjBy
+    exact sub_eq_zero.mp (spinSDot_commutator_totalSpinSOp1 x y N)
+  have h2 : Commute (spinSDot x y N) (totalSpinSOp2 Λ N) := by
+    unfold Commute SemiconjBy
+    exact sub_eq_zero.mp (spinSDot_commutator_totalSpinSOp2 x y N)
+  rw [totalSpinSOpPlus_eq_add]
+  exact h1.add_right (h2.smul_right Complex.I)
+
+end Bond
+
+/-- **`SU(2)` invariance of the AKLT bond projection**: `[P̂_{x,y}, Ŝ⁺_tot] = 0` for any two sites
+of a spin-1 chain.  The projection is the polynomial `½ D + ⅙ D² + ⅓` in the bond operator
+`D = Ŝ_x · Ŝ_y` (Tasaki eq. (7.1.6), p. 182), so this follows term by term from
+`spinSDot_commute_totalSpinSOpPlus`. -/
+theorem bondSpin2ProjectionS_commute_totalSpinSOpPlus {L : ℕ} (x y : Fin L) :
+    Commute (bondSpin2ProjectionS x y : ManyBodyOpS (Fin L) 2)
+      (totalSpinSOpPlus (Fin L) 2) := by
+  have h : Commute (spinSDot x y 2 : ManyBodyOpS (Fin L) 2) (totalSpinSOpPlus (Fin L) 2) :=
+    spinSDot_commute_totalSpinSOpPlus x y 2
+  simp only [bondSpin2ProjectionS]
+  refine Commute.add_left (Commute.add_left ?_ ?_) ?_
+  · exact h.smul_left _
+  · exact (h.mul_left h).smul_left _
+  · exact (Commute.one_left _).smul_left _
+
+/-- **Gate E1: the open three-bond AKLT window commutes with the total raising operator**,
+`[ĥ, Ŝ⁺_tot] = 0` with `ĥ = P̂₀₁ + P̂₁₂ + P̂₂₃` on `(ℂ³)^{⊗4}` (Tasaki eq. (7.1.30) with `ℓ = 3`,
+p. 189).
+
+This is the structural fact that replaces the machine-generated `81 × 81` certificate stack: it
+says that `ĥ` preserves every highest-weight space `ker Ŝ⁺_tot ∩ V_m`, so the Knabe inequality
+`ĥ² ≥ (2/5) ĥ` need only be checked on the five blocks of sizes `1, 3, 6, 6, 3`.  Cross-checked
+before formalisation by exact rational arithmetic on the full `81 × 81` matrices, together with
+three negative controls (a single-site raising operator, an Ising bond, and a single-site `Ŝ^z`
+all fail to commute). -/
+theorem akltWindow3H_commute_totalSpinSOpPlus :
+    Commute akltWindow3H (totalSpinSOpPlus (Fin 4) 2) := by
+  simp only [akltWindow3H]
+  refine Commute.add_left (Commute.add_left ?_ ?_) ?_
+  · exact bondSpin2ProjectionS_commute_totalSpinSOpPlus _ _
+  · exact bondSpin2ProjectionS_commute_totalSpinSOpPlus _ _
+  · exact bondSpin2ProjectionS_commute_totalSpinSOpPlus _ _
+
+end LatticeSystem.Quantum.AKLTExactCertificateSector234Sequential


### PR DESCRIPTION
## Summary

Production landing of two verified deps=0 modules from AKLT Knabe scratch proof: `BondProjectionAlgebraD6b` (285 lines) + `TotalSpinCommuteE1b` (operator-algebra commutators). This PR-4 opens the next wave of the 16-module landing arc (issue #5094); the two modules have no upstream dependencies and can be merged independently in either order.

## Motivation

- §7.1.4 (Knabe gap, Theorem 7.1 capstone) production landing requires a dependency DAG of 16 scratch modules
- PR-1/2/3 landed 7 modules (leaves + deps=1)
- PR-4 lands 2 further deps=0 modules, unblocking downstream deps=2/3/4 tiers
- Real transitive-dependency audit (2026-07-22) corrected prior import-count misclassification; this PR respects verified deps=0 status

## Scope (✓ Completed in commit 629d04e8)

- [x] Copy `BondProjectionAlgebraD6b.lean` from scratch (`AKLTScratch/`) to production (`LatticeSystem/Quantum/SpinS/AKLTKnabe/`)
- [x] Copy `TotalSpinCommuteE1b.lean` from scratch to production (operator-algebra commutator infrastructure, no redefinitions expected)
- [x] Apply lint fixes (scratch `mathlibStandardSet=false` → production strict `mathlibStandardSet=true`)
- [x] Root wiring: update `LatticeSystem.lean` with 2 new import entries
- [x] Verify build: `lake build LatticeSystem.Quantum.SpinS.AKLTKnabe` warning-free, `#print axioms` = std-3
- [x] Strict diff audit vs scratch: lint-fixes-only, no logic change

## Implementation Summary (Commit 629d04e8)

- **Modules landed**: `BondProjectionAlgebraD6b` + `TotalSpinCommuteE1b` into `LatticeSystem/Quantum/SpinS/AKLTKnabe/`
- **Root wiring**: `LatticeSystem.lean` updated with 2 new import entries
- **Lint corrections**: Scratch-only lint suppressions removed; imports re-pointed to production `SiteBlockEmbeddingD5b` path
- **Doc comments**: Applied production standards
- **Axiom status**: `#print axioms = [propext, Classical.choice, Quot.sound]` (std-3)
- **Duplication audit**: 15 new decls verified collision-free by whole-repo grep; existing decls (bondSpin2ProjectionS, onEmbS, totalSpinSOpPlus, ...) remain in production and are referenced by the new modules (not redefined)
- **Build status**: `lake build LatticeSystem.Quantum.SpinS.AKLTKnabe` warning-free, build successful

## Verification Plan

1. **Build warning-free**: production strict `mathlibStandardSet=true` + `warningAsError=true` ✓
2. **Axiom count**: `#print axioms` for both endpoints = `[propext, Classical.choice, Quot.sound]` (std-3) ✓
3. **Diff vs scratch**: both modules syntax-identical to source except lint corrections ✓
4. **No duplicate redefinitions**: operator-algebra infrastructure remains in production; references from both new modules are imports only ✓

Refs #5094

🤖 Generated with [Claude Code](https://claude.com/claude-code)
