### PR TITLE
docs(tex): replace 25 dead per-PR entries with one aggregate note — #5140

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -91,9 +91,14 @@ every one of those stems (`bipartiteToyGroundStateSubspacePredicted`,
 `neelStateOfS`, `heisenbergToyHamiltonianS`, `ladderIterateUp`,
 `allAlignedStateS`, `totalSpinSOpPlus`/`totalSpinSOpMinus`,
 `saturatedFerromagnetJointEigenspace`, and the `Theorem23*` module family) is
-still a live declaration prefix with surviving variants, and those survivors
-keep their own rows in this index — for `ladderIterateUp_*` the survivors are
-even the majority.  Only the variants enumerated above are gone.  Likewise,
+still a live declaration prefix with surviving variants.  Most of those
+survivors keep their own rows in this index, but not all: of the 201 live
+public declarations under the declaration stems just listed, 158 are named in
+some row's first column, three only inside another row's prose, and 40 are not
+named in this file at all.  For `ladderIterateUp_*` the survivors are even the
+majority of the stem's variants: of the 17 declarations with that prefix that
+the tree held before these deletions, 11 are still present.  Only the variants
+enumerated above are gone.  Likewise,
 deleted names of the form `tasaki_2_5_theorem_2_3_of_..._threaded_...` belonged
 to the abandoned route and are not the live capstone `tasaki_2_5_theorem_2_3`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,8 +90,9 @@ every one of those stems (`bipartiteToyGroundStateSubspacePredicted`,
 `bipartiteToyMinEnergyPredicted`, `bipartiteImbalanceWeight`, `neelStateOf`,
 `neelStateOfS`, `heisenbergToyHamiltonianS`, `ladderIterateUp`,
 `allAlignedStateS`, `totalSpinSOpPlus`/`totalSpinSOpMinus`,
-`saturatedFerromagnetJointEigenspace`, and the `Theorem23*` module family) is
-still a live declaration prefix with surviving variants.  Most of those
+`saturatedFerromagnetJointEigenspace`) is still a live declaration prefix with
+surviving variants, and the `Theorem23*` module family is still 56 live modules
+under `Quantum/SpinS/` (no declaration name carries that prefix).  Most of those
 survivors keep their own rows in this index, but not all: of the 201 live
 public declarations under the declaration stems just listed, 158 are named in
 some row's first column, three only inside another row's prose, and 40 are not

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,9 +94,13 @@ every one of those stems (`bipartiteToyGroundStateSubspacePredicted`,
 surviving variants, and the `Theorem23*` module family is still 56 live modules
 under `Quantum/SpinS/` (no declaration name carries that prefix).  Most of those
 survivors keep their own rows in this index, but not all: of the 201 live
-public declarations under the declaration stems just listed, 158 are named in
-some row's first column, three only inside another row's prose, and 40 are not
-named in this file at all.  For `ladderIterateUp_*` the survivors are even the
+public declarations under the declaration stems just listed, 158 are named
+verbatim in some row's first column, two only inside another row's prose, one
+only inside the stem list just given, and 40 are named verbatim nowhere in this
+file, though some of that last group are still named indirectly inside this
+file's own abbreviated forms (brace families such as `_totalSpinSOp{1,2,3}` and
+suffix elisions such as `/ _sq`).
+For `ladderIterateUp_*` the survivors are even the
 majority of the stem's variants: of the 17 declarations with that prefix that
 the tree held before these deletions, 11 are still present.  Only the variants
 enumerated above are gone.  Likewise,

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -13542,9 +13542,10 @@ that currently exists is documented by this note, nor claimed by it to have been
 deleted; and \texttt{docs/index.md} records only part of what survives.  Of the 56
 public declarations the names above resolve to today --- 20
 \texttt{tasaki23\_pf\_\dots}, 21 \texttt{bipartiteToy\dots}, 11
-\texttt{ladderIterateUp\dots}, and four spelled out in full --- it names 43 in a
-row's key column, names the Theorem~2.2 ground-state theorem only inside other
-rows' prose, and does not name the remaining 12 variants at all.
+\texttt{ladderIterateUp\dots}, and four spelled out in full --- it names,
+verbatim, 43 in a key column, the Theorem~2.2 ground-state theorem only in
+prose, and none of the remaining 12, some of which its own suffix elisions
+(\texttt{/ \_re\_eq}) still name indirectly.
 
 \textbf{Route correction (2026-05-26), kept because it is a soundness record.}
 An earlier ``saturated-ladder-iterate'' route toward

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -16065,107 +16065,6 @@ $\texttt{joint} = \texttt{span}(\texttt{ladderIterateUp})$ and hence
 $\dim_\mathbb{C}(\texttt{joint}) = 2m_{\max} + 1$, completing
 Tasaki §2.4 Theorem 2.1.
 
