### PR TITLE
refactor: drop 5 unreferenced JW-abstract bridge lemmas — #5098

### DIFF
--- a/LatticeSystem/Fermion/JWAbstract.lean
+++ b/LatticeSystem/Fermion/JWAbstract.lean
@@ -44,13 +44,6 @@ theorem jwStringAbstract_sq (i : Λ) :
   intro j _
   rw [onSite_mul_onSite_same, pauliZ_mul_self, onSite_one]
 
-/-- The abstract JW string on `Λ = Fin (N+1)` coincides with the
-existing `Fin (N+1)`-specific `jwString N i` definitionally: the
-`LinearOrder (Fin (N+1))` instance's `<` matches `j.val < i.val`. -/
-theorem jwStringAbstract_eq_jwString (N : ℕ) (i : Fin (N + 1)) :
-    jwStringAbstract i = jwString N i :=
-  rfl
-
 /-! ## Abstract fermion creation / annihilation / number operators -/
 
 open LatticeSystem.Quantum in
@@ -69,26 +62,6 @@ open LatticeSystem.Quantum in
 /-- Abstract fermion site-occupation number `n_i = c_i† · c_i`. -/
 noncomputable def fermionNumberAbstract (i : Λ) : ManyBodyOp Λ :=
   fermionCreationAbstract i * fermionAnnihilationAbstract i
-
-/-- Bridge: abstract annihilation on `Fin (N+1)` equals the
-existing `fermionMultiAnnihilation`. -/
-theorem fermionAnnihilationAbstract_eq_fermionMultiAnnihilation
-    (N : ℕ) (i : Fin (N + 1)) :
-    fermionAnnihilationAbstract i = fermionMultiAnnihilation N i :=
-  rfl
-
-/-- Bridge: abstract creation on `Fin (N+1)` equals the existing
-`fermionMultiCreation`. -/
-theorem fermionCreationAbstract_eq_fermionMultiCreation
-    (N : ℕ) (i : Fin (N + 1)) :
-    fermionCreationAbstract i = fermionMultiCreation N i :=
-  rfl
-
-/-- Bridge for the number operator. -/
-theorem fermionNumberAbstract_eq_fermionMultiNumber
-    (N : ℕ) (i : Fin (N + 1)) :
-    fermionNumberAbstract i = fermionMultiNumber N i :=
-  rfl
 
 /-- The JW string at site `i` commutes with any single-site
 operator at the same site `i`: the string only touches sites

--- a/LatticeSystem/Fermion/JWAbstractCrossSite.lean
+++ b/LatticeSystem/Fermion/JWAbstractCrossSite.lean
@@ -123,26 +123,6 @@ theorem jwStringAbstract_anticomm_onSite_pos_spinHalfOpPlus
     _ = 0 * M := by rw [neg_add_cancel]
     _ = 0 := Matrix.zero_mul _
 
-/-- Companion anticommutator at an interior site with the lowering
-operator: for every `i j : Λ` with `i < j`,
-
-  `σ^-_i · jwStringAbstract j + jwStringAbstract j · σ^-_i = 0`.
-
-Derived from the `σ^+_i` version by matrix `conjTranspose`, using
-`jwStringAbstract_isHermitian` and `(σ^+)† = σ^-`. -/
-theorem jwStringAbstract_anticomm_onSite_pos_spinHalfOpMinus
-    (i j : Λ) (hij : i < j) :
-    onSite i spinHalfOpMinus * jwStringAbstract j +
-      jwStringAbstract j * onSite i spinHalfOpMinus = 0 := by
-  have h := jwStringAbstract_anticomm_onSite_pos_spinHalfOpPlus i j hij
-  have h2 := congrArg Matrix.conjTranspose h
-  simp only [Matrix.conjTranspose_add, Matrix.conjTranspose_mul,
-    Matrix.conjTranspose_zero, (jwStringAbstract_isHermitian j).eq] at h2
-  have hplus : (onSite i spinHalfOpPlus)ᴴ = onSite i spinHalfOpMinus := by
-    rw [onSite_conjTransposeAbstract, spinHalfOpPlus_conjTranspose]
-  rw [hplus] at h2
-  exact (add_comm _ _).trans h2
-
 /-- Two abstract Jordan-Wigner strings commute. Both are built as
 `Finset.noncommProd` over subsets of `Λ` of `k ↦ onSite k pauliZ`;
 every cross pair lies at distinct sites so `onSite_mul_onSite_of_ne`

