### PR TITLE
refactor: drop 12 dead marshallSignS/marshallDressedBasisS lemmas (cascade-closed) — #5098

### DIFF
--- a/LatticeSystem/Quantum/SpinS/MarshallSign.lean
+++ b/LatticeSystem/Quantum/SpinS/MarshallSign.lean
@@ -32,11 +32,6 @@ noncomputable def marshallDressedBasisS [DecidableEq V]
     (A : V → Bool) (σ : V → Fin (N + 1)) : (V → Fin (N + 1)) → ℂ :=
   marshallSignS A σ • basisVecS σ
 
-/-- Definitional unfolding of `marshallDressedBasisS`. -/
-theorem marshallDressedBasisS_def [DecidableEq V]
-    (A : V → Bool) (σ : V → Fin (N + 1)) :
-    marshallDressedBasisS A σ = marshallSignS A σ • basisVecS σ := rfl
-
 /-- Component formula: `marshallDressedBasisS A σ τ` is
 `marshallSignS A σ` if `τ = σ`, else `0`. -/
 theorem marshallDressedBasisS_apply [DecidableEq V]
@@ -71,22 +66,6 @@ theorem marshallDressedBasisS_const_zero [DecidableEq V]
       basisVecS (fun _ : V => (0 : Fin (N + 1))) := by
   unfold marshallDressedBasisS
   rw [marshallSignS_const_zero, one_smul]
-
-/-- For `N = 0` (`S = 0`), the Marshall-dressed basis vector equals
-the plain basis vector. -/
-theorem marshallDressedBasisS_N_zero [DecidableEq V]
-    (A : V → Bool) (σ : V → Fin 1) :
-    marshallDressedBasisS A σ = basisVecS σ := by
-  unfold marshallDressedBasisS
-  rw [marshallSignS_N_zero, one_smul]
-
-/-- For an empty lattice, the Marshall-dressed basis vector equals
-the plain basis vector (Marshall sign is `1`). -/
-theorem marshallDressedBasisS_of_isEmpty [DecidableEq V] [IsEmpty V]
-    (A : V → Bool) (σ : V → Fin (N + 1)) :
-    marshallDressedBasisS A σ = basisVecS σ := by
-  unfold marshallDressedBasisS
-  rw [marshallSignS_of_isEmpty, one_smul]
 
 /-- **Orthonormality of the Marshall-dressed basis**:
 
@@ -151,45 +130,6 @@ theorem marshallDressedBasisS_ne_zero [DecidableEq V]
   rw [marshallDressedBasisS_self] at h0
   exact marshallSignS_ne_zero A σ h0
 