-\textbf{Ladder span finrank (PR~\#904)}: the new file
-\texttt{Quantum/SpinS/SaturatedLadderSpan.lean} applies mathlib's
-\texttt{finrank\_span\_eq\_card} to the LI family of \#896,
-yielding
-\texttt{ladderIterateUp\_span\_finrank\_eq\_succ\_card\_mul\_N}:
-$\dim_\mathbb{C} \texttt{Submodule.span} = |V|\cdot N + 1 =
-2m_{\max} + 1$. The span is contained in the joint eigenspace
-of \#903 via \texttt{Submodule.span\_le}.
-
-\textbf{Finrank-equality corollary (PR~\#2769)}: in
-\texttt{Quantum/SpinS/SaturatedLadderSpan.lean},
-\texttt{saturatedFerromagnetJointEigenspace\_finrank\_eq} promotes
-the lower bound of \#903 to the operator-level equality
-$\dim_\mathbb{C}(\texttt{joint J N}) = |V|\cdot N + 1 = 2m_{\max}+1$
-by rewriting through \#2768's \texttt{\_eq\_span\_ladderIterateUp}
-and applying the span-finrank result of \#904. Identifies the
-saturated-ferromagnet joint eigenspace as the unique
-$(2m_{\max}+1)$-dimensional irreducible $SU(2)$ representation at
-the operator level.
-
-\textbf{$\hat S^-_{\rm tot}$ invariance (PR~\#2770)}: the new file
-\texttt{Quantum/SpinS/SaturatedLadderLoweringInvariant.lean} adds
-the operational lowering-side $su(2)$ statement.
-Per-iterate action:
-\texttt{totalSpinSOpMinus\_mulVec\_ladderIterateUp\_interior} gives
-$\hat S^-_{\rm tot}\cdot\texttt{ladderIterateUp V N }k =
-\texttt{ladderIterateUp V N }\langle k+1, \cdot\rangle$ for $k+1 <
-|V|\cdot N + 1$ (definitionally from the iterate definition plus
-$\texttt{pow\_succ'}$);
-\texttt{totalSpinSOpMinus\_mulVec\_ladderIterateUp\_last} gives
-$\hat S^-_{\rm tot}\cdot\texttt{ladderIterateUp V N }(\texttt{Fin.last})
-= 0$ (boundary annihilation via \#905). Lifted via
-\texttt{Submodule.map\_span} + \texttt{Submodule.span\_le} on
-\#2768's $\texttt{joint} = \texttt{span}(\texttt{ladderIterateUp})$
-to the global invariance
-$\texttt{Submodule.map}\,\hat S^-_{\rm tot}.\texttt{mulVecLin}\,
-(\texttt{joint J N}) \le \texttt{joint J N}$. Combined with the
-finrank equality of \#2769 and the raising-side annihilation of
-\#907, this identifies the joint eigenspace as the
-$(2m_{\max}+1)$-dimensional spin-$m_{\max}$ representation of
-$su(2)$ under the total-spin generators.
-
-\textbf{$\hat S^+_{\rm tot}$ invariance (PR~\#2771)}: the new file
-\texttt{Quantum/SpinS/SaturatedLadderRaisingInvariant.lean}
-completes the operational $su(2)$ statement on the raising side.
-Per-iterate action:
-\texttt{totalSpinSOpPlus\_mulVec\_ladderIterateUp\_zero} gives
-$\hat S^+_{\rm tot}\cdot\texttt{ladderIterateUp V N }\langle 0,
-\cdot\rangle = 0$ (top-weight annihilation, via PR \#877's
-\texttt{totalSpinSOpPlus\_mulVec\_allAlignedStateS\_zero});
-\texttt{totalSpinSOpPlus\_mulVec\_ladderIterateUp\_succ} gives
-$\hat S^+_{\rm tot}\cdot\texttt{ladderIterateUp V N }\langle j+1,
-\cdot\rangle = ((j+1)\cdot(|V|\cdot N - j))\cdot
-\texttt{ladderIterateUp V N }\langle j, \cdot\rangle$ (Casimir-
-rearrangement scalar identity from PRs \#882, \#887, \#894 packaged
-as
-\texttt{totalSpinSOpPlus\_mulVec\_totalSpinSOpMinus\_pow\_succ\_allAlignedStateS\_zero}).
-Lifted via the same
-\texttt{Submodule.map\_span} + \texttt{Submodule.span\_le} pattern
-of PR \#2770 to the global invariance
-$\texttt{Submodule.map}\,\hat S^+_{\rm tot}.\texttt{mulVecLin}\,
-(\texttt{joint J N}) \le \texttt{joint J N}$. Together with
-\#2770, this establishes invariance of \texttt{joint J N} under
-both $su(2)$ ladder generators, completing the operational
-identification with the $(2m_{\max}+1)$-dim spin-$m_{\max}$
-irreducible representation.
-
-\textbf{Full Cartesian $su(2)$ closure (PR~\#2772)}: the new file
-\texttt{Quantum/SpinS/SaturatedLadderCartesianInvariant.lean}
-completes the operational $su(2)$-module structure of the
-saturated joint eigenspace. Two total-operator identities lift the
-single-site definitions of \texttt{spinSOp1} / \texttt{spinSOp2}:
-$\hat S^{(1)}_{\rm tot} = (1/2)(\hat S^+_{\rm tot} +
-\hat S^-_{\rm tot})$
-(\texttt{totalSpinSOp1\_eq\_one\_half\_smul\_plus\_add\_minus}) and
-$\hat S^{(2)}_{\rm tot} = (1/(2 i))(\hat S^+_{\rm tot} -
-\hat S^-_{\rm tot})$
-(\texttt{totalSpinSOp2\_eq\_one\_over\_two\_I\_smul\_plus\_sub\_minus}),
-both via \texttt{onSiteS\_smul} + \texttt{onSiteS\_add/sub}.
-The $\hat S^{(1)}_{\rm tot}$ and $\hat S^{(2)}_{\rm tot}$
-invariances
-(\texttt{saturatedFerromagnetJointEigenspace\_totalSpinSOp\{1,2\}\_invariant})
-reduce via these decompositions to the ladder invariances of PRs
-\#2770 / \#2771 plus submodule add/sub/smul closure. The
-$\hat S^{(3)}_{\rm tot}$ case
-(\texttt{saturatedFerromagnetJointEigenspace\_totalSpinSOp3\_invariant})
-is independent: each ladder iterate is an
-$\hat S^z_{\rm tot}$-eigenvector at eigenvalue $m_{\max}-k$
-(\texttt{ladderIterateUp\_mem\_eigenspace}), so its
-$\hat S^z_{\rm tot}$-image is a scalar multiple of the same
-iterate, still in $\texttt{span}(\texttt{ladderIterateUp}) =
-\texttt{joint J N}$ (\#2768). The three together establish
-invariance under all $su(2)$ generators acting through the
-total-spin operators, completing the operational identification of
-the saturated joint eigenspace with the $(2m_{\max}+1)$-dim
-irreducible representation of $su(2)$ at top weight $m_{\max}$.
-This finishes the operational closure of Tasaki §2.4 Theorem 2.1
-on top of \#2768 (joint = span ladder), \#2769 (finrank
-$= 2m_{\max}+1$), \#2770 ($\hat S^-_{\rm tot}$ invariance), and
-\#2771 ($\hat S^+_{\rm tot}$ invariance).
-
 \textbf{Boundary annihilation (PR~\#905)}: the new file
 \texttt{Quantum/SpinS/LadderBoundaryAnnihilation.lean} caps the
 ladder at exactly $2m_{\max}+1$ non-zero terms by proving
@@ -16200,38 +16099,6 @@ diagonality of $\hat S^z_{\rm tot}$, this yields
 \{$|\sigma_{\top/\bot}\rangle$\}}. Analytic counterpart of PR \#885's
 combinatorial cardinality.
 
-\textbf{Maximal-lowering iterate identification (PR~\#909)}: the new
-file \texttt{Quantum/SpinS/LadderBottom.lean} combines PR \#887's
-eigenvalue identity at $k = |V|\cdot N$ ($-m_{\max}$ eigenvalue)
-with PR \#908's extremal subspace identification, giving
-\texttt{totalSpinSOpMinus\_pow\_card\_mul\_N\_allAlignedStateS\_zero\_eq\_smul\_last}:
-there exists a non-zero $c\in\mathbb{C}$ with
-$(\hat S^-_{\rm tot})^{|V|\cdot N}\,|\sigma_\top\rangle =
-c\,|\sigma_\bot\rangle$. Non-vanishing of $c$ uses PR \#895.
-A symmetric span-membership statement is provided for the raising
-side; the non-zero scalar version is in PR \#910.
-
-\textbf{Symmetric inductive non-vanishing for raising side
-(PR~\#910)}: the new file
-\texttt{Quantum/SpinS/IterateInductiveNonvanishingPlus.lean} mirrors
-PR \#895 using PR \#894's MinusPlus Casimir rearrangement
-$\hat S^- \hat S^+ = \hat S_{\rm tot}^2 - (\hat S^z_{\rm tot})^2 -
-\hat S^z_{\rm tot}$. The same eigenvalue scalar $(k+1)(2m_{\max}-k)$
-arises with the raising-side $\hat S^z_{\rm tot}$ eigenvalue
-$-m_{\max}+k$ (PR \#887 raising side), giving
-\texttt{totalSpinSOpPlus\_pow\_allAlignedStateS\_last\_ne\_zero} for
-$k\leq|V|\cdot N$ and the non-zero scalar identification
-\texttt{totalSpinSOpPlus\_pow\_card\_mul\_N\_allAlignedStateS\_last\_eq\_smul\_zero}.
-
-\textbf{Round-trip identity (PR~\#912)}: the new file
-\texttt{Quantum/SpinS/LadderRoundTrip.lean} composes \#909 (lowering
-reaches $c_1\,|\sigma_\bot\rangle$) with \#910 (raising from
-$|\sigma_\bot\rangle$ reaches $c_2\,|\sigma_\top\rangle$) to give
-\texttt{totalSpinSOpPlus\_pow\_mulVec\_totalSpinSOpMinus\_pow\_allAlignedStateS\_zero\_eq\_smul}:
-the round-trip $(\hat S^+_{\rm tot})^{|V|\cdot N}\,(\hat S^-_{\rm tot})^{|V|\cdot N}\,|\sigma_\top\rangle$
-returns to a non-zero $c_1c_2\cdot|\sigma_\top\rangle$. The
-saturated-ferromagnet ladder closes on itself.
-
 \textbf{Expectation values on all-aligned states (PR~\#913)}: the new
 file \texttt{Quantum/SpinS/AllAlignedStateExpectations.lean} computes
 the inner-product expectation values
@@ -16247,38 +16114,6 @@ the explicit $J = m_{\max}$ quantum numbers.
 the off-diagonal case: distinct configurations $\sigma\neq\tau$
 give orthogonal basis vectors. Bundled in Kronecker form
 \texttt{basisVecS\_inner\_kronecker}.
-
-\textbf{Ladder iterate expectation values (PR~\#915)}: the new file
-\texttt{Quantum/SpinS/IterateExpectations.lean} packages the
-eigenvalue identities (\#881 H, \#882 Casimir, \#887 $\hat S^z$)
-into the inner-product form
-$\langle v_k, A\,v_k\rangle = \alpha\,\langle v_k, v_k\rangle$ for
-each iterate $v_k = (\hat S^-_{\rm tot})^k\,|\sigma_\top\rangle$ and
-$A\in\{\hat S^z_{\rm tot}, \hat S_{\rm tot}^2, H\}$ with the
-corresponding eigenvalue $\alpha$.
-
-\textbf{basisVecS spans + linearly independent (PR~\#917)}: the new
-file \texttt{Quantum/SpinS/BasisVecSBasis.lean} proves
-\texttt{basisVecS\_span\_eq\_top} (via
-\texttt{fun\_eq\_sum\_smul\_basisVecS}) and
-\texttt{basisVecS\_linearIndependent} (via pointwise evaluation of
-zero-sums). These structural facts identify
-\texttt{basisVecS} as a basis of the multi-site Hilbert space.
-
-\textbf{Multi-site dimension formula (PR~\#918)}: the new file
-\texttt{Quantum/SpinS/MultiSiteFinrank.lean} proves
-\texttt{multiSiteSpinS\_finrank}: $\dim_\mathbb{C} ((V \to
-\textsf{Fin}\,(N+1)) \to \mathbb{C}) = (N+1)^{|V|}$. Direct from
-mathlib's \texttt{Module.finrank\_fintype\_fun\_eq\_card} +
-\texttt{Fintype.card\_fun} + \texttt{Fintype.card\_fin}. The
-standard quantum-mechanical dimension formula $(2S+1)^{|\Lambda|}$.
-
-\textbf{basisSpinS as Module.Basis (PR~\#919)}: the new file
-\texttt{Quantum/SpinS/BasisSpinS.lean} bundles \#917 into a
-\texttt{Module.Basis (V $\to$ Fin (N+1)) $\mathbb{C}$
-((V $\to$ Fin (N+1)) $\to$ $\mathbb{C}$)} via
-\texttt{Module.Basis.mk}, with the apply equality
-\texttt{basisSpinS V N $\sigma$ = basisVecS $\sigma$}.
 
 \textbf{Universal single-site Casimir expectation (PR~\#920)}: the
 new file \texttt{Quantum/SpinS/SingleSiteCasimirExpectation.lean}
@@ -17020,47 +16855,6 @@ configuration $\sigma$ (transverse operators are purely off-diagonal,
 the saturated-ferromagnet $|c..c\rangle$ has per-axis spin profile
 $(0, 0, N/2-c)$ — only the z-component is non-zero.
 
-\textbf{Singlet correlation sum (PR~\#929)}: the new file
-\texttt{Quantum/SpinS/SingletCorrelationSum.lean} proves that for
-any singlet state $\Phi$ ($\hat{S}_{\rm tot}^2\,\Phi = 0$),
-$\sum_{x, y}\langle\Phi, \hat{S}_x\cdot\hat{S}_y\,\Phi\rangle = 0$.
-Direct combination of \texttt{totalSpinSSquared\_eq\_sum\_spinSDot}
-with \texttt{Matrix.sum\_mulVec} + \texttt{dotProduct\_sum} linearity
-and \texttt{dotProduct\_zero}.
-
-\textbf{Universal correlation = Casimir expectation (PR~\#930)}:
-the new file \texttt{Quantum/SpinS/CorrelationSumCasimir.lean}
-generalises \#929 to ANY state:
-$\sum_{x, y}\langle\Phi, \hat{S}_x\cdot\hat{S}_y\,\Phi\rangle =
-\langle\Phi, \hat{S}_{\rm tot}^2\,\Phi\rangle$. Specialised to
-$|\sigma_\top\rangle$ and $|\sigma_\bot\rangle$ gives the Casimir
-eigenvalue $m_{\max}(m_{\max}+1)$.
-
-\textbf{Eigenvector correlation sum (PR~\#931)}: the new file
-\texttt{Quantum/SpinS/CorrelationEigenvector.lean} parameterises
-the result of \#930 by the eigenvalue: for $\hat{S}_{\rm tot}^2\Phi
-= \lambda\,\Phi$, $\sum_{x, y}\langle\Phi, \hat{S}_x\cdot\hat{S}_y\,\Phi\rangle
-= \lambda\,\langle\Phi, \Phi\rangle$. For normalized $\Phi$, the
-sum equals $\lambda$.
-
-\textbf{Off-diagonal correlation sum (PR~\#933)}: the new file
-\texttt{Quantum/SpinS/CorrelationOffDiagonal.lean} introduces the
-universal diagonal sum
-$\sum_x\langle\Phi, \hat{S}_x\cdot\hat{S}_x\,\Phi\rangle =
-|V|\cdot S(S+1)\cdot\langle\Phi,\Phi\rangle$ (from \#920) and
-subtracts from \#931 to give: for $\hat{S}_{\rm tot}^2\Phi =
-\lambda\,\Phi$, $\sum_{x\neq y}\langle\Phi, \hat{S}_x\cdot\hat{S}_y\,\Phi\rangle
-= (\lambda - |V|\cdot S(S+1))\cdot\langle\Phi,\Phi\rangle$.
-
-\textbf{Saturated off-diagonal correlation sum (PR~\#934)}: the
-new file
-\texttt{Quantum/SpinS/SaturatedOffDiagonalCorrelation.lean}
-specialises \#933 to $|\sigma_{\top/\bot}\rangle$ using \#882
-(Casimir at $k=0$) + \#913 (normalization), yielding
-$\sum_{x\neq y}\langle|\sigma_\top\rangle,
-\hat{S}_x\cdot\hat{S}_y\,|\sigma_\top\rangle\rangle =
-m_{\max}(m_{\max}+1) - |V|\cdot S(S+1) = N^2\,|V|(|V|-1)/4$.
-
 \textbf{Fermion $\leftrightarrow$ spin-`S` bridge at $N = 1$
 (PR~\#936)}: the new file
 \texttt{Fermion/SpinSBridge.lean} composes the existing
@@ -17092,14 +16886,6 @@ new file \texttt{Quantum/SpinS/SpinSDotAllAlignedLast.lean} mirrors
 \hat{S}^-$, $0 \leftrightarrow N$ swap. The $(3)(3)$ coefficient
 $(-N/2)^2$ also gives $N^2/4$.
 
-\textbf{Per-pair correlation expectation (PR~\#941)}: the new file
-\texttt{Quantum/SpinS/PerPairCorrelationExpectation.lean} packages
-\#939/\#940 with the normalization (\#913):
-$\langle|\sigma_{\top/\bot}\rangle, \hat{S}_x\cdot\hat{S}_y\,
-|\sigma_{\top/\bot}\rangle\rangle = N^2/4 = S^2$ for $x \neq y$.
-The total off-diagonal sum then equals $|V|\cdot(|V|-1)\cdot S^2$,
-matching \#934.
-
 \textbf{Heisenberg expectation on saturated states (PR~\#943)}: the
 new file \texttt{Quantum/SpinS/SaturatedHeisenbergExpectation.lean}
 gives the H-eigenvalue expectation:
@@ -17107,12 +16893,6 @@ $\langle|\sigma_\top\rangle, H\,|\sigma_\top\rangle\rangle =
 \texttt{saturatedFerromagnetEigenvalueS}\,J\,N$ (defined as
 $H(\sigma_\top, \sigma_\top)$ in \#899). Symmetric for
 $|\sigma_\bot\rangle$, with eigenvalue $H(\sigma_\bot, \sigma_\bot)$.
-
-\textbf{Uniform-J Heisenberg equals Casimir (PR~\#945)}: the new
-file \texttt{Quantum/SpinS/HeisenbergUniformCasimir.lean} proves
-\texttt{heisenbergHamiltonianS (fun \_ \_ => 1) N = totalSpinSSquared V N}.
-Direct from the definition $H = \sum_{x, y} J\,\hat{S}_x\cdot\hat{S}_y$
-+ \texttt{totalSpinSSquared\_eq\_sum\_spinSDot}.
 
 \textbf{H-diagonal symmetry (PR~\#946)}: the new file
 \texttt{Quantum/SpinS/SaturatedHeisenbergSymmetric.lean} shows
@@ -17122,23 +16902,6 @@ $H(\sigma_\bot, \sigma_\bot) =
 the eigenvalue on a non-zero eigenvector (via
 \texttt{allAlignedStateS\_ne\_zero}) extracts
 $E = H(\sigma_\top, \sigma_\top) = H(\sigma_\bot, \sigma_\bot)$.
-
-\textbf{Symmetric H expectation cleanup (PR~\#948)}: the new file
-\texttt{Quantum/SpinS/SaturatedHeisenbergExpectationClean.lean}
-chains \#943 and \#946 to give the clean form
-$\langle|\sigma_\bot\rangle, H\,|\sigma_\bot\rangle\rangle =
-\texttt{saturatedFerromagnetEigenvalueS}\,J\,N$, matching the
-$|\sigma_\top\rangle$ statement.
-
-\textbf{Uniform-J saturated eigenvalue equals Casimir (PR~\#949)}:
-the new file
-\texttt{Quantum/SpinS/SaturatedHeisenbergUniformEigenvalue.lean}
-proves
-$\texttt{saturatedFerromagnetEigenvalueS}\,(\lambda\_\_, 1)\,N =
-\texttt{saturatedFerromagnetCasimirEigenvalueS}\,V\,N =
-m_{\max}(m_{\max}+1)$. Direct from \#945 ($H_{\rm uniform} =
-\hat{S}_{\rm tot}^2$) plus the diagonal entry of $\hat{S}_{\rm tot}^2$
-at $\sigma_\top$.
 
 \textbf{Explicit form of saturated FM eigenvalue (PR~\#951)}: the
 new file
@@ -17155,40 +16918,11 @@ In the Tasaki §2.5 Theorem~2.3 chain, the same explicit formula gives
 the saturated ferromagnetic energy is represented by its real part as a real
 scalar.
 
-\textbf{Explicit uniform-J eigenvalue simplification (PR~\#953)}:
-the new file
-\texttt{Quantum/SpinS/SaturatedExplicitUniformSimp.lean} combines
-\#951 (explicit form) with \#949 (uniform = Casimir) to give
-the closed-form simplification
-$\sum_x \sum_y (\textsf{if}\ x=y\ \textsf{then}\ N(N+2)/4\
-\textsf{else}\ (N/2)^2) = m_{\max}(m_{\max}+1)$.
-
-\textbf{Explicit H expectation on saturated states (PR~\#954)}: the
-new file \texttt{Quantum/SpinS/HExpectationExplicit.lean} chains
-\#943/\#948 with \#951 to give the explicit combinatorial form of
-$\langle|\sigma_{\top/\bot}\rangle, H\,|\sigma_{\top/\bot}\rangle\rangle$
-in terms of the $J(x,y)$ couplings.
-
 \textbf{Distinct constant-spin states are different (PR~\#956)}:
 the new file \texttt{Quantum/SpinS/AllAlignedStateDistinct.lean}
 proves \texttt{allAlignedConfigS\_injective} (when $V$ is non-empty)
 and the corresponding \texttt{allAlignedStateS\_ne\_of\_ne}.
 Used as a building block for the LI of the all-aligned family.
-
-\textbf{All-aligned states form a LI family (PR~\#957)}: the new
-file \texttt{Quantum/SpinS/AllAlignedStateLI.lean} proves
-\texttt{allAlignedStateS\_linearIndependent}: the
-$(N+1)$-element family $\{|c..c\rangle : c \in \textsf{Fin}\,(N+1)\}$
-is linearly independent over $\mathbb{C}$. Direct application of
-\texttt{Module.End.eigenvectors\_linearIndependent'} with the
-injective $\hat{S}^z_{\rm tot}$ eigenvalue function
-$c \mapsto |V|\cdot N/2 - |V|\cdot c$.
-
-\textbf{All-aligned span finrank (PR~\#959)}: the new file
-\texttt{Quantum/SpinS/AllAlignedStateSpan.lean} applies
-\texttt{finrank\_span\_eq\_card} to PR \#957's LI family,
-yielding $\dim_\mathbb{C}\,\texttt{Submodule.span}\,\mathbb{C}\,
-(\textsf{Set.range}\,\texttt{allAlignedStateS}) = N + 1$.
 
 \textbf{All-aligned states orthogonal (PR~\#960)}: the new file
 \texttt{Quantum/SpinS/AllAlignedStateOrthogonal.lean} proves
@@ -17948,6 +17682,54 @@ Generalises by induction (with the higher-$k$ extension of
 PR~\#890) to the full $(2m_{\max}+1)$-vector family
 $\{(\hat S^\mp_{\rm tot})^k\,|\sigma_{\top/\bot}\rangle:
  k=0,\ldots,2m_{\max}\}$.
+
+\textbf{Removed entries (PR~\#5145, issue~\#5140).}  Twenty-five per-PR entries of
+this subsection were removed because each of them names exactly one module and
+none of those modules exists any more: the entries for PRs~\#904, \#909, \#910,
+\#912, \#915, \#917, \#918, \#919, \#929, \#930, \#931, \#933, \#934, \#941,
+\#945, \#948, \#949, \#953, \#954, \#957, \#959, \#2769, \#2770, \#2771 and
+\#2772.  Between them those 25 entries named 24 distinct modules under
+\texttt{LatticeSystem/Quantum/SpinS/} --- the entries for \#904 and \#2769 named
+the same one --- and every one of those 24 was removed by one single commit, the
+same one that the $\gamma$-4 chronicle note earlier in this section records:
+PR~\#3919, commit \texttt{7b65d59e}, the Phase-C refactor that deleted 525 orphan
+modules and 35{,}002 lines of dead code in one step.  Of the declarations those
+entries stated as their subjects, these five have no occurrence anywhere under
+\texttt{LatticeSystem/} today: the ladder-span finrank
+\texttt{ladderIterateUp\_span\_finrank\_eq\_succ\_card\_mul\_N}, the basis span
+\texttt{basisVecS\_span\_eq\_top}, the joint-eigenspace finrank
+\texttt{saturatedFerromagnetJointEigenspace\_finrank\_eq}, the multi-site finrank
+\texttt{multiSiteSpinS\_finrank}, and
+\texttt{allAlignedStateS\_linearIndependent}.
+
+\textbf{What this note does \emph{not} say.}  The Phase-C removal is stated
+extensionally: it covers exactly those modules of the 25 removed entries that
+commit \texttt{7b65d59e} deleted, and that commit's diff is the authoritative
+list.  It is not a claim about any name family.  Declarations that those entries
+cited as inputs are still present under \texttt{LatticeSystem/} and are
+\emph{not} covered by this note --- among them \texttt{onSiteS\_add},
+\texttt{onSiteS\_smul}, \texttt{fun\_eq\_sum\_smul\_basisVecS},
+\texttt{spinSOp1}, \texttt{spinSOp2},
+\texttt{totalSpinSSquared\_eq\_sum\_spinSDot} and
+\texttt{ladderIterateUp\_mem\_eigenspace}, the last of which shares its name stem
+with removed ladder lemmas and survives all the same.  No declaration that
+currently exists is documented by this note, nor claimed by it to have been
+deleted; the per-declaration record for the survivors is \texttt{docs/index.md}.
+
+\textbf{Where those results stand today.}  Three citations of PR~\#904 survive
+above, in the \#2759 entry and in the \#2768 closure entry: as the
+span-equals-joint argument, as the reverse inclusion fed to
+\texttt{le\_antisymm}, and in the list of inputs to the operator-level form of
+the theorem.  Those citations are to the historical pull request, which did the
+work described; only its module and its own entry here are gone.  The span
+identification it supplied is carried today by the theorem
+\texttt{saturatedFerromagnetJointEigenspace\_eq\_span\_ladderIterateUp} that the
+surviving \emph{Tasaki §2.4 Theorem 2.1 closure (PR~\#2768)} entry already
+names; the dimension equality that PR~\#2769 packaged went with its module, and
+what the sources state today is the lower bound
+\texttt{saturatedFerromagnetJointEigenspace\_finrank\_ge\_succ\_card\_mul\_N}.
+The theorem being closed is H.~Tasaki, \emph{Physics and Mathematics of Quantum
+Many-Body Systems}, Springer 2020, §2.4 Theorem~2.1, p.~34.
 
 \subsection*{DONE: Tasaki Problem 2.2.c}
 

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -13539,7 +13539,12 @@ standard bipartite coupling, and parts of the \texttt{bipartiteToy\dots} and
 \texttt{saturatedFerromagnetJointEigenspace\_eq\_span\_ladderIterateUp}, the
 declaration that carries the saturated-ladder span result today.  No declaration
 that currently exists is documented by this note, nor claimed by it to have been
-deleted; the per-declaration record for the survivors is \texttt{docs/index.md}.
+deleted; and \texttt{docs/index.md} records only part of what survives.  Of the 56
+public declarations the names above resolve to today --- 20
+\texttt{tasaki23\_pf\_\dots}, 21 \texttt{bipartiteToy\dots}, 11
+\texttt{ladderIterateUp\dots}, and four spelled out in full --- it names 43 in a
+row's key column, names the Theorem~2.2 ground-state theorem only inside other
+rows' prose, and does not name the remaining 12 variants at all.
 
 \textbf{Route correction (2026-05-26), kept because it is a soundness record.}
 An earlier ``saturated-ladder-iterate'' route toward

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -13576,8 +13576,9 @@ carries no \texttt{hOutside} hypothesis but does keep the canonical orientation
 $c_{\rm toy}$ strictly above every diagonal entry of the dressed toy-coupling
 matrix.  The Theorem~2.2
 sector statement is the preceding subsection, \emph{Marshall--Lieb--Mattis
-Theorem 2.2 (Tasaki §2.5) --- formalisation outline}.  The per-declaration index
-of everything that survives is \texttt{docs/index.md} itself.  Which of its rows
+Theorem 2.2 (Tasaki §2.5) --- formalisation outline}.  The per-declaration
+record for the survivors is \texttt{docs/index.md} itself, which --- as counted
+earlier in this note --- names most of them but not all.  Which of its rows
 were pruned when the deleted routes went, and what those rows used to document,
 is recorded separately in that file's ``Deleted routes'' section.  The label
 \texttt{subsec:mlm-theorem-2-3} of the removed subsection is kept on this note,

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -13465,11 +13465,15 @@ has the Marshall sign structure
   Marshall-positive sector-supported eigenvectors at the same $\mu$.
 \end{enumerate}
 
-\textbf{Lean entry point}:
-\texttt{LatticeSystem/Quantum/SpinS/MagSectorEmbedding.lean},
-theorem
-\texttt{marshallLiebMattis\_spinS\_heisenbergHamiltonianS\_groundState\_full}
-(\#869).
+\textbf{Lean entry point}: the outline above is packaged in Lean as a single
+bundled theorem, namely
+\texttt{marshallLiebMattis\_spinS\_heisenbergHamiltonianS\_groundState\_full},
+which PR~\#869 introduced and which is carried today, in the
+\texttt{h\_intermediate}-free structural form of PR~\#3891, by the module
+\texttt{LatticeSystem/Quantum/SpinS/Theorem23StructuralMLMFull.lean}.  The
+sector~$\leftrightarrow$~full-Hilbert-space lift lemmas that this module imports
+for the last item of the outline are in
+\texttt{LatticeSystem/Quantum/SpinS/MagSectorEmbedding.lean}.
 
 \subsection*{Removed chronicle: the \texorpdfstring{$\gamma$-4}{gamma-4} step
              log for Tasaki §2.5 Theorem 2.3, unbalanced case}
@@ -13481,11 +13485,12 @@ Theorem~2.3 in the unbalanced case $|A| \neq |B|$ (H.~Tasaki, \emph{Physics and
 Mathematics of Quantum Many-Body Systems}, Springer 2020, §2.5 Theorem~2.3,
 p.~42).  It consisted of 218 individual ``Step~$n$ (PR~\#\dots)'' entries, one
 per merged pull request, one summary entry for Steps~219--261
-(PRs~\#3012--\#3054), and 57 further run-in bold headings for the threading
-layers that came after, recording the conditional wrappers, callback-threaded
-energy-interval chains, predecessor-coefficient lemmas, lowered and raised
-site-sum dominance sources, and toy-Hamiltonian predicted-ground-state layers
-of that development.
+(PRs~\#3012--\#3054), and 57 further run-in bold headings: the \textbf{Goal}
+statement that opened the subsection ahead of Step~1, and 56 headings for the
+threading layers that came after the Step entries, recording the conditional
+wrappers, callback-threaded energy-interval chains, predecessor-coefficient
+lemmas, lowered and raised site-sum dominance sources, and toy-Hamiltonian
+predicted-ground-state layers of that development.
 
 \textbf{Why it is gone.}  The chronicle carried 226 distinct \texttt{.lean} file
 references, of which 194 name files that no longer exist, and every one of those
@@ -13517,7 +13522,9 @@ modules ended in ``etc.''.  Four wildcard patterns were used as well:
 and the suffix-less \texttt{LatticeSystem.Quantum.SpinS.Theorem23*} and
 \texttt{Theorem23Structural*}, which do match surviving modules.
 
-\textbf{What this note does \emph{not} say.}  The removal is stated
+\textbf{What this note does \emph{not} say.}  The Phase-C removal --- the one
+performed by commit \texttt{7b65d59e}, not either of the other two removals named
+above, commits \texttt{f7947dfc} and \texttt{f91a7f26} --- is stated
 extensionally: it covers exactly those modules of the chronicle that commit
 \texttt{7b65d59e} deleted, and that commit's diff is the authoritative list.  It
 is not a claim about any name family.  Deleted wrappers shared name stems with

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -17700,9 +17700,10 @@ none of those modules exists any more: the entries for PRs~\#904, \#909, \#910,
 the same one --- and every one of those 24 was removed by one single commit, the
 same one that the $\gamma$-4 chronicle note earlier in this section records:
 PR~\#3919, commit \texttt{7b65d59e}, the Phase-C refactor that deleted 525 orphan
-modules and 35{,}002 lines of dead code in one step.  Of the declarations those
-entries stated as their subjects, these five have no occurrence anywhere under
-\texttt{LatticeSystem/} today: the ladder-span finrank
+modules and 35{,}002 lines of dead code in one step.  Of the declaration names
+those entries mention --- subjects and cited inputs alike, module file names
+aside --- twenty have no occurrence anywhere under \texttt{LatticeSystem/}
+today; these five are among them: the ladder-span finrank
 \texttt{ladderIterateUp\_span\_finrank\_eq\_succ\_card\_mul\_N}, the basis span
 \texttt{basisVecS\_span\_eq\_top}, the joint-eigenspace finrank
 \texttt{saturatedFerromagnetJointEigenspace\_finrank\_eq}, the multi-site finrank
@@ -17721,7 +17722,13 @@ cited as inputs are still present under \texttt{LatticeSystem/} and are
 \texttt{ladderIterateUp\_mem\_eigenspace}, the last of which shares its name stem
 with removed ladder lemmas and survives all the same.  No declaration that
 currently exists is documented by this note, nor claimed by it to have been
-deleted; the per-declaration record for the survivors is \texttt{docs/index.md}.
+deleted.  Of the seven survivors just named, four are recorded in
+\texttt{docs/index.md}: \texttt{spinSOp1} and \texttt{spinSOp2} share a row
+there, \texttt{ladderIterateUp\_mem\_eigenspace} sits in the ladder-family row,
+and \texttt{totalSpinSSquared\_eq\_sum\_spinSDot} appears there only inside the
+row of its leaf-level mirror \texttt{leafSpinSSquared\_eq\_sum\_spinSDot}.  The
+other three, \texttt{onSiteS\_add}, \texttt{onSiteS\_smul} and
+\texttt{fun\_eq\_sum\_smul\_basisVecS}, have no mention in that file at all.
 
 \textbf{Where those results stand today.}  Three citations of PR~\#904 survive
 above, in the \#2759 entry and in the \#2768 closure entry: as the


### PR DESCRIPTION
## 目的

Issue #5140 の**最終波**. `tex/proof-guide.tex` の subsection B に残る **25 の per-PR エントリ (266 行)** を削除し, **集約 1 本の履歴注記 (39 行)** に置換する. これで検査器の `UNRESOLVED` が **0** になる (残余は `EXCLUSIONS` 3 件のみ).

## 設計正本

`.self-local/reports/design-5140-wave3b-tex-subsectionB-entries-2026-07-25.md`

## ユーザー承認済 (2026-07-25)

「subsection A 全削除 + subsection B は 25 エントリのみ削除」. **B の全削除は不可** — Problem 2.5.c (35 参照) / 2.5.d (27 参照) の文献アンカー (p.43 / p.40 / 解答 p.498), CAR/JW/Hubbard 年代記, **生存ファイル 5 本の唯一の記載**を含むため.

## 対象の実測 (設計時)

行番号は Wave 3a の +19 行純増でずれているので**着手時に再測**する.

- 25 段落 (各 `\textbf{}` 1 個), 241 行 + 前置空行 25 = **266 行**
- **24 distinct モジュール** (`SaturatedLadderSpan.lean` が #904/#2769 で重複)
- **24/24 が単一コミット `7b65d59e` (PR #3919) で削除済**

## 誤爆ゼロの実測 (削除 266 行内)

`\label` 0 / `\ref` 系 0 / `\begin|\end` 0 / **`Problem 2.5.c` 0 (文書全体 36 件はすべて範囲外)・`2.5.d` 0 (同 29 件)** / `p.~N` 0 / `Springer` 0 / 外部参照 0 / **既存 `.lean` パス 0** / brace・`$` balance 25/25 OK. 生存ファイル 5 本と CAR/JW/Hubbard 年代記は範囲外で存続. `Theorem 2.1` は 9 行中 1 行のみ削除 (8 存続). **`EXCLUSIONS` (`tex:161`/`:4069`/`:4078`) は最初の削除行より前**なので不変.

## 注記の方針 (メイン確定)

**25 個別注記ではなく集約 1 本 (39 行) を B 末尾に置く** — 個別注記は誤帰属の機会を 25 回作るため. 外延的削除主張 (`7b65d59e` の diff が正本), `What this note does not say` で live 入力補題を明記, 「現存宣言を documentation しない」を明文化, **`.lean` パスを一切書かない** (→ 過去形アンカー不要, 検査器の `named_as_deleted` 免除に非依存).

## `#904` の宙吊り対策

B 内に `#904` を引く箇所が 5 箇所あり, 25 エントリ削除で宙吊りになる. live 後継 `saturatedFerromagnetJointEigenspace_eq_span_ladderIterateUp` (`SaturatedLadderJointEigenspace.lean:384`) を名指しする.

## 同 PR で回収する Wave 3a 繰り越し 3 件

1. `tex:13520` 付近の "The removal is stated extensionally … commit `7b65d59e` deleted" の **"The removal" の先行詞を限定** (Wave 3a R3 で削除元コミットが 3 本になり曖昧化. 例: "The Phase-C removal").
2. `tex:13484` 付近の "57 further run-in bold headings **for the threading layers that came after**" は数 (57) は正確だが 1 本 (`\textbf{Goal}`) が Step 群より**前**にあるので修飾語を直す.
3. `tex:13468-13472` の「Lean entry point: `MagSectorEmbedding.lean`, theorem `marshallLiebMattis_spinS_heisenbergHamiltonianS_groundState_full`」は誤りで実体は `Theorem23StructuralMLMFull.lean:30` — **ファイルが存在するため検査器では原理的に不可視な宣言レベルの stale**.

## Acceptance

- 現行検査器で **`UNRESOLVED=0 (excluded-by-design=3, in-deletion-notes=23)`** (**3 値を引用**; `exit 0` は必要条件だが単独ゲートにしない)
- ビルド (pdfLaTeX, **TEXMF override なし**, `proof-guide.log` の grep は **`grep -a` 必須**) = exit 0
- **272 → 270 ページ**
- warning 56 で数字マスク後 multiset 一致
- undefined reference 0
- `git diff --name-only main...HEAD | grep -c '\.lean$'` = 0
- `docs/index.md` は触らない

## 本 issue の教訓 (この PR で必ず適用)

偽主張が計 8 件発生し, **そのすべてが「量化・網羅を伴う主張」**だった (「194 すべて」「226 モジュール」「その他 32」「no surviving module goes unaccounted for」等). 数える基盤 (`.lean` パス参照 / dotted 名 / bare stem / basename / 宣言単位) がずれると崩れる. **集約注記に量化主張を書くときは「何を数えたのか」を必ず明示する**. 照合は brace-glob / 先頭 `_` 接尾省略 / スラッシュ略記 / tex の `\_` / `…` (U+2026) を**全展開し語境界を課す**.

## 検査器の性質 2 件 (Wave 3a で判明)

(a) `EXCLUSIONS` は **`(path, 行番号)` 鍵**なので `tex:161`/`:4069`/`:4078` より前の行の挿入・削除で壊れる (B は後方なので削除は安全).
(b) 検査器を `.self-local/tmp/…` のコピーから実行すると `ROOT = path.split("/.self-local")[0]` で**実 repo を再走査**して偽陽性が出る → 元の場所から実行し worktree は repo 外に置く.

## #5098 への引き渡し

B 削除で tex 記載を失う live 宣言 **3 件** (`fun_eq_sum_smul_basisVecS` `Magnetization.lean:251` / `onSiteS_add` `MultiSiteCore.lean:257` / `onSiteS_smul` `:308`). Wave 3a の 15 件と合わせ **最終合計 18 件** (うち使用 0 の 3 件は参照 0 装飾スイープ対象).

## 後続

本 PR merge 後に `dev-issue-manager` が検証して **#5140 を close** 判定する (本 PR は `Refs` のみ).

Refs #5140
Refs #5098
Refs #4718


## 【訂正追記 (merge 前)】本文の 2 点を訂正

1. **Acceptance の「`docs/index.md` は触らない」は誤り.** 実 diff は `docs/index.md` を **+18/−8** 編集している.
   編集内容は本 issue の自 PR (#5143 / #5144) が書いた**偽の量化主張の是正のみ**で, 表本体・他の行は不変
   (`**PROVED**` 19 / `axiom-free` 71 / `#print axioms` 24 / 表ヘッダ区切り 54 / 表行 2209 が不変, 編集行の
   パイプ数 0 = 散文行のみ). 偽の公開主張を放置する方が規約違反であり, 是正は #5140 の目的の内側.
   なお tex の hunk `@13465` (Lean entry point の repoint) は `4e19753f` (2026-05-03) 由来で自 PR ではないが,
   PR #5141「repoint stale .lean file references」と同一クラスで goal 内.
2. **「偽主張が計 8 件」は stale** — 本 issue 全体で **15 件** (本 PR だけで 5 件) に達した. 内訳と教訓は
   #5140 本文の最終追記に記録した.