--- a/tex/proof-guide.tex
+++ b/tex/proof-guide.tex
@@ -4666,7 +4666,7 @@ forms), each obtained from an $i < j$ form by trichotomy and
 $\mathrm{add\_comm}$, mirroring the $\mathrm{Fin}(N+1)$-indexed
 ``multi'' versions in \texttt{Fermion/JordanWigner/CAR/CrossSiteOfNe.lean}. The required
 abstract Jordan--Wigner string lemmas
-($\{\sigma^\pm_i, J_j\} = 0$ for $i < j$, and commutation of two JW
+($\{\sigma^+_i, J_j\} = 0$ for $i < j$, and commutation of two JW
 strings) are proved alongside; the creation forms are obtained from the
 annihilation forms by conjugate transposition. These anticommutators
 are the Wick-reordering inputs for the eventual determinant expansion.


### PR DESCRIPTION
## 目的

#5098 の死蔵宣言 sweep **第 2 PR**. 参照 0 の 5 宣言を削除する.

| ファイル | 宣言 | 行 (main `2287a073`) |
|---|---|---|
| `LatticeSystem/Fermion/JWAbstract.lean` | `jwStringAbstract_eq_jwString` | 50 |
| 〃 | `fermionAnnihilationAbstract_eq_fermionMultiAnnihilation` | 75 |
| 〃 | `fermionCreationAbstract_eq_fermionMultiCreation` | 82 |
| 〃 | `fermionNumberAbstract_eq_fermionMultiNumber` | 88 |
| `LatticeSystem/Fermion/JWAbstractCrossSite.lean` | `jwStringAbstract_anticomm_onSite_pos_spinHalfOpMinus` | 133 |

**5 件 / 2 ファイル / 全て first-order / cascade 0 段 / BLOCKED 除外 0 件**.

## 台帳 (判定の正本)

`.self-local/reports/audit3-ledger-2026-07-26/`
(`ledger.py` sha256 `dcfbb494ad683a6770a035c59bb6cc1a617888a91665f76ebacc1e95360263b5`,
2 回実行で全出力 byte 一致, 抽出規則は `extraction-rules.md`).
**DELETE-candidate 134 件 / 実行計画 11 PR**, 束ね方は **「1 PR = 1 cascade 閉包」**.
旧台帳 `.self-local/reports/audit2-h3-2026-07-26/` は `fc7656b4` 基準で系統的に過大なため**使わない**.

**注意 (第 3 PR 以降にも効く)**: 同ディレクトリの `out/` は **`7e4ce687` 固定**で
**#5150 で削除済の 12 件をまだ含む**. 一方 `out_749e1d4b/` の tree は現 main と
**byte 一致** (`2287a073^{tree}` = `0834ed61…`) で 12 件は正しく消えている.
→ **以後の起票は `out_749e1d4b/` (またはそれと集合が一致する最新台帳) を参照する**.
本 PR の対象は `Fermion/` 配下で #5150 の 12 件とは無関係なため, この論点の影響を受けない.

## 着手前の独立実測 (`dev-research` @ main `2287a073`)

4 ゲートすべて通過:

1. **外部参照 0**: 5 件とも `git grep -nw` (tracked 全ファイル, ファイル除外なし, 語境界付き,
   brace-glob / 先頭 `_` の接尾省略 / スラッシュ略記 / tex の `\_` / `…` を全展開) で
   **ヒット 1 件 = 自身の宣言行のみ**.
2. **simp 依存なし**: 5 件とも `@[simp]` なし, `attribute [simp] <name>` 後付け 0 件,
   `simp [<name>]` の明示利用 repo 全体 0 件.
3. **book item 非該当**: doc comment / 本体コメントに Tasaki の定理・補題・式・§ 番号の
   言及 **0 件**. `JWAbstract.lean` は `docs/index.md` / `tex/proof-guide.tex` に出現 0.
4. **capstone 非該当**: 5 件とも `docs/index.md` の宣言名リストに一切出現しない.

**【訂正】** 上の「`JWAbstract.lean` は docs/index.md / tex に出現 0」は**偽**.
実測では **`Fermion/JWAbstract.lean` は `docs/index.md` に 7 箇所**出現する
(散文 `:540` + 表 file 列 `:1463`–`:1468` の 6 行). tex 側は正しい
(`JWAbstract.lean` の完全一致 0 件; `tex:4658` が名指すのは `JWAbstractCrossSite.lean`).
**ただし capstone 判定は無傷**: 実効ゲートは「**削除する 5 名**が `docs/index.md` の
宣言名リストに不在」であり, そちらは 5 件とも `git grep -nw` で 0 ヒットを再確認済.
`docs/index.md:1463-1468` の 6 行が名指す 11 宣言は**全て生存**している.

**境界事例 (明示しておく)**: `JWAbstractCrossSite.lean` は **`docs/index.md:149` の
P2 ロードマップ行の散文中**に module パスとして言及がある (「in `Fermion/JWAbstractCrossSite.lean`」).
これは表の file 列ではなく prose 内引用であり, 台帳の規則上「専用の file 列からしか採らない」ため
被覆に数えていない. かつ当該行が名指す具体名は `{c_i, c_j} = 0` 系の**フェルミオン演算子側の
反交換子**であり, **今回削除する spin-JW-string 側の companion 補題ではない**.
それでも完全に無関係ではないため, レビューで再確認されたい.

## cascade 閉包 (1 段で完結)

5 件の証明本体が使う依存先 11 件 — `jwStringAbstract_anticomm_onSite_pos_spinHalfOpPlus` (他 4 参照) /
`jwStringAbstract_isHermitian` (6) / `onSite_conjTransposeAbstract` (4) /
`spinHalfOpPlus_conjTranspose` (8) / `jwStringAbstract` (40) / `fermionMultiAnnihilation` (565) /
`fermionMultiCreation` (622) / `fermionMultiNumber` (199) / `jwString` (150) /
`fermionAnnihilationAbstract` (50) / `fermionCreationAbstract` (47) — は
**すべて他所からの参照が残る (最小 4 件)** ため, **削除後に新規参照 0 へ転落する宣言は 0 件**.
波及先ファイルなし. closure-only が 0 件なので **BLOCKED 条件の除外も 0 件**.

## Acceptance

- (a) 引数なし `lake build` で **warning / error / PANIC / backtrace / appArg! / sorry / admit /
  native_decide ゼロ**, EXIT=0. **stale olean を疑い変更モジュールの olean を削除してから走らせ,
  ログで `Built` (`Replayed` でない) を確認する**.
- (b) 削除 5 名すべて repo 全体 (Lean + docs + tex) で **0 ヒット**.
- (c) **cascade 不動点**: 削除前後で repo 全体の参照 0 集合を再計算し,
  **新たに参照 0 へ転落する宣言 0 件**. (第 1 PR #5150 ではここが FAIL し 4 件転落した.)
- (d) 両 root からの **到達不能 0 本の維持**.
- (e) 残存全宣言の `#print axioms` が標準 3 公理の部分集合.
- (f) 検査器 `.self-local/reports/design-5140/check_lean_refs.py` が
  `UNRESOLVED=0 (excluded-by-design=3, in-deletion-notes=23)` 維持,
  sha256 `a874056f0fc2c357c200e71ecf93cf0738063c4b040b260b4885e1de3acffa05` 不変.
- (g) `docs/index.md` の `**PROVED**` 19 / `axiom-free` 71 / `#print axioms` 24 / 表ヘッダ区切りが不変.
- (h) **残存全宣言に doc comment があること** (private も必須).
- (i) **PR 本文が主張する数値が実 diff から再導出できること** (squash で main の恒久履歴になる).

## 第 1 PR (#5150) から引き継いだ規律

- **照合は全展開 + 語境界**. **ファイル名の部分一致に注意** (本セッションで 2 度取り違えが起きた).
- **抽出は宣言名が宣言キーワードの次行に折り返される形も拾う**.
- **worktree を作るなら `.lake` を共有させない** (stale olean が build 判定を汚染した実例あり).
- **広域 `pkill` 厳禁** (PID 指定のみ).
- **実装後に必ず push** してから検証・レビューを回す (gates が local でなく origin を測るため).

Refs #5098
Refs #4718

---
## 実装結果 (commit `11deaaa5`)

**2 ファイル / 5 宣言削除 / 47 deletions / 0 insertions / docs・tex 無変更**.

- `Fermion/JWAbstract.lean` — `jwStringAbstract_eq_jwString` /
  `fermionAnnihilationAbstract_eq_fermionMultiAnnihilation` /
  `fermionCreationAbstract_eq_fermionMultiCreation` /
  `fermionNumberAbstract_eq_fermionMultiNumber` (いずれも `rfl` bridge)
- `Fermion/JWAbstractCrossSite.lean` — `jwStringAbstract_anticomm_onSite_pos_spinHalfOpMinus`
  (生存している `…_spinHalfOpPlus` の conjTranspose mirror companion)

### 削除根拠 (実測)

5 件とも `git grep -nw` (tracked 全ファイル, 除外なし) で **hit 1 = 自身の宣言行のみ**.
非 `-w` の部分一致 grep でも同数 (superstring なし), tex の `\_` 展開形 **0 hit**.
`@[simp]` 属性・後付け `attribute [simp]`・明示 `simp [<name>]` いずれも **0 件**.
`docs/index.md` の宣言名リストに不在 (capstone 非該当), Tasaki の定理・補題・式番号の言及なし.

### ドキュメント変更なし + 回帰カバレッジの維持

5 件は `docs/index.md` / `tex/proof-guide.tex` に記載 0 のため docs 変更は不要.

さらに **削除した 4 本の `rfl` bridge は `LatticeSystem/Tests/JWAbstract.lean:15-25` が
同一命題を無名 `example` (`:= rfl`) として保持**している. したがって:
- 回帰カバレッジは維持される (無名 `example` も build で検査される).
- `docs/index.md:1463` / `:1465` の散文 (「generalises the Fin-specific `jwString`」/
  「rfl-bridges to the Fin-specific versions」) は **stale にならず, 実体で裏付けられたまま**.
- つまり削除した 4 件は **「名前付きだが誰も使わない重複」**だった
  (無名 `example` は参照にならないため台帳では検出されない関係).

**境界事例の再確認**: `docs/index.md:149` の P2 ロードマップ行は健在.
同行が名指すのは `{c_i, c_j} = 0` 系の 4 本の `…_of_ne` (**全て生存**) であり,
今回削除した spin-JW-string 側 companion ではない.

### 検証 (実装者の実測値; 独立検証は別途)

- **root build**: 変更 2 モジュール + 下流 7 の olean/ilean/trace/c を削除後, 引数なし `lake build`.
  **EXIT=0**, `warning / error / PANIC / backtrace / appArg! / sorry / admit / native_decide` **全て 0**,
  両モジュールとも **`Built`** (`Replayed` ではない).
- **cascade 不動点**: repo 全体の参照 0 宣言集合 **1047 → 1042**. 抜けたのは削除 5 件ちょうどで,
  **新たに参照 0 へ転落した宣言は 0 件** (宣言数 9616 → 9611).
  第 1 PR #5150 ではここが FAIL し 4 件転落したが, 本 PR は事前予測どおり 0 段で完結した.
- **到達性**: 両 root から **1504/1504**, 到達不能 0 (前後不変).
- **`#print axioms`**: 残存 **30 宣言** (JWAbstract 17 / CrossSite 13, **`private` 5 件含む**) すべて
  `[propext, Classical.choice, Quot.sound]` のみ.
- **検査器**: `UNRESOLVED=0 (excluded-by-design=3, in-deletion-notes=23)` 維持,
  sha256 `a874056f…acffa05` 不変.
- **docs/tex**: `docs/index.md` と `tex/proof-guide.tex` は **sha256 まで前後同一**.
  `**PROVED**` 19 / `axiom-free` 71 / `#print axioms` 24 / 表ヘッダ 56 いずれも不変.
- **diff**: Lean 2 ファイル / 削除宣言ちょうど **5** / 挿入 **0 行**.

### 空コミットについて

branch には PR 起票用の空コミット `5520311b` がある. これは `dev-pr-workflow` が定める
**実装前に PR を開けるための空コミット**であり (第 1 PR #5150 の `628b0adc` と同じ),
欠陥ではない. squash-merge で解消されるため整理不要.
ただし **squash メッセージは検証済み本文から `--body-file` で明示的に与える**こと
(commit 連結の既定に任せると, 削除を主張する空コミットのメッセージが混入する).

---
## 【追加コミット `419b00a1`】公開 TeX の stale 化を是正

**独立レビューと tier1 監査が別プロセスで同一箇所を検出した** (2 系統一致).

`tex/proof-guide.tex:4669` (段落のスコープは `:4658` で
`\texttt{Fermion/JWAbstractCrossSite.lean}` と明示):

- 修正前: `($\{\sigma^\pm_i, J_j\} = 0$ for $i < j$, and commutation of two JW`
- 修正後: `($\{\sigma^+_i, J_j\} = 0$ for $i < j$, and commutation of two JW`

**理由**: `\sigma^\pm` の **σ⁻ 側が本 PR で削除した
`jwStringAbstract_anticomm_onSite_pos_spinHalfOpMinus` そのもの**であり,
削除後は同ファイルに σ⁺ 形しか存在しない.
実測: `…_spinHalfOpMinus` = **0 ヒット**, `…_spinHalfOpPlus` = `JWAbstractCrossSite.lean:98,155,219` に生存.

**この型は名前照合では検出できない**: 削除した宣言の**名前は tex のどこにも無い**.
壊れたのは `\sigma^\pm` という**記法によるワイルドカード列挙** (= 「σ⁺ と σ⁻ の両方について
成り立つ」という**量化主張**) であり, 片側の実体が消えた瞬間に内容が偽になる.
本 PR 当初の「tex 記載 0」は**完全名の照合としては正しかった**.
検出できたのはレビューと監査が段落を読んで内容を理解したからで, grep ではない.

**触らなかった箇所** (両監査が stale でないと確認済):
`docs/index.md:149` (名指す `…_of_ne` 4 本は全生存) / `:1463` / `:1465`
(生存 def の性質記述で defeq は今も真, かつ `Tests/JWAbstract.lean` の無名 `example` で機械検査される).
`docs/index.md:2286/2287` の `jwString_anticomm_onSite_pos_spinHalfOpPlus/Minus` は
**Fin 層の別実体** (`Fermion/JordanWigner/CAR/StringFactorizationCore.lean:95/133`, 両方生存) で無関係.

**検証**: pdfLaTeX で **TEXMF override なし**にコンパイルし **EXIT=0**, PDF 生成成功.
致命エラーなし (残る警告は編集箇所と無関係な既存の font-shape / overfull hbox).

### 最終 diff

**3 ファイル / 1 insertion / 48 deletions**
(`JWAbstract.lean` −27 / `JWAbstractCrossSite.lean` −20 / `tex/proof-guide.tex` +1−1).
本文上部の「docs・tex 無変更」は**この追加コミットで解消済み**と読み替えられたい.

### 監査で拾った後続課題 (P3, 本 PR では対応しない — #5098 で追跡)

1. **本 PR が shake の罠を作った**: `Fermion/JWAbstract.lean:1` の
   `import LatticeSystem.Fermion.JordanWigner` は削除により **module-local には未使用**
   になった (同ファイルが参照する `Fermion/JordanWigner/` 配下宣言 = 0).
   **ただし単純削除すると `Tests/JWAbstract.lean` が壊れる** — 同 test は
   `LatticeSystem.Fermion.JWAbstract` だけを import しつつ `jwString` /
   `fermionMulti*` を**推移 re-export 経由**で得ており, この依存は今回初めて
   「JWAbstract.lean 自身の用途」から切り離された.
   → **次の shake cadence では test 側に import を足してから shake する**
   (#5147 で shake が下流を壊したのと同型).
2. **`onSite_conjTransposeAbstract` (`JWAbstract.lean:85`) は宣言重複**:
   doc comment 自身が「`JordanWigner.lean` の `private` helper の public copy」と明言し,
   同主張が `Fermion/JordanWigner/Operators.lean:104` と `Quantum/TotalSpin.lean:462` にも存在.
   **本 repo は宣言重複を厳禁**している. 本 PR で参照が 3 → 2 に減り sweep 対象に近づいた.
   → 次の dedup PR 候補.

