### PR TITLE
refactor: move the MagnetizationSubspaceCore import to its real consumer (shake) — #5098

### DIFF
--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpin.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpin.lean
@@ -1,6 +1,4 @@
 import LatticeSystem.Quantum.TotalSpin
-import LatticeSystem.Quantum.TotalSpin.Casimir
-import LatticeSystem.Quantum.MagnetizationSubspaceCore
 import LatticeSystem.Quantum.MarshallLiebMattis.SublatticeSpinCore
 
 set_option linter.unusedSectionVars false

--- a/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpinLadderPropertiesCore.lean
+++ b/LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpinLadderPropertiesCore.lean
@@ -1,3 +1,4 @@
+import LatticeSystem.Quantum.MagnetizationSubspaceCore
 import LatticeSystem.Quantum.MarshallLiebMattis.SublatticeSpin
 
 /-!


### PR DESCRIPTION
## 目的

#5098 の 2026-07-25 波 H2 (PR #5147) の follow-up ①. PR #5147 で取り下げた shake の import 削除を,
**正しい手順 (A-2)** で行う.

## 設計正本

`.self-local/reports/design-5098-a2/design-5098-a2-shake-sublatticespin-2026-07-26.md`
(再利用チェッカ `.self-local/reports/design-5098-a2/check_import_removal.py`).

## PR #5147 の事故の根本原因が特定された

**shake 自身が正しい直し方を出力する**. `--no-downstream` を付けず素で走らせると, 削除と下流追加が
**対で**出力される:

```
LatticeSystem/Quantum/MarshallLiebMattis/SublatticeSpin.lean:
  remove #[LatticeSystem.Quantum.MagnetizationSubspaceCore]
  instead
    import [LatticeSystem.Quantum.MagnetizationSubspaceCore] in ...SublatticeSpinLadderPropertiesCore
```

**PR #5147 の build error 9 件は, この downstream 出力を使わなかったことだけが原因**だった.

## import 構成の実測 (現 main, PR #5147 後の 4 行)

| import | in-file 使用 | Core 経由到達 | shake | 判定 |
|---|---|---|---|---|
| `TotalSpin` | 3 件 | 可 | 無言 | **KEEP** |
| `TotalSpin.Casimir` | **0 件** | 可 | 無言 | **DROP** |
| `MagnetizationSubspaceCore` | **0 件** | **不可** | remove | **DROP** (主目的) |
| `SublatticeSpinCore` | 8 件 | — | 無言 | **KEEP** |

`lake env lean` で「Core 1 行だけでも EXIT=0」を実測済 (対照実験で harness 妥当性も確認). shake が
`TotalSpin`/`Casimir` を指摘しない理由は `Shake/Main.lean:266-300` の読解で確定 — 削除判定は
`needs` の推移閉包和 (`transDeps`) に入らない import のみなので, **`Casimir` を外しても shake は
新たな `add` を出さない**.

## 下流依存の全数走査

直接 4 本 + 推移コーン 14 本: `MagnetizationSubspaceCore` 除去で名前解決が壊れるのは
**`SublatticeSpinLadderPropertiesCore` 1 本のみ** (`magnetizationSubspace` L138/139/155/156,
`mem_magnetizationSubspace_iff` L140/157). 他の `magnetizationSubspace` 使用者
(`SublatticeCasimirNeel(Core)`, `ToyHamiltonianCasimir`) は自前で直接 import 済.
**`TotalSpin.Casimir` 除去は閉包を失うモジュール 0 本**.

## スコープ (2 commit, この順序厳守)

① **足す** — `MarshallLiebMattis/SublatticeSpinLadderPropertiesCore.lean` に
`import LatticeSystem.Quantum.MagnetizationSubspaceCore` を 1 行追加 (この時点でも shake は無言)
② **外す** — `MarshallLiebMattis/SublatticeSpin.lean` から `MagnetizationSubspaceCore` と
`TotalSpin.Casimir` の 2 行を削除. **逆順は #5147 の 9 error を再現する**. `shake --fix` は順序事故を
起こさないが repo 全体 332 件を巻き込むため本 PR では手編集.

## リスク (実測)

`MagnetizationSubspaceCore` の属性は **`@[simp] mem_magnetizationSubspace_iff` 1 件のみ**,
`instance` / `attribute` / `notation` / `macro` は **0 件**. 閉包を失う 6 本はいずれも
`magnetizationSubspace` を一切書かないので発火しえない. **ただし simp 可視性と mathlib 側の間接
import 消失は静的に保証できないので実ビルドが唯一の裁定者**.

## Acceptance

(a) 静的近似チェッカ `check_import_removal.py` が PASS (**同チェッカは #5147 の誤りを FAIL として
再現できることを実証済**: `--add` を省くと
`[BROKEN] ... unresolved names ['magnetizationSubspace', 'mem_magnetizationSubspace_iff']` /
`RESULT: FAIL`)
(b) **引数なし `lake build` で warning / error / PANIC / backtrace / appArg! ゼロ, EXIT=0** —
**これが唯一の裁定者**
(c) **shake 再走で当該 2 ファイルのヒットが 0** (repo 全体 332 → 331 ブロック)
(d) 両 root からの到達不能 **0 本の維持** (1504/1504)
(e) capstone の `#print axioms` 不変
(f) 検査器 `python3 .self-local/reports/design-5140/check_lean_refs.py` が
`UNRESOLVED=0 (excluded-by-design=3, in-deletion-notes=23)` 維持.

## 【規律の更新】

