### PR TITLE
refactor: drop 2 dead ferroHole declarations — #5098

### DIFF
--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaTheorem.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaTheorem.lean
@@ -8,11 +8,13 @@ This file builds toward Tasaki Theorem 11.5: for a Hubbard model with
 among the ground states of the effective Hamiltonian there are at least
 `(2 S_max + 1)` states with total spin `S_tot = S_max = N/2`.
 
-The first ingredient (this commit) is that the *ferromagnetic hole state*
-`|Φ_{x,(↑)}⟩` — the one-hole state with every occupied site spin-up — lies in
-the maximal-spin sector: `(Ŝ_tot)² |Φ_{x,(↑)}⟩ = S_max(S_max+1) |Φ_{x,(↑)}⟩`
-with `S_max = N/2`. Indeed `Ŝ^+_tot` annihilates it (no down electrons to
-raise) and `Ŝ^z_tot` acts with eigenvalue `N/2` (the `N` up electrons).
+This file supplies the abstract half of that statement: for *any* nonzero
+highest-weight state `v` (`Ŝ^+_tot v = 0`, `Ŝ^z_tot v = (N/2) v`) the
+spin-lowering tower `(Ŝ^-_tot)^k v` (`k = 0, …, N`) is nonzero, linearly
+independent, energy-degenerate, and confined to the maximal-spin sector
+`S_tot = S_max = N/2`; this is packaged as `weakNagaoka_spinMultiplet`. The
+concrete highest-weight ground state fed into it is built in
+`WeakNagaokaGroundState.lean`.
 
 Tracked in Issue #4130. Reference: Tasaki, *Physics and Mathematics of Quantum
 Many-Body Systems*, 1st edition, §11.2.1, Theorem 11.5, pp. 382-385.
