### PR TITLE
ci: stop PR runs from saving the .lake cache (restore-only) — #5098

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -17,7 +17,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      # lean-action's own `actions/cache/restore` and `actions/cache/save`
+      # steps are gated by the single `use-github-cache` input (see
+      # https://github.com/leanprover/lean-action/blob/v1/action.yml), so
+      # there is no way to ask lean-action itself for "restore but don't
+      # save". On pull_request runs we therefore restore the `.lake` cache
+      # here (same key scheme lean-action uses internally) and then tell
+      # lean-action not to touch the cache at all, so it neither restores
+      # again (this step already did it) nor saves at the end of the job.
+      # This avoids PR runs evicting the `main`-branch cache entry via LRU
+      # in the shared 10 GB repo cache quota (see #5098).
+      - uses: actions/cache/restore@v5
+        if: github.event_name == 'pull_request'
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+          restore-keys: |
+            lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
       - uses: leanprover/lean-action@v1
+        with:
+          use-github-cache: ${{ github.event_name != 'pull_request' }}
 
   # API docs generation (doc-gen4 via docgen-action) is currently
   # DISABLED because it was taking unreasonably long on every push


### PR DESCRIPTION
## 背景・承認

2026-07-26 にユーザーが CI 遅延対策として **案 A (本 PR: workflow 変更) と案 B (死蔵キャッシュの
削除) の両方**を明示承認した。本 PR は案 A。案 B は別工程で並行実施済み/実施中。

## 真因 (詳細: `.self-local/reports/ci-build-duration-2026-07-26.md`)

CI 遅延の真因は **GitHub Actions キャッシュの追い出し** であり、mathlib の再取得 (`lake exe
cache get`) ではない。

- `.lake` キャッシュ実体は **2.54 GiB**。repo のキャッシュ枠 10 GB には **3.6 本**しか入らない。
- PR run は毎回 `actions/cache/save` するため、LRU (最終アクセス順) で main のキャッシュが
  追い出され、キャッシュミス率が **4% → 31%** に悪化した。
- 実測: `gh api .../actions/cache/usage` の `active_caches_size` は **10.9 GB / 4 本**、うち
  **PR スコープのキャッシュ 3 本 (7.6 GiB) が死蔵**されキャッシュ枠を圧迫していた。
- ステップ別内訳: `lake build` が全体所要時間の **94.8%**。`lake exe cache get`
  (mathlib のバイナリキャッシュ取得) は **25 秒**のみで原因ではない。
- キャッシュヒット時は CI 全体で **約 2 分**、ミス (フルビルド) 時は **約 38 分**。cold build
  自体の所要時間は過去数週間 34–39 分で不変であり、悪化したのは**発生頻度 (ミス率)**。

## 変更内容

`leanprover/lean-action@v1` は内部で `actions/cache/restore@v5` (build 前) と
`actions/cache/save@v5` (build 後) を単一の `use-github-cache` フラグで制御しており、
「restore だけ有効・save だけ無効」を lean-action の入力だけでは表現できない
(upstream `action.yml` で確認済み: 両ステップとも `if: inputs.use-github-cache == 'true'` の
同一条件)。

そこで `.github/workflows/lean_action_ci.yml` に以下を追加した:

1. lean-action の**手前**に `actions/cache/restore@v5` を追加し、**PR event でのみ**実行する
   (key/restore-keys は lean-action 内部の式と同一形式: `lake-${{ runner.os }}-${{ runner.arch
   }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}` [-sha]。
   restore-keys の prefix match で main 由来のキャッシュにフォールバックする)。
2. lean-action ステップに `use-github-cache: ${{ github.event_name != 'pull_request' }}` を渡す。
   - **push (main) / workflow_dispatch**: `use-github-cache` = `true` (従来どおり)。
     lean-action 自身が restore + build + save を行う (変更なし)。
   - **pull_request**: `use-github-cache` = `false`。手前で追加した独立 restore ステップが
     キャッシュを効かせつつ、lean-action 内部の save は実行されない。

## 効果見積り

- ミス率 31% → ほぼ 0 (main のキャッシュが PR run に追い出されなくなるため)。
- CI 短縮: 週あたり **25–27 時間**。PR 1 本あたり **40 分 → 2–20 分**。

## 副作用 (正直に書く)

同一 PR 内で 2 回目以降の push をしても、**自分の前 run が作った途中キャッシュは保存されない**
ため再利用できない。restore-keys の prefix フォールバックにより main 由来の (やや古い) キャッシュ
までは効くが、そこから先は **main 基準の差分再ビルド**になる。ケースによっては
2 分 → 5–20 分に増えることがある。それでも「31% のフルビルド発生」という純損失に比べれば
純便益は大きい。

## 案 B について

死蔵キャッシュ (PR スコープの 3 本, 7.6 GiB) の削除は**別途、別工程で実施済み/実施中**であり、
本 PR では `gh cache delete` を一切実行していない。

## 回帰防止の計測 (新規機構は設けない)

既存の 20 PR 定期見直しのタイミングで、以下を目視確認する:
- `gh api repos/phasetr/lattice-system/actions/cache/usage` の `active_caches_size`
- `gh run list --limit 100` で実行時間が `>15m` の run の比率

## 検証方法

**この PR 自身の CI run が案 A の動作確認になる** (PR event なので理論上は restore のみ走り、
lean-action 内部の save は走らないはず)。run のログ (`gh run view <id> --log` の該当ステップ)
で実際の挙動を確認した上でマージする。

Refs #5098
