### PR TITLE
refactor: dedup honeycombDart_symm_fst_eq_false (_local twin) — #5098

### DIFF
--- a/LatticeSystem/Quantum/SpinS/HoneycombAKLTBondAnnihilation.lean
+++ b/LatticeSystem/Quantum/SpinS/HoneycombAKLTBondAnnihilation.lean
@@ -80,16 +80,6 @@ private theorem honeycombExtendBondRest_apply_of_ne
   classical
   simp [honeycombExtendBondRest, he]
 
-/-- Reversing a dart whose source is on sublattice `B` gives a forward
-honeycomb dart. -/
-private theorem honeycombDart_symm_fst_eq_false_local
-    (e : (honeycombTorusGraph m).Dart)
-    (he : e.fst.2 ≠ false) :
-    e.symm.fst.2 = false := by
-  rcases honeycombTorusGraph_adj.mp e.adj with h | h
-  · exact (he h.1).elim
-  · exact h.2.1
-
 /-- The complete virtual sum splits into an off-bond assignment and the
 selected singlet bit without duplication. -/
 private theorem sum_honeycombVirtualConfig_eq_sum_rest_bit [NeZero m]
@@ -129,7 +119,7 @@ private theorem honeycombIncidenceSpin_extend_of_ne
   · rw [honeycombIncidenceSpin, dif_neg hf,
       honeycombIncidenceSpin, dif_neg hf]
     have hne :
-        (⟨e.symm, honeycombDart_symm_fst_eq_false_local e hf⟩ :
+        (⟨e.symm, honeycombDart_symm_fst_eq_false e hf⟩ :
           HoneycombForwardDart m) ≠ d := by
       intro h
       have hval := congrArg Subtype.val h
@@ -137,9 +127,9 @@ private theorem honeycombIncidenceSpin_extend_of_ne
       have := congrArg SimpleGraph.Dart.symm hval
       simpa using this
     rw [honeycombExtendBondRest_apply_of_ne d
-        ⟨e.symm, honeycombDart_symm_fst_eq_false_local e hf⟩ hne,
+        ⟨e.symm, honeycombDart_symm_fst_eq_false e hf⟩ hne,
       honeycombExtendBondRest_apply_of_ne d
-        ⟨e.symm, honeycombDart_symm_fst_eq_false_local e hf⟩ hne]
+        ⟨e.symm, honeycombDart_symm_fst_eq_false e hf⟩ hne]
 
 /-- The set of down-spin outgoing incidences at a vertex. -/
 private def honeycombDownDarts [NeZero m]

--- a/LatticeSystem/Quantum/SpinS/HoneycombAKLTVBS.lean
+++ b/LatticeSystem/Quantum/SpinS/HoneycombAKLTVBS.lean
@@ -62,7 +62,7 @@ theorem HoneycombForwardDart.snd_eq_true
     exact Bool.noConfusion hfalse
 
 /-- Reversing a non-forward honeycomb dart gives a forward dart. -/
-private theorem honeycombDart_symm_fst_eq_false
+theorem honeycombDart_symm_fst_eq_false
     (d : (honeycombTorusGraph m).Dart)
     (hd : d.fst.2 ≠ false) :
     d.symm.fst.2 = false := by


### PR DESCRIPTION
## Summary
Deduplication of `honeycombDart_symm_fst_eq_false` lemma: merge private `_local` variant from `HoneycombAKLTBondAnnihilation.lean:85` into public `HoneycombAKLTVBS.lean:65`; rewire 3 consumer sites; discharge "No duplicate declarations ever" refactoring debt (#4718, #5098).

## Scope
- **Remove duplicate**: `HoneycombAKLTBondAnnihilation.lean:85` private `honeycombDart_symm_fst_eq_false_local` (α-equivalent to VBS-side statement) → delete, re-export from VBS.
- **Rewire consumers**: Lines 132, 140, 142 in `HoneycombAKLTBondAnnihilation.lean` → import from `HoneycombAKLTVBS` instead of local private.
- **Exclude from this PR**: `glueBond_symm_*` twins (separate PR, import-direction design TBD); AnisotropicHeisenberg sprawl (separate arc).

## Refs
Refs #5098, #4718