#5098 に登録済の「shake 指摘の import 削除前に下流の推移 re-export 依存を実ビルドで確認する」を,
より正確に **「shake は `--no-downstream` を付けずに走らせ, 対で出力される下流追加を必ず適用する.
最終判定はビルドで取る (simp 可視性・mathlib の間接 import 消失は静的に保証できない)」** へ更新する.

## 別起票に回すもの (本 PR では触らない)

① **`docs/index.md` の stale file ref 12 行** (L1001/1002/1003/1006/1009/1012/1031/1039/1042/1044/1055
が実体のない `MarshallLiebMattis/SublatticeSpin.lean` に宣言を帰属; 過去の Core 分割由来.
`check_lean_refs.py` はパス存在のみ検査するため未検出 = **S5 クラス**). 本 PR は宣言を動かさないので
同梱の必然性なし.
② **repo 全体 shake sweep (332 ファイル / うち下流追加を伴う 153)** — 規模が大きく独自の計画を要する
ため #5098 の項目として起票し, 進め方 (ディレクトリ単位 / `--fix` 併用 / 1 PR 上限) は別途設計する.

---

Refs #5098
Refs #4718


## 【訂正追記 2026-07-26】shake ブロック数と docs stale 記述の訂正 (dev-issue-manager 実測)

本文の一部が **起票時の計画値 / 汚染環境での実測値** のままだったので訂正する (本文の該当箇所は
履歴として残し、以下を正とする)。

**訂正 1: Acceptance (c) の「repo 全体 332 → 331 ブロック」は誤り。** 正しくは
**merge base 327 → HEAD 326 (相対差 −1)**。332/331 は `.lake` を本チェックアウトと共有した
worktree での実行値で、**stale olean 由来の phantom ブロック 5 本**を含んでいた
(`MarshallLiebMattis/{SublatticeCasimirNeelCore, SublatticeSpinDot, SublatticeSpinLadderProperties}`,
`SpinS/PMMemAdjoin`, `Tests/TestHelpers`; いずれも本 PR の 3 行 import 変更と因果関係を持ち得ず、
本チェックアウトでの独立 2 実行 = `.self-local/tmp/shake-head2.log` (HEAD) と
`.self-local/reports/audit2-2026-07-25/shake-now.txt` (07-25 main) の双方に皆無)。
6 番目の超過分 `SpinS/SublatticeSpinLadderDef.lean` は **実在ブロック**で、PR #5147 が同ファイルを
50 行/3 定理に縮小した副作用 (merge base 由来、本 PR とは無関係)。
**acceptance (c) の実質は満たしている**: HEAD で当該 2 ファイルのヒット **0**、かつ
**新規ヒット 0**。**shake の絶対ブロック数を acceptance に使わない**
(相対差 + 当該ファイル消滅 + 新規ヒットなしで判定)。
**なお「差 5 = shake 自身のビルドノイズ行」という当初の説明は誤り**: ノイズ行
(`⚠ Replayed Shake.Main` 1 + `warning: Shake/Main.lean…` 3 + `Note: …` 3 + 空行 3 = 10 行) は
全ログで同数であり、ヘッダ行 (`*.lean:`) 計数では**元から除外**されている。

**訂正 2: 「repo 全体 shake sweep (332 ファイル / うち下流追加を伴う 153)」も汚染値。**
HEAD 実測 = **326 ブロック / `add` を伴う 290 / `instead` (下流追加) を伴う 151 /
pure-remove-only 4**。別起票する sweep の計画はこの値を前提にする。

**訂正 3: 別起票 ① の「実体のない `MarshallLiebMattis/SublatticeSpin.lean`」は誤り。**
同ファイルは **実在** (9417 B / live 宣言 10 本) で、stale は **宣言レベルの帰属ずれ** (= S5)。実測:
同パスを引く docs 行は **14 行**、うち **L999 / L1000 は帰属が正しく stale ではない**。
**stale は 12 行 = L1001/1002/1003/1006/1007/1009/1012/1031/1039/1042/1044/1055** で、
本文の列挙 11 個には **L1007 が欠落**していた
(`sublatticeSpinSOp{1,2,3}_sq_eq_conjTranspose_mul` の実体は
`SpinS/SublatticeSpinLadderDef.lean:33/39/45`、spin-1/2 mirror は
`MarshallLiebMattis/SublatticeSpinRealnessCore.lean:21/26/31`)。件数「12 行」は正しい。

**訂正 4: 「スコープ (2 commit)」は 3 commits** (`881a585e` = 空コミット, `cc1ecf28` = 足す,
`36f09763` = 外す)。集約 diff は非空 (`origin/main..36f09763` = 2 files / +1 / −2) なので
空 merge リスクはない。

**追加根拠 (build green より強い保証)**: 静的 import グラフ (1504 モジュール) で
`MagnetizationSubspaceCore` を閉包に持つモジュールは **580 → 574**、失うのは **6 本**
(`MarshallLiebMattis/{SublatticeSpin, SublatticeSpinDot, SublatticeSpinRealness,
SublatticeSpinRealnessCore}` + `Tests/{MarshallLiebMattisSublatticeSpin,
MarshallLiebMattisSublatticeSpinDot}`)、その HEAD 閉包の**合併 22 モジュール**のソースに
`magnetizationSubspace` が **0 回** = `@[simp] mem_magnetizationSubspace_iff` は
**原理的に発火不能**。`TotalSpin.Casimir` 除去で閉包を失うモジュールは **0 本**。