@@ -215,25 +217,5 @@ theorem weakNagaoka_spinMultiplet (N : ℕ) (t : Fin (N + 1) → Fin (N + 1) →
   refine ⟨spinMinusPow_linearIndependent N v hv hsz hcas, fun k => ?_, fun k => ?_⟩
   · exact hubbardEffectiveHamiltonian_mulVec_spinMinusPow N t U hJ hU v E hE (k : ℕ)
   · exact fermionTotalSpinSquared_mulVec_spinMinusPow N v _ (k : ℕ) hcas
-
-/-! ## The ferromagnetic hole state is a highest-weight maximal-spin state -/
-
-/-- The localized ferromagnetic hole state `|Φ_{x,(↑)}⟩` is a nonzero
-highest-weight maximal-spin state: `Ŝ^+_tot` annihilates it, `Ŝ^z_tot` acts with
-`N/2`, and `(Ŝ_tot)²` with `S_max(S_max+1)`. Hence its `N + 1` spin-lowering
-descendants are linearly independent (instance of
-`spinMinusPow_linearIndependent`). It is *not* in general an `Ĥ_eff`-eigenvector
-(the hole is localized), so the full degeneracy statement
-`weakNagaoka_spinMultiplet` applies to the Perron–Frobenius ground state rather
-than to this localized state. -/
-theorem spinMinusPow_ferroHole_linearIndependent (N : ℕ) (x : Fin (N + 1)) :
-    LinearIndependent ℂ (fun k : Fin (N + 1) =>
-      ((fermionTotalSpinMinus N) ^ (k : ℕ)).mulVec (basisVec (ferroHoleConfig N x))) := by
-  refine spinMinusPow_linearIndependent N (basisVec (ferroHoleConfig N x)) ?_
-    (fermionTotalSpinZ_mulVec_ferroHole N x) (fermionTotalSpinSquared_mulVec_ferroHole N x)
-  intro h
-  have h2 := congrFun h (ferroHoleConfig N x)
-  rw [Pi.zero_apply, basisVec_self] at h2
-  exact one_ne_zero h2
 
 end LatticeSystem.Fermion

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaTheorem.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaTheorem.lean
@@ -8,13 +8,22 @@ This file builds toward Tasaki Theorem 11.5: for a Hubbard model with
 among the ground states of the effective Hamiltonian there are at least
 `(2 S_max + 1)` states with total spin `S_tot = S_max = N/2`.
 
-This file supplies the abstract half of that statement: for *any* nonzero
-highest-weight state `v` (`Ŝ^+_tot v = 0`, `Ŝ^z_tot v = (N/2) v`) the
-spin-lowering tower `(Ŝ^-_tot)^k v` (`k = 0, …, N`) is nonzero, linearly
-independent, energy-degenerate, and confined to the maximal-spin sector
-`S_tot = S_max = N/2`; this is packaged as `weakNagaoka_spinMultiplet`. The
-concrete highest-weight ground state fed into it is built in
-`WeakNagaokaGroundState.lean`.
+This file supplies the abstract half of that statement, in two steps.
+*The spin-lowering tower*: for **any** nonzero highest-weight state `v`
+(`Ŝ^+_tot v = 0`, `Ŝ^z_tot v = (N/2) v`) the states `(Ŝ^-_tot)^k v`
+(`k = 0, …, N`) are nonzero (`spinMinusPow_ne_zero`), linearly independent
+(`spinMinusPow_linearIndependent`), and confined to the maximal-spin sector
+`S_tot = S_max = N/2`; no Hamiltonian hypothesis enters here.
+*Theorem 11.5 core*: if **in addition** `v` is an `Ĥ_eff`-eigenvector at energy
+`E`, then the whole tower is `Ĥ_eff`-degenerate at `E`. This second, stronger
+statement is what `weakNagaoka_spinMultiplet` packages; its three conjuncts are
+linear independence, energy degeneracy, and the maximal-spin sector.
+Nonvanishing is *not* one of them (it follows from linear independence, and is
+stated on its own as `spinMinusPow_ne_zero`). The `Ĥ_eff`-eigenvector hypothesis
+cannot be dropped: a *localized* ferromagnetic hole state is highest-weight but
+is not in general an `Ĥ_eff`-eigenvector, so its tower need not be degenerate.
+The concrete highest-weight ground state fed into `weakNagaoka_spinMultiplet` is
+built in `WeakNagaokaGroundState.lean`.
 
 Tracked in Issue #4130. Reference: Tasaki, *Physics and Mathematics of Quantum
 Many-Body Systems*, 1st edition, §11.2.1, Theorem 11.5, pp. 382-385.

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaTheoremCore.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaTheoremCore.lean
@@ -15,9 +15,15 @@ The raising-after-lowering Casimir identities, the multiplet non-vanishing / lin
 independence, the whole-tower energy degeneracy, and the weak Nagaoka spin multiplet are
 kept in the capstone module `WeakNagaokaTheorem.lean`.
 
-`ferroHoleConfig` and `fermionTotalSpinZ_mulVec_ferroHole` are module-public: they carry
-the hole-state spin data consumed by the all-up Tasaki basis state and by the `Ŝ^z` tower
-below. The remaining hole-state helper lemmas stay `private`.
+Visibility, as it currently stands: `ferroHoleConfig` and `fermionTotalSpinZ_mulVec_ferroHole`
+are non-`private`, and every use of either is inside this module — there is no cross-module
+reference to either. `ferroHoleConfig` occurs in the *statement* of the non-`private`
+`fermionTotalSpinZ_mulVec_spinMinusPow_ferroHole` below; `fermionTotalSpinZ_mulVec_ferroHole`
+occurs only inside proofs, so nothing at present requires it to be non-`private`. The two are
+coupled — making `ferroHoleConfig` `private` would put a `private` constant into the statement
+of that non-`private` theorem — so any change has to treat them together; the visibility
+cleanup is left to the refactoring pass tracked in #5098. The remaining hole-state helper
+lemmas stay `private`.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*
 (1st ed., Springer, 2020), §9.3.3 (Theorem 11.5 core).
@@ -113,7 +119,7 @@ private theorem fermionTotalSpinPlus_mulVec_ferroHole (N : ℕ) (x : Fin (N + 1)
   rw [← Matrix.mulVec_mulVec, fermionMultiAnnihilation_mulVec_basisVec,
     if_neg (by rw [ferroHole_down_zero]; decide), Matrix.mulVec_zero]
 
-/-! ## The all-up Tasaki basis state is a highest-weight maximal-spin state -/
+/-! ## The all-up Tasaki basis state is a highest-weight state -/
 
 /-- `Ŝ^+_tot` annihilates the all-up Tasaki basis state
 `|Φ^T_{x,↑}⟩ = ε • |Φ_{x,↑}⟩` (no down electrons to raise). -/

--- a/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaTheoremCore.lean
+++ b/LatticeSystem/Fermion/JordanWigner/Hubbard/WeakNagaokaTheoremCore.lean
@@ -12,13 +12,12 @@ highest-weight identification, the energy degeneracy of the spin-lowering multip
 the SU(2) ladder commutator `[Ŝ⁺, Ŝ⁻] = 2 Ŝ^z` with the Casimir–lowering commutation.
 
 The raising-after-lowering Casimir identities, the multiplet non-vanishing / linear
-independence, the whole-tower energy degeneracy, and the weak Nagaoka spin multiplet
-(plus the ferromagnetic-hole highest-weight state) are kept in the capstone module
-`WeakNagaokaTheorem.lean`.
+independence, the whole-tower energy degeneracy, and the weak Nagaoka spin multiplet are
+kept in the capstone module `WeakNagaokaTheorem.lean`.
 
-To let the capstone reuse the hole-state spin data across the module boundary,
-`ferroHoleConfig` and `fermionTotalSpinZ_mulVec_ferroHole` are module-public here; the
-remaining hole-state helper lemmas stay `private`.
+`ferroHoleConfig` and `fermionTotalSpinZ_mulVec_ferroHole` are module-public: they carry
+the hole-state spin data consumed by the all-up Tasaki basis state and by the `Ŝ^z` tower
+below. The remaining hole-state helper lemmas stay `private`.
 
 Reference: H. Tasaki, *Physics and Mathematics of Quantum Many-Body Systems*
 (1st ed., Springer, 2020), §9.3.3 (Theorem 11.5 core).
@@ -47,7 +46,7 @@ theorem fermionMultiNumber_mulVec_basisVec (N : ℕ) (j : Fin (N + 1))
   · rw [hcj, show Function.update c j 1 = c from by rw [← hcj]; exact Function.update_eq_self _ _]
     simp [spinHalfOpMinus, spinHalfOpPlus, Matrix.mul_apply, Fin.sum_univ_two]
 
-/-! ## The ferromagnetic hole state is maximal-spin -/
+/-! ## The ferromagnetic hole state is a highest-weight state -/
 
 /-- The ferromagnetic hole configuration: hole at `x`, every other site spin-up. -/
 def ferroHoleConfig (N : ℕ) (x : Fin (N + 1)) : Fin (2 * N + 2) → Fin 2 :=
@@ -113,20 +112,6 @@ private theorem fermionTotalSpinPlus_mulVec_ferroHole (N : ℕ) (x : Fin (N + 1)
   intro k _
   rw [← Matrix.mulVec_mulVec, fermionMultiAnnihilation_mulVec_basisVec,
     if_neg (by rw [ferroHole_down_zero]; decide), Matrix.mulVec_zero]
-
-/-- **The ferromagnetic hole state is maximal-spin** (the `S_tot = S_max` part
-of Theorem 11.5): `(Ŝ_tot)² |Φ_{x,(↑)}⟩ = S_max(S_max+1) |Φ_{x,(↑)}⟩` with
-`S_max = N/2`. -/
-theorem fermionTotalSpinSquared_mulVec_ferroHole (N : ℕ) (x : Fin (N + 1)) :
-    (fermionTotalSpinSquared N).mulVec (basisVec (ferroHoleConfig N x)) =
-      ((N : ℂ) / 2 * ((N : ℂ) / 2 + 1)) • basisVec (ferroHoleConfig N x) := by
-  unfold fermionTotalSpinSquared
-  rw [Matrix.add_mulVec, ← Matrix.mulVec_mulVec, fermionTotalSpinPlus_mulVec_ferroHole,
-    Matrix.mulVec_zero, zero_add, ← Matrix.mulVec_mulVec, Matrix.add_mulVec,
-    Matrix.one_mulVec, fermionTotalSpinZ_mulVec_ferroHole, Matrix.mulVec_add,
-    Matrix.mulVec_smul, fermionTotalSpinZ_mulVec_ferroHole, smul_smul, ← add_smul]
-  congr 1
-  ring
 
 /-! ## The all-up Tasaki basis state is a highest-weight maximal-spin state -/
 


### PR DESCRIPTION
## 目的

#5098 の死蔵宣言 sweep **第 4 PR**. **2 宣言を削除する** (起点 1 + cascade 1).

| 宣言 | ファイル | 区分 |
|---|---|---|
| `spinMinusPow_ferroHole_linearIndependent` | `Fermion/JordanWigner/Hubbard/WeakNagaokaTheorem.lean:229` | 台帳 TODO (first-order) |
| `fermionTotalSpinSquared_mulVec_ferroHole` | `Fermion/JordanWigner/Hubbard/WeakNagaokaTheoremCore.lean:120` | **cascade round-1** (台帳では `REVIEW-book-citation`) |

## 台帳と道具 (正本)

- 台帳: `.self-local/reports/audit3-ledger-2026-07-26/**out_dotfix/**`
  (`ledger.py` sha256 `b5b49c3045b50aae517a14224c63698bd2209054fd58256f8357feb2de418e59`, base `b093c754`).
- cascade: **`cascade_check.py --deleted`** (sha256 `b5bbe24add33be50e21b4f2c1d218669ebd3da471d05445576d37284f561c1cb`).
- 規約: `extraction-rules.md` **§8「cascade の定義」**.

進捗: DELETE 115 = **済 20 + HOLD 4 + TODO 91** → 本 PR で **済 21 + cascade 1**.

## 【削除しない】HOLD 4 件

**参照 0 だが公開文書の主張の唯一の witness** であり, `cascade_check.py` の protection は
`other` (**ツールは保護しない**) ため, 台帳を再計算するたびに DELETE 候補として再浮上する.
本 PR でも**削除対象に含めない**:
`spinReflectionThetaVec_involutive` / `nonsingularHubbardHamiltonian_commute_fermionTotalNumber` /
`hubbardHoleOccupationDiag_posSemidef` / `fermionTotalSpinMinus_eq_sum_siteSpinMinus`.
(一覧と根拠は #5098 の「HOLD 登録」節が正本.)

## 【要レビュー】保護クラスの上書き — `fermionTotalSpinSquared_mulVec_ferroHole`

台帳はこの宣言を **`REVIEW-book-citation`** に分類し**自動 DELETE から除外**している
(doc comment が「Theorem 11.5」を番号付きで引用するため, 機械判定が人手判断へ回した).
**本 PR はこれを上書きして削除する**. 根拠は段落読解による実測 3 点:

1. **`docs/index.md` / `tex/proof-guide.tex` は当該宣言を一切名指ししない**
   (capstone として名指しされるのは `weakNagaoka_spinMultiplet` / `weakNagaoka_theorem_11_5`).
2. **Theorem 11.5 の主張は一般形が担っており, そちらは生存する**.
   `weakNagaoka_spinMultiplet` は「**任意の** highest-weight ferromagnetic GS 固有ベクトル `v`」
   についての主張であり, 局所化した `ferroHole` 状態固有の主張ではない.
3. **著者自身の doc comment が探索的分岐であることを自己申告している** —
   「`weakNagaoka_spinMultiplet` applies to the Perron–Frobenius ground state
   **rather than to this localized state**」.

したがって **削除しても公開文書の主張から裏付けが失われない**.
これは #5152 で復活させた 3 補題 (削除すると主張が裏付けを失う) と**逆の結果**である.

**台帳の `documented_sibling: fermionTotalSpinSquared_mulVec` は接頭辞一致の誤検出**と確認済
(実際に docs 記載があるのは `_allUpState` / `_basisVec_merge_self` / `_spinMinusPow` という別宣言).

**レビュー・監査は上記 3 点を独立に検証されたい. 異議があれば復活させる.**
(前例: #5152 の `eigenModePeelTerm` も `PROT_KIND:def` の上書き削除で, codex が明示的に推奨した.)

## 着手前の 5 ゲート実測 (`dev-research` @ main `3b3f628f`)

| # | ゲート | 結果 |
|---|---|---|
| 1 | **外部参照 0** (`cascade_check.py`, コメント除去済) | `code_refs=0`. `git grep -nw` でも宣言行のみ |
| 2 | `@[simp]` / `attribute` 後付け / `simp [...]` 明示利用 | **両ファイルに `@[` が皆無** |
| 3 | **book item 該当性** | `ledger.tsv` の `book_doc_hits` 空. 起点側の doc comment に Tasaki の番号なし |
| 4 | **capstone 該当性** | 2 件とも `docs/index.md` / `tex` に出現 0 |
| 5 | **公開文書の witness か (段落読解)** | **該当なし**. `docs/index.md:149` と `tex:6980-7070` を読解し, 片側欠落型の量化崩れ (`\sigma^\pm` 型) が無いことを確認 |

## cascade (`cascade_check.py --deleted`, tree `3b3f628f`)

- **round-1 = 1 件**: `fermionTotalSpinSquared_mulVec_ferroHole`. **これが本 PR の申告値**.
- **round-2 以降なし** (`fermionTotalSpinZ_mulVec_ferroHole` は `:201` に別の生存 consumer があり転落しない).
- **BLOCKED 除外分 0**. `--propagate all` / `deletable` いずれも同結果 (未保護のため一致).
- **コメント stale 化なし** (`comment_only_refs=0`, 両件).

**`new-orphans-after-sweep.tsv` は転記していない** — あれは DELETE 候補全件削除の仮定値であり
PR 単位の cascade リストではない (#5152 の申告漏れの原因).

## 併合しない理由

`new_pr=2` (`honeycombTorusGraph_isBipartite`, `Lattice/HoneycombLattice.lean`) とは**併合しない**.
テーマが無関係で cascade もそこへ及ばない (閉包は `Fermion/JordanWigner/Hubbard/` 内に閉じる).
本 PR の 2 件は「**未使用の ferroHole 局所状態系列**」という 1 つの意味的まとまり.

## Acceptance

- (a) 引数なし `lake build` で **warning / error / PANIC / backtrace / appArg! / sorry / admit /
  native_decide ゼロ**, EXIT=0. **stale olean を疑い変更モジュールと下流の olean を削除してから走らせ,
  ログで `Built` (`Replayed` でない) を確認する**.
- (b) 削除 2 名すべて repo 全体 (Lean + docs + tex) で **0 ヒット**.
- (c) **cascade 不動点**: `cascade_check.py --deleted` で **round-1 の新規転落 0 件**
  (2 件を同時に消すので閉包は閉じるはず). **独自 scanner を書かない**.
- (d) 両 root からの **到達不能 0 本の維持**.
- (e) 変更ファイルの残存全宣言の `#print axioms` が標準 3 公理の部分集合.
- (f) 検査器 `check_lean_refs.py` が `UNRESOLVED=0 (excluded-by-design=3, in-deletion-notes=23)` 維持,
  sha256 `a874056f0fc2c357c200e71ecf93cf0738063c4b040b260b4885e1de3acffa05` 不変.
- (g) `docs/index.md` の不変量が不変 (**行数ベース**: `**PROVED**` 19 / `axiom-free` 71 /
  `#print axioms` 24 / 表ヘッダ区切り 56. 出現数ベースは 23 / 153 / 28).
- (h) **残存全宣言に doc comment があること** (private も必須).
- (i) **module docstring と本文中の相互参照が stale 化しないこと**
  (削除 2 名を列挙している箇所があれば同一 PR で書き換える).
- (j) **PR 本文が主張する数値が実 diff から再導出できること**.

## #5152 から引き継いだ規律

- **`cascade_check.py --deleted` で PR 単位の cascade を計算する. 独自 grep scanner を書かない**
  (`git grep -nw` はコメントとコードを区別しない).
- **参照 0 は削除可の必要条件であって十分条件ではない**.
- **削除した宣言名が文書に無くても内容が偽になりうる** — 記法の量化 (`\pm` / brace / `…`) と
  散文の主張は **grep では検出できず段落を読むしかない**.
- **`docs/index.md` と tex の双子記述を両方確認する** (#5152 で tex だけ直したのが blocker になった).
- **build 緑は誤削除にしか反証にならない** — cascade の計数漏れ・コメントの stale 化・
  公開文書の量化破綻は build では検出できない.
- **実装後に必ず push** してから検証・レビューを回す.
- **worktree を作るなら `.lake` を共有させない**. **広域 `pkill` 厳禁** (PID 指定のみ).

Refs #5098
Refs #4718

---
## 【是正コミット `a2a8023e`】docstring の誤りを 3 件修正 (doc-only)

`dev-review` と `dev-audit-tier1` が**独立に同じ 2 件**を検出した.
**宣言の追加・削除・証明の変更は 0** — Lean コメントを除去すると**コード本文は `647c7107` とバイト一致**.

### 1. 偽の数学的主張 (`WeakNagaokaTheorem.lean`)

`647c7107` で書いた module docstring が
「for **any** nonzero highest-weight state `v` … nonzero / linearly independent /
**energy-degenerate** / maximal-spin sector」と述べていたが, **energy-degenerate は
highest-weight だけからは従わない**. `weakNagaoka_spinMultiplet` は追加で
`hE : (hubbardEffectiveHamiltonian N t U).mulVec v = E • v` (+ `hJ` / `hU`) を要求する.

**反例はまさに局所化 ferromagnetic hole state** — 本 PR で削除した
`spinMinusPow_ferroHole_linearIndependent` の doc comment が記録していた caveat そのもの.

→ `tex/proof-guide.tex:6918-6946` の分節 (「The spin-lowering tower」/
「**If in addition** `v` is an `Ĥ_eff`-eigenvector」) に合わせて **2 段に分割**した.
宣言側 doc comment と `docs/index.md:2691` は元から正しく, **本 PR で新規に書いた段落だけが
仮説を落としていた**.

あわせて **nonzero が `weakNagaoka_spinMultiplet` の conjunct ではない**ことも明記
(`LinearIndependent` から従う. 独立命題は `spinMinusPow_ne_zero`).
実際の conjunct は 3 本 = 線形独立 / `Ĥ_eff` 縮退 / Casimir `(N/2)(N/2+1)`.

### 2. 成立しない visibility の理由付け (`WeakNagaokaTheoremCore.lean`)

「module-public: 同一ファイル内の宣言が消費する」と書いたが, **Lean の `private` はファイルスコープ**
なので同一モジュール内の消費は public 可視性の理由になりえない.
旧文の理由 (「capstone が module 境界を越えて再利用するため」) の唯一の cross-module consumer は
**本 PR が削除した宣言**だった.

**実測**: `ferroHoleConfig` のコード参照 **17 箇所**, `fermionTotalSpinZ_mulVec_ferroHole` の **2 箇所**は
**すべて同一ファイル内, cross-module 0**. しかも引用していた consumer の一方
`fermionTotalSpinZ_mulVec_spinMinusPow_ferroHole` (`:179`) は**それ自身が参照 0 の死蔵**
(台帳 `REVIEW-documented-sibling-family`) — **死蔵宣言で根拠を支えていた**.

→ **理由付けを止め, 実測した事実だけを書いた**:
`ferroHoleConfig` が非 `private` である実質的理由は **`:179` の非 `private` 定理の *statement* に
現れるから** / `fermionTotalSpinZ_mulVec_ferroHole` には非 `private` を要求する理由が現状ない /
**2 件は結合している** (`ferroHoleConfig` を `private` 化すると非 `private` な statement に
`private` 定数が入る) / **整理は #5098 の別 PR**.

**visibility 自体は変更していない** (死蔵削除のスコープ外の設計判断).

### 3. 節見出しの対称性 (`WeakNagaokaTheoremCore.lean:116`)

「The all-up Tasaki basis state is a highest-weight **maximal-spin** state」→
「… is a highest-weight state」. 当該節は `Ŝ⁺` 消滅と `Ŝ^z` 固有値のみで **Casimir witness が無い**.
本 PR が `:49` の兄弟見出しを同じ理由で改名したため非対称になっていた.

### 最終状態

**2 files / 29 insertions / 47 deletions**. 削除宣言は **2** のまま (追加 0).

| ゲート | 実測 |
|---|---|
| root build (2 モジュール + 下流 217 の artifacts 削除後) | **EXIT=0**, 両モジュール **`Built`** (`Replayed` でない), warning 系 8 種 **0** |
| doc のみの変更 | **コメント除去後のコード本文が `647c7107` とバイト一致** |
| cascade (`cascade_check.py --deleted`) | `dead_now_gfp` **199** (是正前 `647c7107` / 是正後 `a2a8023e` の両 tree で一致), 宣言 9,594, stale comment 0. **`round-1` は HEAD tree では測定不能 — 下記【本文の訂正 tier1 P3-4】参照** |
| 削除 2 名 | tracked 全ファイルで **0 ヒット** |
| HOLD 4 件 | **全件残存** |
| `docs/index.md` / `tex/proof-guide.tex` | **main と sha256 一致** (行数ベースの不変量を包含する強い検証) |
| doc comment | 残存 24 宣言 (**`private` 6** 含む) すべてに有り |
| 行幅 | 最大 89 / 98 codepoint (≤100) |

### 後続課題 (#5098 へ記録)

1. **`ferroHoleConfig` / `fermionTotalSpinZ_mulVec_ferroHole` の visibility 整理**.
   現状 cross-module 参照 0 で `private` 化の余地があるが, **2 件は同時に判断する必要がある**.
2. **`fermionTotalSpinZ_mulVec_spinMinusPow_ferroHole` (`:179`) は参照 0** で,
   台帳では `REVIEW-documented-sibling-family`. **これが `ferroHoleConfig` を非 `private` に
   留めている唯一の実質的理由**なので, 1 と同時に扱う.

### 本文の訂正 (tier1 P3-2)

cascade 節に「`fermionTotalSpinZ_mulVec_ferroHole` は `:201` に別の生存 consumer があり転落しない」と
書いたが, **`:201` の consumer 自身が参照 0** である. 判定は到達可能性計算が担保しているので誤りでは
ないが, **堅牢な生存根拠は `:147` の `fermionTotalSpinZ_mulVec_hubbardTasakiBasisStateUp`**
(`WeakNagaokaGroundStateCore.lean:71` から cross-module に生存消費) の方である.

### 本文の訂正 (tier1 P3-4, 2026-07-26)

**1. 「最終状態」表の `cascade` 行「round-1 = 0」の実態**

上表の「round-1 = 0」は **HEAD tree (是正前 `647c7107` / 是正後 `a2a8023e`, いずれも両宣言を
削除済) での測定**であり, `cascade_check.py --deleted` は削除対象 `D` の 2 名を HEAD 上で解決
できず (`deletion set D: requested 2  resolved decls 0  unresolved 2` →
`UNRESOLVED-NAME fermionTotalSpinSquared_mulVec_ferroHole` /
`UNRESOLVED-NAME spinMinusPow_ferroHole_linearIndependent`), **`!! refusing to report a cascade
while names are unresolved` と明示拒否した出力**である (削除済みの名前を HEAD で探すため `D` が
空になる仕様通りの挙動). **この `0` は情報量ゼロ**であり, 「是正前と完全一致」という結論の実質的
根拠ではない.
実際に是正の doc-only 性を裏付けるのは次の 2 点 (いずれも同ツールで再実測):
- `dead_now_gfp` が **`647c7107` (是正前) / `a2a8023e` (是正後) の両 tree で `199` と一致**.
- **base tree `3b3f628f` (削除前, `D` は 2 件とも解決) で `round-1 = 0`**
  (`dead_now_gfp` は `201` → `199`, cascade が実際に閉じていることを確認 — こちらが唯一
  意味のある fixed-point 測定).

**2. 参照カウントの数え方の不統一**

「`2. 成立しない visibility の理由付け」節の「`ferroHoleConfig` のコード参照 **17 箇所**」は
**宣言行 (`:58`) 込み**, 「`fermionTotalSpinZ_mulVec_ferroHole` の **2 箇所**」は**宣言行
(`:103`) を除いた数**で, 数え方が不統一だった.
→ **正しくは 16 対 2, いずれも宣言行を除く** (実測: `ferroHoleConfig` の宣言行を除く code 参照
= 16, `fermionTotalSpinZ_mulVec_ferroHole` の宣言行を除く code 参照 = 2).

**3. 「2 件は結合している」→ 3 者**

同節の「**2 件は結合している** (`ferroHoleConfig` を `private` 化すると非 `private` な
statement に `private` 定数が入る)」は範囲が過小だった. 実際は **3 者が結合している**:
`ferroHoleConfig` 自身に加えて, **`fermionTotalSpinZ_mulVec_ferroHole` 自身も非 `private` であり,
その statement (`WeakNagaokaTheoremCore.lean:103-105`) 自体が `ferroHoleConfig` を含む** ため,
これも同じ結合に入る (残る 1 者は `fermionTotalSpinZ_mulVec_spinMinusPow_ferroHole` `:179`).
結論 (結合している) は真だが, 対象範囲が 2 者に過小だった.