-/-- The Marshall-dressed basis vector at its own configuration has
-norm 1: `‖marshallDressedBasisS A σ σ‖ = 1`. -/
-theorem marshallDressedBasisS_self_norm [DecidableEq V]
-    (A : V → Bool) (σ : V → Fin (N + 1)) :
-    ‖marshallDressedBasisS A σ σ‖ = 1 := by
-  rw [marshallDressedBasisS_self, marshallSignS_norm]
-
-/-- Component-wise norm of the Marshall-dressed basis equals the
-component-wise norm of the plain basis (since dressing only changes
-sign): `‖marshallDressedBasisS A σ τ‖ = ‖basisVecS σ τ‖`. -/
-theorem marshallDressedBasisS_norm_eq_basisVecS [DecidableEq V]
-    (A : V → Bool) (σ τ : V → Fin (N + 1)) :
-    ‖marshallDressedBasisS A σ τ‖ = ‖(basisVecS σ τ : ℂ)‖ := by
-  unfold marshallDressedBasisS
-  rw [Pi.smul_apply, smul_eq_mul, norm_mul]
-  rw [marshallSignS_norm, one_mul]
-
-/-- The Marshall-dressed basis vector lies in the supremum of all
-magnetization subspaces (since it lies in `magSubspaceS V N (magEigenvalueS σ)`
-which is included in `⨆ M, magSubspaceS V N M`). -/
-theorem marshallDressedBasisS_mem_iSup_magSubspaceS [DecidableEq V]
-    (A : V → Bool) (σ : V → Fin (N + 1)) :
-    (marshallDressedBasisS A σ : (V → Fin (N + 1)) → ℂ) ∈
-      ⨆ M : ℂ, magSubspaceS V N M :=
-  Submodule.mem_iSup_of_mem (magEigenvalueS σ)
-    (marshallDressedBasisS_mem_magSubspaceS A σ)
-
-/-- **Marshall-dressed basis is `±basisVecS`**: depending on whether
-the Marshall sign is `+1` or `-1`, the dressed basis vector equals
-`+basisVecS σ` or `-basisVecS σ`. -/
-theorem marshallDressedBasisS_eq_or [DecidableEq V]
-    (A : V → Bool) (σ : V → Fin (N + 1)) :
-    marshallDressedBasisS A σ = basisVecS σ ∨
-      marshallDressedBasisS A σ = -basisVecS σ := by
-  unfold marshallDressedBasisS
-  rcases marshallSignS_eq_one_or_neg_one A σ with h | h
-  · left; rw [h, one_smul]
-  · right; rw [h, neg_smul, one_smul]
-
 /-- **Inverse decomposition**: every plain basis vector is
 `marshallSignS A σ` times the corresponding Marshall-dressed basis
 vector. (This is `marshallSignS_smul_marshallDressedBasisS` restated
@@ -200,20 +140,5 @@ theorem basisVecS_eq_marshallSignS_smul_marshallDressedBasisS
     (basisVecS σ : (V → Fin (N + 1)) → ℂ) =
       marshallSignS A σ • marshallDressedBasisS A σ :=
   (marshallSignS_smul_marshallDressedBasisS A σ).symm
-
-/-- **Marshall-dressed basis decomposition** of any vector:
-`v = Σ_σ (marshallSignS A σ * v(σ)) • marshallDressedBasisS A σ`.
-Substituting `basisVecS σ = marshallSignS A σ • marshallDressedBasisS A σ`
-into `fun_eq_sum_smul_basisVecS`. -/
-theorem fun_eq_sum_smul_marshallDressedBasisS [DecidableEq V]
-    (A : V → Bool) (v : (V → Fin (N + 1)) → ℂ) :
-    v = ∑ σ : V → Fin (N + 1),
-      (marshallSignS A σ * v σ) • marshallDressedBasisS A σ := by
-  conv_lhs => rw [fun_eq_sum_smul_basisVecS v]
-  refine Finset.sum_congr rfl ?_
-  intro σ _
-  rw [basisVecS_eq_marshallSignS_smul_marshallDressedBasisS A σ]
-  rw [smul_smul]
-  rw [mul_comm (v σ) (marshallSignS A σ)]
 
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/MarshallSign.lean
+++ b/LatticeSystem/Quantum/SpinS/MarshallSign.lean
@@ -130,15 +130,4 @@ theorem marshallDressedBasisS_ne_zero [DecidableEq V]
   rw [marshallDressedBasisS_self] at h0
   exact marshallSignS_ne_zero A σ h0
 
-/-- **Inverse decomposition**: every plain basis vector is
-`marshallSignS A σ` times the corresponding Marshall-dressed basis
-vector. (This is `marshallSignS_smul_marshallDressedBasisS` restated
-with sides swapped for use as a rewrite from `basisVecS` toward
-`marshallDressedBasisS`.) -/
-theorem basisVecS_eq_marshallSignS_smul_marshallDressedBasisS
-    [DecidableEq V] (A : V → Bool) (σ : V → Fin (N + 1)) :
-    (basisVecS σ : (V → Fin (N + 1)) → ℂ) =
-      marshallSignS A σ • marshallDressedBasisS A σ :=
-  (marshallSignS_smul_marshallDressedBasisS A σ).symm
-
 end LatticeSystem.Quantum

--- a/LatticeSystem/Quantum/SpinS/MarshallSignCore.lean
+++ b/LatticeSystem/Quantum/SpinS/MarshallSignCore.lean
@@ -60,22 +60,6 @@ theorem marshallSignS_eq_neg_one_pow_of_A_true (σ : V → Fin (N + 1)) :
   simp only [if_true]
   rw [← Finset.prod_pow_eq_pow_sum]
 
-/-- Marshall sign over an empty lattice is `1`. -/
-theorem marshallSignS_of_isEmpty [IsEmpty V]
-    (A : V → Bool) (σ : V → Fin (N + 1)) :
-    marshallSignS A σ = 1 := by
-  unfold marshallSignS
-  rw [show (Finset.univ : Finset V) = ∅ from Finset.eq_empty_of_isEmpty _]
-  exact Finset.prod_empty
-
-/-- For `N = 0` (`S = 0`), the only configuration is the constant
-zero, so the Marshall sign is always `1`. -/
-theorem marshallSignS_N_zero (A : V → Bool) (σ : V → Fin 1) :
-    marshallSignS A σ = 1 := by
-  have : σ = (fun _ => (0 : Fin 1)) := by
-    funext x; apply Fin.ext; have := (σ x).isLt; omega
-  rw [this, marshallSignS_const_zero]
-
 /-- Product of two Marshall signs at the same sublattice indicator
 factors site-wise: each `A`-site contributes `(-1)^((σ x).val + (σ' x).val)`. -/
 theorem marshallSignS_mul (A : V → Bool) (σ σ' : V → Fin (N + 1)) :
@@ -132,13 +116,6 @@ theorem marshallSignS_eq_one_or_neg_one
   · right
     have := add_eq_zero_iff_eq_neg.mp h2
     rw [this]
-
-/-- The norm of the Marshall sign is `1`. -/
-theorem marshallSignS_norm (A : V → Bool) (σ : V → Fin (N + 1)) :
-    ‖marshallSignS A σ‖ = 1 := by
-  rcases marshallSignS_eq_one_or_neg_one A σ with h | h
-  · rw [h, norm_one]
-  · rw [h]; simp
 
 /-- **Marshall sign factorization on two-site differences**: when
 configurations `σ', σ` agree at every site except possibly `x` and


### PR DESCRIPTION
## 目的

#5098 の 2026-07-25 波 **H3 (死蔵の全件再計算) に基づく sweep の第 1 PR**. `LatticeSystem/Quantum/SpinS/MarshallSign.lean` の**参照 0 の補題 8 件**を削除する: `marshallDressedBasisS_def` / `_N_zero` / `_of_isEmpty` / `_self_norm` / `_norm_eq_basisVecS` / `_mem_iSup_magSubspaceS` / `_eq_or` / `fun_eq_sum_smul_marshallDressedBasisS`.

**訂正 (第 2 コミット 749e1d4b 追記)**: 上記 8 件の削除により `MarshallSign.lean` / `MarshallSignCore.lean` に**新たに参照 0 へ転落した宣言が 4 件**判明した. 本 PR は最終的に **2 ファイル / 計 12 宣言**を削除する (詳細は下記「Cascade close-out」節). 以下の「スコープ」節にある「他の Lean ファイルは触らない」「`MarshallSign.lean` から 8 宣言を削除するのみ」は**第 1 コミット時点の記述であり, 第 2 コミットで更新済み**の旨に留意.

## sweep の前提が整った経緯

`docs/index.md` は CLAUDE.local.md が定める **capstone 判定の正本**だが, セッション開始時点で **stale `.lean` 参照が 650 箇所** (約 1/5 が虚偽) あり死蔵判定の前提が崩れていた. **#5140 (6 PR) で 872 箇所 → 0**, **PR #5149 で正本側の glob 偽記載 49 key を全数掃討** (documented 975 → 1009) した上で **H3 で全件再計算** した結果に基づく.

## 対象の位置づけ (計数のクラスに注意)

sweep の対象は **`DELETE-candidate` 94 件**であり, `final.py` の "clean delete candidates" **155 は 3 クラスの和** (DELETE-candidate 94 / REVIEW-documented-sibling-family 60 / REVIEW-book-citation 1) なので**そのまま削除に流してはならない**.

## 着手前の独立実測 (`dev-research` @ main `7e4ce687`)

- **8 件は現 main でも DELETE-candidate のまま**. PR #5149 の docs 修正は `Quantum/NeelState.lean` 系の glob 表記のみで `MarshallSign.lean` / `marshallDressedBasisS*` に一切触れていない (`git show 7e4ce687 -- docs/index.md | grep -i marshall` = 0 件).
- **外部参照 0**: 8 件すべて宣言行自身の 1 件のみ (Lean + docs + tex 全体, 語境界付き). 基底 `marshallDressedBasisS` を参照する `Tests/SpinSMarshallSign.lean` の 17 ヒットは**削除対象外の兄弟のみ** (`_self` / `_of_ne` / `_const_zero` / `_inner_product` / `_mem_magSubspaceS` / `_ne_zero` 等).
- **`_def` の simp 依存なし**: `marshallDressedBasisS_def` に `@[simp]` なし (ファイル内の `@[simp]` は L53 の `marshallDressedBasisS_self` のみで対象外), `simp [marshallDressedBasisS_def]` の明示呼び出しは repo 全体 **0 件**, `attribute [...]` 後付け登録も **0 件**. 8 件すべて同様.
- **book item 非該当**: 8 件の doc comment に Tasaki の定理・式・Problem 番号は**一切なし**. さらに **`MarshallSign.lean` というファイル名自体が `docs/index.md` / `tex/proof-guide.tex` に一度も出現しない**. (#5146 では「Tasaki Problem 2.5.a の book item」だったため削除が誤りだった前例があるので, 削除前に必ず確認する規律.)
- **cascade なし**: 8 件が消費する `marshallSignS` / `basisVecS` / `magSubspaceS` 等は他の生存宣言からも参照されており, **削除で新規に参照 0 へ転落する宣言は無い**. ← 第 1 コミット時点の判定であり誤り. 実際に 4 件転落した (下記 Cascade close-out で訂正)
- **docs/tex 同期不要**: 8 件は 4 分類 (表の第 1 列 / 他行の散文 / 段落自身の列挙のみ / どこにも無い) の**「どこにも無い」**に該当.
- ファイル状態: 総 219 行 / 宣言 18 (def 1 + theorem 17) → 削除後 **10** (def 1 + theorem 9) 【訂正: これは第 1 コミット時点の想定であり誤り. 実測 (`origin/refactor/sweep-dead-marshall-dressed-basis` 時点) は `MarshallSign.lean` が **9** (def 1 + theorem 8, cascade 1 件込み), `MarshallSignCore.lean` を含む 2 ファイル計 **31** 宣言. 下記「Cascade close-out」節参照】. **module docstring (L7-11) は個別宣言名を挙げていないので削除後も stale 化しない**.

## スコープ

**第 1 コミット時点**: `MarshallSign.lean` から 8 宣言を削除するのみ. **第 2 コミット (749e1d4b) で cascade が判明**し, `MarshallSign.lean` から追加で 1 件 + `MarshallSignCore.lean` から 3 件 = 計 4 件を削除した 【訂正: 「`MarshallSignCore.lean` から追加で 4 宣言」は誤り. 実測は `MarshallSign.lean` から 1 件 (`basisVecS_eq_marshallSignS_smul_marshallDressedBasisS`) + `MarshallSignCore.lean` から 3 件の計 4 件. 直後の文の内訳 (9 + 3 = 12) と整合させた】 (下記「Cascade close-out」節). **最終スコープ = `MarshallSign.lean` (9 宣言, cascade 1 件含む) + `MarshallSignCore.lean` (3 宣言, 全て cascade) の計 12 宣言, 2 ファイル**. **docs/tex は変更不要** (記載ゼロ, 実 diff と一致). 上記 2 ファイル以外の Lean ファイルは触っていない.

## Acceptance

- (a) 引数なし `lake build` で **warning / error / PANIC / backtrace / appArg! ゼロ**, EXIT=0. **stale olean を疑い変更モジュールの olean を削除してから走らせ, 実際に再 elaborate されたことをログで確認**
- (b) 削除後 **8 名すべて repo 全体 (Lean + docs + tex) で 0 ヒット** 【訂正: 第 1 コミット時点の記述. 第 2 コミット (cascade 4 件) を含めた最終値は **12 名すべて 0 ヒット**】
- (c) **cascade で新規に参照 0 へ落ちる宣言が 0 件** (削除前後の参照数を比較)
- (d) 両 root からの **到達不能 0 本の維持** (1504/1504)
- (e) 残存 10 宣言の `#print axioms` が標準 3 公理の部分集合 【訂正: 第 1 コミット時点の記述. 最終値は残存 **31 宣言** (`MarshallSign.lean` 9 + `MarshallSignCore.lean` 22) の `#print axioms`】
- (f) 検査器 `python3 .self-local/reports/design-5140/check_lean_refs.py` が **`UNRESOLVED=0 (excluded-by-design=3, in-deletion-notes=23)`** 維持 (sha256 `a874056f0fc2c357c200e71ecf93cf0738063c4b040b260b4885e1de3acffa05` 不変)
- (g) `docs/index.md` の `**PROVED**` / `axiom-free` / `#print axioms` / 表ヘッダ区切り が**不変** (docs 無変更なので当然だが確認する)
- (h) **残存全宣言に doc comment があること**.

## 本セッションで確立した規律の適用

照合は **brace-glob / 先頭 `_` 接尾省略 / スラッシュ略記 / tex の `\_` / `…` を全展開し語境界を課す**. **`theorem` の次行に折り返された宣言名も拾う**. **worktree を作るなら `.lake` を共有させない** (stale olean が build 判定と shake 計測の両方を汚染した実例あり). **広域 `pkill` 厳禁**.

## 後続

sweep は **1 PR = 1 ファイル・8 宣言以下**で進める (#5147 は 28 件を 1 PR で通せたが**あれは同一 stem の単一 family**だった). 次は `Quantum/SpinS/DressedHeisenberg.lean` 7 件 (**`_A_false` = 2026-07-25 波が接頭辞バイアスで落とした 1 件を含む**), その次が `Quantum/NeelState/InnerProductCore.lean` 5 件.

**【2026-07-26 訂正】この「後続」の記述は撤回する.**
- 束ね方は **「1 PR = 1 cascade 閉包」** に変更した (下記「計画上の教訓」節).
- 次候補として挙げた `Quantum/NeelState/InnerProductCore.lean` 5 件は **偽陽性であり撤回済**.
  旧台帳が `fc7656b4` 基準で, PR #5149 が `docs/index.md` の当該行を中置省略形から
  brace-glob 形へ書き換えた差分を反映していなかったため. 現 main では 5 件とも
  **documented (保護側)** であり, 新台帳 `out/ledger.tsv` に当該ファイルの行は **0 件**.
- 後続の正本は **`.self-local/reports/audit3-ledger-2026-07-26/out/pr-plan.tsv`** (DELETE 134 件 / 11 PR).
  旧台帳 `.self-local/reports/audit2-h3-2026-07-26/` は**使わない**.

### Cascade close-out (commit 749e1d4b)

第 1 コミットで参照 0 の `marshallDressedBasisS` ヘルパ 8 件を削除した結果,
**4 宣言が新たに参照 0 へ転落**した. 本コミットでその 4 件を削除し, sweep を
**不動点**で閉じた.

**注意**: ここでいう「不動点」は **本 PR の削除がもたらす cascade 閉包**を閉じたという意味であり,
当該 2 ファイルから死蔵が一掃されたという意味ではない. 実際 `marshallSignS_inv`
(`LatticeSystem/Quantum/SpinS/MarshallSignCore.lean:256`) は **main 時点でも参照 0** のまま残っている
(本 PR の退行ではなく sweep の取りこぼし). 新台帳の 11 PR 計画で回収する.

**別課題 (本 PR では対応しない)**: `MarshallSign.lean` の module docstring は自身を
`(capstone)` と自称するが, capstone 判定の正本である `docs/index.md` に同ファイルは
**一度も出現しない**. 削除判断は正本に従っており正当だが, 自称ラベルと正本の齟齬は
将来の監査を誤らせるため #5098 で追跡する.

| 宣言 | ファイル | 削除理由 |
|---|---|---|
| `basisVecS_eq_marshallSignS_smul_marshallDressedBasisS` | `Quantum/SpinS/MarshallSign.lean` | `marshallSignS_smul_marshallDressedBasisS` の `.symm` 言い換え (本体は `Tests/SpinSMarshallSign.lean` 経由で生存) |
| `marshallSignS_of_isEmpty` | `Quantum/SpinS/MarshallSignCore.lean` | 空格子の退化ケース |
| `marshallSignS_N_zero` | `Quantum/SpinS/MarshallSignCore.lean` | `N = 0` の退化ケース |
| `marshallSignS_norm` | `Quantum/SpinS/MarshallSignCore.lean` | `marshallSignS_eq_one_or_neg_one` の packaged 言い換え |

4 件とも tracked 全ファイルに対する語境界付き `git grep -nw` で参照 0, `@[simp]` なし
(`attribute` 後付けもなし), docs/index.md・tex に 0 ヒット, doc comment に Tasaki の
定理/式/Problem 番号を持たない. `docs/index.md` が `MarshallSignCore.lean` を参照する
唯一の行 (L1946) が挙げるのは `marshallSignS_mul_of_agree_off_site` 系 5 件で
いずれも生存しているため capstone 非該当.

**不動点の根拠**: 削除 4 件が消費していた `marshallSignS_smul_marshallDressedBasisS` /
`marshallSignS_const_zero` / `marshallSignS_eq_one_or_neg_one` は全て他所に生存参照が残る.
削除前後で repo 全体の参照 0 集合を再計算し, **新たに参照 0 へ転落した宣言 0 件**を確認した.

なお main からの差分で参照 0 集合が 12 でなく **8 しか減らない**ことが, この 4 件が
**真正な cascade** (main 時点では参照されていた) であることの独立な裏付けになっている.

### 計画上の教訓 (#5098 へ反映済)

削除集合を **削除前の参照数 (first-order)** で切ったために cascade を取りこぼした.
死蔵は「参照 0」の一次判定ではなく **削除操作の不動点 (closure)** で定義されるべきで,
first-order で切ると各 PR が次の PR 用の死蔵を生産し続ける. 転落した 4 件は台帳の
`dead-closure.tsv` に `tier=closure-only` として最初から収録されていた.
以後の sweep は **「1 PR = 1 ファイル」ではなく「1 PR = 1 cascade 閉包」** で束ねる.

### 独立検証 (dev-verify, HEAD 749e1d4b)

- **root build**: 変更 2 モジュールの olean/ilean/trace を削除後, 引数なし `lake build`.
  EXIT=0, 4577 jobs, 両モジュールとも `Built` (`Replayed` ではない).
  warning / error / PANIC / backtrace / appArg! / sorry / admit / native_decide **全て 0**.
- **削除 12 名**: tracked 全ファイルへの `git grep -nw` で全件 0 ヒット.
- **cascade**: 新たに参照 0 へ転落した宣言 **0 件**. 総宣言数の減少はちょうど 12
  (意図しない増減なし).
- **到達性**: 両 build root から 1504/1504, 到達不能 0.
- **`#print axioms`**: 残存 31 宣言 (MarshallSign 9 + MarshallSignCore 22) を列挙して全件実行,
  すべて `[propext, Classical.choice, Quot.sound]`.
- **docs 不変**: `docs/index.md` は main とバイト同一. PROVED=19 / axiom-free=71 /
  `#print axioms`=24 いずれも不変.
- **doc comment**: 残存全 31 宣言に doc comment あり (欠落 0).

Refs #5098
Refs #4718


